### PR TITLE
Add Claude Code and opencode plugin scaffolding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "mcp-emacs",
+  "owner": {
+    "name": "Gunnar Bastkowski"
+  },
+  "plugins": [
+    {
+      "name": "mcp-emacs",
+      "source": "./",
+      "description": "Live Emacs integration for Claude Code over the in-Emacs MCP HTTP server."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "mcp-emacs",
+  "description": "Live Emacs integration for Claude Code: buffers, Org, xref, diagnostics, and a cooperative human/AI Org-task session loop, over the in-Emacs MCP HTTP server.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Gunnar Bastkowski"
+  },
+  "homepage": "https://github.com/gbastkowski/mcp-emacs"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "emacs": {
+      "type": "http",
+      "url": "http://localhost:8765/mcp"
+    }
+  }
+}

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -41,3 +41,15 @@ claude --plugin-dir /path/to/mcp-emacs
   - `edit-at-point` — edit the buffer/selection the user is actually looking at.
   - `review-diagnostics` — fix code problems the checker reports.
   - `diagnose-emacs` — troubleshoot the Emacs/tooling setup itself.
+
+## opencode
+
+The same MCP server, skills, and command also work in
+[opencode](https://opencode.ai). `opencode.json` in the repo root registers the
+`emacs` MCP server (`type: remote`) and the `/emacs-loop` command; opencode
+loads the `SKILL.md` files under `skills/` (and `.claude/skills/`) directly, so
+no separate skill copies are needed.
+
+Run opencode from the repo root, or merge the `mcp` and `command` blocks from
+`opencode.json` into your `~/.config/opencode/opencode.json`. Same prerequisite:
+the in-Emacs server must be listening on the configured `url`.

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -1,0 +1,43 @@
+# mcp-emacs (Claude Code plugin)
+
+Registers the in-Emacs MCP HTTP server with Claude Code and ships skills and a
+command for working in a live Emacs session.
+
+## Prerequisite
+
+The Emacs side must be running. Install `mcp-emacs` in Emacs (see the repo
+root `README.md`) and make sure the server is listening:
+
+```
+emacsclient --eval '(mcp-emacs-server-ensure)'   # returns the endpoint URL
+```
+
+Default endpoint: `http://localhost:8765/mcp`. If you changed
+`mcp-emacs-server-port`, edit the `url` in `.mcp.json` to match.
+
+## Install
+
+From this repository (local marketplace):
+
+```
+/plugin marketplace add /path/to/mcp-emacs
+/plugin install mcp-emacs@mcp-emacs
+```
+
+Or for one session, point Claude Code at the plugin dir:
+
+```
+claude --plugin-dir /path/to/mcp-emacs
+```
+
+## What you get
+
+- **MCP server `emacs`** — all `mcp-emacs` tools (buffers, Org, xref,
+  diagnostics, `eval`, and the `org_task_*` session tools).
+- **`/mcp-emacs:emacs-loop [file.org]`** — start the cooperative Org-task
+  session loop.
+- **Skills** (auto-invoked by context):
+  - `org-task-loop` — cooperative human/AI Org-task session loop.
+  - `edit-at-point` — edit the buffer/selection the user is actually looking at.
+  - `review-diagnostics` — fix code problems the checker reports.
+  - `diagnose-emacs` — troubleshoot the Emacs/tooling setup itself.

--- a/commands/emacs-loop.md
+++ b/commands/emacs-loop.md
@@ -1,0 +1,16 @@
+---
+description: Start the cooperative Org-task session loop against a session Org file open in Emacs.
+argument-hint: [path-to-session.org]
+---
+
+Start the cooperative human/AI Org-task session loop for the session file:
+`$1`
+
+If no path was given, use the Org file currently open in Emacs
+(`get_buffer_filename`).
+
+Follow the `org-task-loop` skill: read the session with `org_task_session`,
+work the first actionable TODO item, report status back into the file via the
+`org_task_*` tools, then block on `org_task_wait_for_change` and react to the
+human's next edit. The human is the driver — never reorder, delete, rewrite, or
+save their content.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "emacs": {
+      "type": "remote",
+      "url": "http://localhost:8765/mcp",
+      "enabled": true
+    }
+  },
+  "command": {
+    "emacs-loop": {
+      "description": "Start the cooperative Org-task session loop against a session Org file open in Emacs.",
+      "template": "Start the cooperative human/AI Org-task session loop for the session file: $ARGUMENTS\n\nIf no path was given, use the Org file currently open in Emacs (get_buffer_filename).\n\nFollow the org-task-loop skill: read the session with org_task_session, work the first actionable TODO item, report status back into the file via the org_task_* tools, then block on org_task_wait_for_change and react to the human's next edit. The human is the driver — never reorder, delete, rewrite, or save their content."
+    }
+  }
+}

--- a/skills/diagnose-emacs/SKILL.md
+++ b/skills/diagnose-emacs/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: diagnose-emacs
+description: Diagnose the Emacs/tooling setup itself when the editor environment is broken — no checker running, missing or dead LSP client, wrong exec-path, missing executables, or environment/PATH problems. Use when diagnostics are absent or nonsensical, LSP won't start, "command not found" in Emacs, or the user asks why their Emacs tooling isn't working. For fixing actual code problems the checker reports, use the review-diagnostics skill instead.
+---
+
+# Diagnose the Emacs / tooling setup
+
+This skill is about the **editor environment**, not the project's code. Reach
+for it when the tooling that produces diagnostics is itself broken: no checker
+is running, the LSP client won't start or has died, an executable isn't found,
+or Emacs's `exec-path`/environment differs from your shell.
+
+## Gather
+
+- `diagnose_emacs` — the primary tool: `exec-path`, active LSP clients, and
+  other runtime info about the running Emacs.
+- `get_env_vars` — environment variables visible to Emacs. Compare against what
+  your shell has; a GUI Emacs often inherits a different `PATH`.
+- `get_error_context` — `*Messages*` and `*Warnings*` frequently hold the real
+  reason an LSP server or checker failed to start.
+- `project_info` — confirm Emacs sees the intended project root and file set.
+
+## Diagnose
+
+1. Confirm the expected checker/LSP client is actually active (`diagnose_emacs`).
+   If none is running, that alone explains empty or missing diagnostics.
+2. If a client is configured but dead, read `*Messages*`/`*Warnings*`
+   (`get_error_context`) for the startup failure.
+3. If the failure is "command not found" or a wrong binary, check `exec-path`
+   and `PATH` (`diagnose_emacs`, `get_env_vars`) — the executable may be
+   present in your shell but not on Emacs's `exec-path`.
+4. Use `eval` to inspect or probe further (e.g. `(executable-find "...")`,
+   feature/mode state) when the standard tools don't pin it down.
+
+## Rules
+
+- Fix the setup story, not the code — patching source won't help a missing
+  server or a bad `exec-path`.
+- Report what you found and the concrete remedy (add to `exec-path`, install
+  the binary, load the client, fix the env), and say what you could not verify.
+- Prefer read-only probing; only `eval` mutating Elisp with clear intent, and
+  say what you ran.
+- Once the tooling is healthy again, hand back to `review-diagnostics` to work
+  through the real code diagnostics.

--- a/skills/edit-at-point/SKILL.md
+++ b/skills/edit-at-point/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: edit-at-point
+description: Edit the file the user is actually looking at in Emacs, at the cursor or selection, instead of guessing paths. Use when the user says "here", "at point", "this selection", "where my cursor is", "the buffer I have open", or references their current Emacs context without a path.
+---
+
+# Edit at point in the live Emacs buffer
+
+The user is working in Emacs. Their cursor position, selection, and current
+buffer are real state you can read through the `emacs` MCP tools — use them
+instead of asking for a path or guessing.
+
+## Orienting
+
+- `project_info` — project root, active file, tracked file count.
+- `get_buffer_filename` — path of the current buffer.
+- `get_selection` — the active region, if any.
+- `get_current_task_at_point` / `get_current_clocked_task` — Org context.
+
+## Reading context around the cursor
+
+- `get_buffer_content` — full current buffer (includes unsaved edits).
+- `imenu_list_symbols` — symbols with line numbers, to locate structure.
+- `treesit_info` — tree-sitter node type and ancestor chain at point.
+
+## Editing
+
+- `insert_at_point` — insert text at point, or replace the active selection.
+- `edit_file_region` — replace a region by start/end line & column.
+  **Emacs coordinates: lines are 1-based, columns are 0-based.** First
+  character in the file is line 1, column 0.
+- `goto_line` — move point to a line/column, or jump to a named function via
+  imenu, before an insert.
+
+## After editing
+
+- Leave saving to the user by default. Only call `save_buffer` if the user
+  asks, or if a downstream tool (build, LSP) needs the file on disk — and say
+  so when you do.
+- Check the result with `get_diagnostics` or `describe_flycheck_info_at_point`
+  before declaring the edit clean.

--- a/skills/org-task-loop/SKILL.md
+++ b/skills/org-task-loop/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: org-task-loop
+description: Run a cooperative human/AI Org-task session loop against a live Emacs buffer. Use when the user points at a session Org file (a heading with a SESSION property and a TODO checklist) and wants the AI to work items, report status, and wait for their next direction. Trigger phrases: "run the org loop", "start the task session", "work this session file", "cooperative loop".
+---
+
+# Org-task session loop
+
+You drive a shared Org file with the human. The human edits it live in Emacs;
+you read and update it through the `emacs` MCP tools. The human stays the
+driver — you react to their edits, you never reorder, delete, or rewrite
+human-authored items, and you never save the buffer automatically.
+
+## Inputs
+
+The user gives you the path to a session Org file, or the file is already open
+in Emacs. Its first heading is the task: the TODO keyword is the session
+status, the `SESSION` property is the session id, child headings are the
+checklist.
+
+## Loop
+
+1. **Read** the session with `org_task_session` (pass the file path). Note the
+   returned **change token** and the checklist with each item's Org keyword.
+2. **Pick** the first actionable `TODO` item. If none are actionable, skip to
+   step 6.
+3. **Set it in progress** if the workflow uses an in-progress keyword, via
+   `org_task_set_item_status` (identify the item by its ID/CUSTOM_ID property or
+   exact heading text — never by position).
+4. **Do the work** the item describes (edit code, run commands, etc.).
+5. **Report**: mark the item `DONE` with `org_task_set_item_status`, and add a
+   short progress note with `org_task_append_note`. Update overall status with
+   `org_task_set_session_status` when the whole task advances.
+6. **Wait** for the human with `org_task_wait_for_change`, passing the latest
+   change token. It blocks (up to a timeout) until the human edits the file,
+   then returns the change plus the fresh session view.
+7. **React** to what changed — a new item, an edited item, a status flip — and
+   go back to step 2 with the new token.
+
+## Rules
+
+- Every read/write is scoped to the explicit file path; there is no ambient
+  "current task file".
+- Only touch items you can positively identify. Leave everything else untouched.
+- Do not save the buffer; the human owns saving.
+- If `org_task_session` reports missing session metadata, tell the user rather
+  than guessing.
+- On `wait_for_change` timeout with no change, either loop again (keep waiting)
+  or stop and report, depending on what the user asked for.
+
+Stop the loop when the user says so, or when the task heading reaches its
+terminal status and no actionable items remain.

--- a/skills/review-diagnostics/SKILL.md
+++ b/skills/review-diagnostics/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: review-diagnostics
+description: Pull live Flycheck/Flymake/LSP diagnostics and build-error buffers from Emacs and fix the underlying code problems in the project. Use when the user says "what are the errors", "fix the warnings", "check diagnostics", "why won't this compile", or wants the AI to act on the squiggles they see in their editor. For a broken Emacs/tooling setup (missing LSP client, bad exec-path) use the diagnose-emacs skill instead.
+---
+
+# Review and fix project code diagnostics
+
+The user's Emacs already knows what is wrong with the code — Flycheck/Flymake,
+LSP, and the compilation/error buffers hold it. Read that state through the
+`emacs` MCP tools rather than re-deriving errors yourself. This skill is about
+problems in the **project's code**; if the diagnostics are absent or broken
+because the tooling itself is misconfigured, switch to the `diagnose-emacs`
+skill.
+
+## Gather
+
+- `get_diagnostics` — all diagnostics for the current buffer (Flycheck or
+  Flymake, auto-detected).
+- `describe_flycheck_info_at_point` — diagnostic(s) at the cursor, when the
+  user is pointing at one specific squiggle.
+- `get_error_context` — summarizes `*Messages*`, `*Warnings*`, and compilation
+  logs, for build/runtime errors not tied to a buffer line.
+
+## Fix them
+
+1. List the diagnostics with file:line and severity; lead with errors, then
+   warnings.
+2. For each one you intend to fix, open/goto the location (`goto_line`,
+   `open_file`) and inspect with `get_buffer_content` / `treesit_info`.
+3. Apply the fix via `edit_file_region` or `insert_at_point`
+   (Emacs coords: lines 1-based, columns 0-based).
+4. Re-run `get_diagnostics` to confirm the diagnostic cleared before moving on.
+
+## Rules
+
+- Report faithfully: if a fix doesn't clear the diagnostic, say so with the
+  remaining output — don't claim success.
+- Don't save the buffer unless the user asks or a build needs it on disk.
+- If diagnostics are empty, stale, or clearly wrong (e.g. no checker running,
+  the whole file flagged), the problem is likely the Emacs/tooling setup, not
+  the code — hand off to the `diagnose-emacs` skill.


### PR DESCRIPTION
Package the in-Emacs MCP server as an installable plugin for Claude Code (manifest, marketplace, MCP config, command, 4 skills) and opencode (opencode.json). No server code touched.