### PR TITLE
Add harness-agnostic IDE-integration MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ observe the real buffers, windows, and Org state of the running session.
 | `xref_find_references`            | Find references to an identifier (or the symbol at point) via xref                         |
 | `xref_find_apropos`               | Find symbols matching a pattern across the project via xref apropos                        |
 | `treesit_info`                    | Tree-sitter node info at point: node type, range, and ancestor chain                       |
+| `apply_diff`                      | Propose new file content via an interactive ediff session; returns applied/rejected/timeout |
+| `list_open_editors`               | List file-visiting buffers with their path, buffer name, and dirty flag                    |
+| `check_document_dirty`            | Report whether the buffer visiting a file has unsaved changes                              |
 | `project_info`                    | Project root, active file, and tracked file count                                          |
 | `diagnose_emacs`                  | Collect diagnostic info about the running Emacs (exec-path, LSP clients, …)                 |
 | `get_env_vars`                    | List environment variables visible to Emacs                                                |

--- a/elisp/mcp-emacs-server.el
+++ b/elisp/mcp-emacs-server.el
@@ -263,6 +263,33 @@ rather than `null' (an empty alist would)."
          :description "Tree-sitter node info at point: node type, range, and ancestor chain"
          :schema (mcp-emacs-server--no-args)
          :handler (lambda (_args) (mcp-emacs-treesit-info)))
+   (list :name "list_open_editors"
+         :description "List file-visiting buffers with their path, buffer name, and dirty flag"
+         :schema (mcp-emacs-server--no-args)
+         :handler (lambda (_args) (mcp-emacs-list-open-editors)))
+   (list :name "check_document_dirty"
+         :description "Report whether the buffer visiting a file has unsaved changes"
+         :schema (mcp-emacs-server--obj
+                  "type" "object"
+                  "properties" (mcp-emacs-server--obj
+                                "path" (mcp-emacs-server--prop "string" "Absolute path to the file"))
+                  "required" (vector "path"))
+         :handler (lambda (args)
+                    (mcp-emacs-check-document-dirty (alist-get 'path args))))
+   (list :name "apply_diff"
+         :description "Propose new content for a file via an interactive ediff session; the human edits/accepts/rejects and the tool returns applied (with final content), rejected, or timeout"
+         :schema (mcp-emacs-server--obj
+                  "type" "object"
+                  "properties" (mcp-emacs-server--obj
+                                "path" (mcp-emacs-server--prop "string" "Absolute path to the file to change")
+                                "new_content" (mcp-emacs-server--prop "string" "Proposed new content for the file")
+                                "timeout" (mcp-emacs-server--prop "integer" "Timeout in seconds (default 120, capped at 600)"))
+                  "required" (vector "path" "new_content"))
+         :handler (lambda (args)
+                    (mcp-emacs-apply-diff
+                     (alist-get 'path args)
+                     (alist-get 'new_content args)
+                     (alist-get 'timeout args))))
    (list :name "org_task_session"
          :description "Read a session task Org file: task heading, session id, status, and TODO checklist"
          :schema (mcp-emacs-server--obj

--- a/elisp/mcp-emacs.el
+++ b/elisp/mcp-emacs.el
@@ -30,6 +30,12 @@
 (require 'subr-x nil t)
 (require 'org nil t)
 (require 'org-agenda nil t)
+(require 'ediff nil t)
+
+(defvar ediff-control-buffer)
+(defvar ediff-quit-hook)
+(declare-function ediff-buffers "ediff" (buffer-a buffer-b &optional startup-hooks job-name))
+(declare-function ediff-really-quit "ediff-util" (reverse-default-keep-variants))
 
 (defun mcp-emacs--current-buffer ()
   "Return the buffer associated with the currently selected window."
@@ -860,6 +866,130 @@ a change indication, the new token, and the current session view."
                     (if changed "yes" "no")
                     (mcp-emacs-org-task-read path)))))
     (user-error (error-message-string err))))
+
+;;; Editor-state tools
+
+(defun mcp-emacs-list-open-editors ()
+  "Return a text listing of file-visiting buffers.
+Each line is PATH\\tBUFFER-NAME\\tdirty|clean.  Returns a header line
+noting no open editors when none exist."
+  (let ((entries
+         (delq nil
+               (mapcar
+                (lambda (buf)
+                  (with-current-buffer buf
+                    (when buffer-file-name
+                      (format "%s\t%s\t%s"
+                              buffer-file-name
+                              (buffer-name)
+                              (if (buffer-modified-p) "dirty" "clean")))))
+                (buffer-list)))))
+    (if entries
+        (mapconcat #'identity entries "\n")
+      "No open editors.")))
+
+(defun mcp-emacs-check-document-dirty (path)
+  "Report whether the buffer visiting PATH has unsaved changes.
+When no live buffer visits PATH, report that the document is not open."
+  (condition-case err
+      (let* ((file (expand-file-name path))
+             (buf (find-buffer-visiting file)))
+        (cond
+         ((null buf) (format "Not open: %s" file))
+         ((buffer-modified-p buf) (format "Dirty: %s" file))
+         (t (format "Clean: %s" file))))
+    (error (error-message-string err))))
+
+;;; Interactive diff/apply
+
+(defcustom mcp-emacs-apply-diff-default-timeout 120
+  "Default timeout, in seconds, for `mcp-emacs-apply-diff'."
+  :type 'integer
+  :group 'mcp-emacs)
+
+(defcustom mcp-emacs-apply-diff-max-timeout 600
+  "Maximum timeout, in seconds, for `mcp-emacs-apply-diff'."
+  :type 'integer
+  :group 'mcp-emacs)
+
+(defun mcp-emacs-apply-diff (path new-content timeout)
+  "Present NEW-CONTENT as a proposed change to the file at PATH via ediff.
+Open an `ediff-buffers' session comparing the file's current content
+against NEW-CONTENT, block cooperatively until the human resolves it or
+TIMEOUT elapses, then return the outcome.  The buffer visiting PATH is
+Buffer A; the proposal is a temporary Buffer B.  On quit, if Buffer A's
+content changed from its entry state the outcome is applied (the final
+content is returned; saving is left to the human); otherwise rejected.
+On timeout the ediff session is abandoned and Buffer A left untouched.
+TIMEOUT is capped at `mcp-emacs-apply-diff-max-timeout' and defaults to
+`mcp-emacs-apply-diff-default-timeout'."
+  (condition-case err
+      (let* ((file (expand-file-name path))
+             (buffer-a (find-file-noselect file))
+             (entry-content (with-current-buffer buffer-a
+                              (buffer-substring-no-properties
+                               (point-min) (point-max))))
+             (buffer-b (generate-new-buffer
+                        (format "*mcp-apply-diff: %s*"
+                                (file-name-nondirectory file))))
+             (winconf (current-window-configuration))
+             ;; Per-call result cell captured by the quit hook closure.
+             (result (list nil))
+             (secs (min mcp-emacs-apply-diff-max-timeout
+                        (if (and (numberp timeout) (> timeout 0))
+                            timeout
+                          mcp-emacs-apply-diff-default-timeout)))
+             control)
+        (with-current-buffer buffer-b
+          (insert new-content)
+          (let ((mode (assoc-default file auto-mode-alist 'string-match)))
+            (when (functionp mode) (ignore-errors (funcall mode)))))
+        (unwind-protect
+            (progn
+              (ediff-buffers
+               buffer-a buffer-b
+               (list (lambda ()
+                       (setq control ediff-control-buffer)
+                       (with-current-buffer ediff-control-buffer
+                         (setq-local
+                          ediff-quit-hook
+                          (list (lambda ()
+                                  (setcar
+                                   result
+                                   (if (buffer-live-p buffer-a)
+                                       (with-current-buffer buffer-a
+                                         (if (string=
+                                              (buffer-substring-no-properties
+                                               (point-min) (point-max))
+                                              entry-content)
+                                             'rejected
+                                           'applied))
+                                     'rejected)))))))))
+              ;; Cooperative wait: yield so ediff, edits, and other tool
+              ;; calls keep processing until the human quits or we time out.
+              (let ((deadline (+ (float-time) secs)))
+                (while (and (null (car result))
+                            (< (float-time) deadline))
+                  (accept-process-output
+                   nil mcp-emacs-org-task-wait-poll-interval)))
+              (cond
+               ((eq (car result) 'applied)
+                (format "Status: applied\n%s"
+                        (with-current-buffer buffer-a
+                          (buffer-substring-no-properties
+                           (point-min) (point-max)))))
+               ((eq (car result) 'rejected) "Status: rejected")
+               (t
+                ;; Timeout: force-quit any still-live ediff session.
+                (when (and control (buffer-live-p control))
+                  (with-current-buffer control
+                    (if (fboundp 'ediff-really-quit)
+                        (ignore-errors (ediff-really-quit nil))
+                      (kill-buffer control))))
+                "Status: timeout")))
+          (when (buffer-live-p buffer-b) (kill-buffer buffer-b))
+          (ignore-errors (set-window-configuration winconf))))
+    (error (error-message-string err))))
 
 (provide 'mcp-emacs)
 

--- a/openspec/changes/add-ide-integration-tools/.openspec.yaml
+++ b/openspec/changes/add-ide-integration-tools/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/add-ide-integration-tools/design.md
+++ b/openspec/changes/add-ide-integration-tools/design.md
@@ -1,0 +1,117 @@
+## Context
+
+`mcp-emacs` is a single-threaded, event-driven MCP server running inside Emacs.
+Tool handlers run on the Emacs main thread; long-running handlers must yield to
+the event loop (via `accept-process-output`) so other tool calls and human edits
+keep flowing — the pattern already established by
+`mcp-emacs-org-task-wait-for-change`.
+
+`claude-code-ide.el` implements an interactive diff via `ediff`, but wraps it in
+per-session, per-tab bookkeeping tied to its Claude-Code-CLI IDE protocol
+(sessions keyed by project dir, "quit-from-claude" remote-quit handling, side
+windows for the Claude buffer). None of that applies here: mcp-emacs has no
+notion of a Claude side window or a remote CLI that can quit the diff. The
+design goal is the same interaction (review a proposed change in `ediff`,
+edit/accept/reject) with the minimum machinery that fits mcp-emacs's stateless,
+pull-model tools.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide `apply_diff`: show original vs proposed in `ediff`, let the human
+  edit/accept/reject, and return `applied` (with final content) / `rejected` /
+  `timeout`.
+- Block cooperatively with a bounded timeout, reusing the existing
+  `accept-process-output` wait pattern so the server stays responsive.
+- Provide `list_open_editors` and `check_document_dirty` as small, stateless
+  queries over Emacs's live buffers.
+- Keep every tool harness-agnostic: plain MCP over the existing HTTP transport,
+  no client-specific handshake.
+
+**Non-Goals:**
+- The Claude-Code-CLI IDE WebSocket protocol, lockfile/env handshake, terminal
+  runner, and live selection push notifications.
+- Multi-session / per-project diff bookkeeping and remote (client-initiated)
+  quit of the ediff session.
+- Three-way merge or conflict resolution beyond what `ediff` offers by default.
+
+## Decisions
+
+### D1: Reuse the `accept-process-output` cooperative-wait pattern
+The `apply_diff` handler starts the `ediff` session, then spins a wait loop
+identical in shape to `mcp-emacs-org-task-wait-for-change`: while the outcome is
+still pending and the deadline has not passed, call
+`(accept-process-output nil poll-interval)`. This keeps the single-threaded
+server responsive to other tool calls and to the human's interaction with ediff.
+
+- **Alternative considered:** deferring the response via an idle timer and a
+  second poll tool (as some MCP servers do). Rejected — it doubles the tool
+  surface and contradicts the blocking model the user chose and that
+  `wait_for_change` already establishes.
+
+### D2: Signal the outcome through a per-session result cell + `ediff-quit-hook`
+Before launching ediff, bind a fresh result cell (a cons or a `let`-scoped
+variable captured in the hook closures). Install a buffer-local
+`ediff-quit-hook` on the control buffer that records the outcome, then quits.
+The wait loop reads this cell.
+
+- Buffer A = the file's current content (via `find-file-noselect`), Buffer B =
+  the proposed content in a temporary buffer.
+- **Accept** = the human copies/merges the desired result into Buffer A and it
+  ends up modified to the accepted content, or an explicit accept action is
+  taken; the hook captures Buffer A's final text and marks `applied`.
+- **Reject** = the human quits ediff without accepting; the hook marks
+  `rejected` and Buffer A is left as it was on entry.
+- **Alternative considered:** claude-code-ide's session/tab hash tables. Rejected
+  as overkill — mcp-emacs handles one interactive diff at a time per call, and
+  the result cell is captured in the closure, so no global registry is needed.
+
+### D3: Determine `applied` vs `rejected` by Buffer A's final content
+Rather than intercept individual ediff commands, compare Buffer A's content at
+quit time against its content at entry. If it changed (the human merged the
+proposal, wholly or partially), return `applied` with the new content and mark
+the buffer for the human to save (do not auto-save — saving stays the human's
+job, consistent with the existing `save_buffer`/no-auto-save rule). If unchanged,
+return `rejected`.
+
+- **Alternative considered:** requiring a dedicated "accept" keybinding. Rejected
+  as an extra thing the human must learn; content-diff detection works with
+  plain ediff usage.
+
+### D4: Timeout abandons the session cleanly
+On timeout the handler force-quits any still-live ediff control buffer
+(`ediff-really-quit` guarded by `ignore-errors`, falling back to killing the
+control buffer), restores the window configuration saved before launch, leaves
+Buffer A unmodified, and returns `timeout`. Default and max timeouts reuse /
+mirror the existing `org-task-wait` customs.
+
+### D5: `list_open_editors` and `check_document_dirty` are pure queries
+- `list_open_editors`: iterate `(buffer-list)`, keep buffers with a non-nil
+  `buffer-file-name`, return `path`, buffer `name`, and `(buffer-modified-p)`.
+- `check_document_dirty`: resolve the buffer visiting the given path; return its
+  `buffer-modified-p`, or "not open" when no live buffer visits it.
+Both are registered as tool descriptors alongside the existing ones and need no
+waiting or state.
+
+## Risks / Trade-offs
+
+- **Content-diff outcome detection can misclassify a no-op accept** (human
+  accepts but the accepted content equals the original) → such a case is
+  indistinguishable from reject and returns `rejected`; acceptable because the
+  file ends in the same state either way.
+- **Only one interactive diff per call; concurrent `apply_diff` calls could
+  interleave ediff sessions** → the result cell is per-call, but two overlapping
+  ediff sessions would confuse the human; document that `apply_diff` is meant to
+  be used one at a time (the blocking model naturally serializes a single
+  client).
+- **`ediff` modifies window configuration** → mitigated by saving and restoring
+  the window configuration around the session (D4).
+- **A wait that never resolves** → bounded by the timeout (D4), so the call
+  cannot hang the client indefinitely; the server itself never blocks (D1).
+
+## Open Questions
+
+- Should `apply_diff` optionally auto-save Buffer A on `applied`, or always
+  leave saving to the human? Current design: always leave it to the human,
+  matching the existing no-auto-save convention; revisit if a caller needs the
+  file on disk immediately (they can call `save_buffer`).

--- a/openspec/changes/add-ide-integration-tools/proposal.md
+++ b/openspec/changes/add-ide-integration-tools/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+`claude-code-ide.el` offers useful editor-integration features — an interactive
+diff/apply flow and editor-state queries — but ships them behind the
+Claude-Code-CLI-specific "IDE" WebSocket protocol (lockfile handshake,
+`CLAUDE_CODE_SSE_PORT`/`ENABLE_IDE_INTEGRATION` env vars).
+`mcp-emacs` already exposes Emacs to any MCP client over plain HTTP, so the
+pull-model subset of those features can live here instead and work with any
+harness, removing the need for a second, CLI-bound package.
+
+## What Changes
+
+- Add an `apply_diff` MCP tool: given a file path and proposed new content, open
+  an `ediff` session (original vs proposed), let the human edit, accept, or
+  reject the proposal interactively, then return the final content and a status
+  of `applied`, `rejected`, or `timeout`.
+- The `apply_diff` handler blocks cooperatively using the existing
+  `accept-process-output` wait pattern (as in `org_task_wait_for_change`), so
+  the single-threaded server keeps processing other tool calls and edits while
+  it waits, and it honours a bounded timeout.
+- Add a `list_open_editors` MCP tool: return the live file-visiting buffers
+  (path, buffer name, modified flag).
+- Add a `check_document_dirty` MCP tool: report whether a given file's buffer
+  has unsaved changes.
+- Out of scope (not harness-agnostic): the Claude-Code-CLI IDE WebSocket
+  protocol, the lockfile/env-var handshake, the terminal runner, and live
+  selection/at-mention push notifications.
+- No new tools for capabilities already covered: `open_file`, `get_selection`,
+  and `save_buffer` already exist and are reused.
+
+## Capabilities
+
+### New Capabilities
+- `ide-integration-tools`: harness-agnostic, pull-model editor-integration MCP
+  tools — an interactive `ediff`-based diff/apply flow and editor-state queries
+  (open editors, document dirty state).
+
+### Modified Capabilities
+<!-- None. Existing specs cover only org-task features; these tools are new and independent. -->
+
+## Impact
+
+- `elisp/mcp-emacs.el`: new helper functions (`apply_diff` ediff orchestration
+  and blocking wait, open-editors listing, dirty check).
+- `elisp/mcp-emacs-server.el`: register the three new tool descriptors
+  (`:name`, `:description`, `:schema`, `:handler`).
+- Plugin/skill surface: `apply_diff` becomes available to `review-diagnostics`
+  and `edit-at-point` workflows; docs (`README.md`, skills) mention it.
+- No new package dependencies — `ediff` is built in; reuses the existing wait
+  infrastructure and timeout customization.
+- No breaking changes; purely additive.

--- a/openspec/changes/add-ide-integration-tools/specs/ide-integration-tools/spec.md
+++ b/openspec/changes/add-ide-integration-tools/specs/ide-integration-tools/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Interactive diff/apply tool presents a proposal via ediff
+The system SHALL expose an MCP tool that accepts a file path and proposed new content, opens an `ediff` session comparing the file's current content against the proposal, and lets the human review, edit, accept, or reject the proposal interactively before the tool returns.
+
+#### Scenario: Accepting the proposal as-is
+- **WHEN** a client calls the diff tool with a path and new content and the human accepts the proposal
+- **THEN** the tool writes the accepted content to the buffer and returns a status of `applied` together with the final content
+
+#### Scenario: Rejecting the proposal
+- **WHEN** the human rejects the proposal during the ediff session
+- **THEN** the tool leaves the file's buffer unchanged and returns a status of `rejected`
+
+#### Scenario: Human edits the proposal before accepting
+- **WHEN** the human edits the proposed side during the ediff session and then accepts
+- **THEN** the tool returns a status of `applied` with the human-edited content, not the original proposal
+
+### Requirement: Diff/apply waiting does not block the Emacs event loop
+While waiting for the human's decision, the diff tool SHALL yield to the Emacs event loop so that human edits, timers, and other MCP tool calls continue to be processed.
+
+#### Scenario: Other work proceeds during a diff wait
+- **WHEN** the diff tool is waiting for the human to resolve the ediff session
+- **THEN** other MCP tool calls and buffer edits continue to be handled
+
+### Requirement: Diff/apply wait is bounded by a timeout
+The diff tool SHALL apply a default timeout when none is given and MUST cap the timeout at a defined maximum, so the call cannot hang indefinitely.
+
+#### Scenario: Human does not respond in time
+- **WHEN** the human neither accepts nor rejects before the timeout elapses
+- **THEN** the tool abandons the ediff session, leaves the buffer unchanged, and returns a status of `timeout`
+
+#### Scenario: Excessive timeout requested
+- **WHEN** a client requests a timeout above the maximum
+- **THEN** the tool waits no longer than the maximum
+
+### Requirement: Open editors can be listed
+The system SHALL expose an MCP tool that returns the live file-visiting buffers, each with its file path, buffer name, and modified (dirty) flag.
+
+#### Scenario: Listing visited files
+- **WHEN** a client calls the open-editors tool while files are open in Emacs
+- **THEN** the tool returns an entry for each file-visiting buffer with its path, buffer name, and whether it has unsaved changes
+
+#### Scenario: No files open
+- **WHEN** a client calls the open-editors tool and no file-visiting buffers exist
+- **THEN** the tool returns an empty list rather than raising an error
+
+### Requirement: Document dirty state can be queried
+The system SHALL expose an MCP tool that reports whether a given file's buffer has unsaved changes.
+
+#### Scenario: File has unsaved changes
+- **WHEN** a client queries the dirty state of a file whose buffer has been modified since its last save
+- **THEN** the tool reports that the document is dirty
+
+#### Scenario: File is not open
+- **WHEN** a client queries the dirty state of a file that has no live buffer
+- **THEN** the tool reports that the document is not dirty (or not open) rather than raising an error

--- a/openspec/changes/add-ide-integration-tools/tasks.md
+++ b/openspec/changes/add-ide-integration-tools/tasks.md
@@ -1,0 +1,26 @@
+## 1. Editor-state helpers and tools
+
+- [x] 1.1 Add `mcp-emacs-list-open-editors` helper in `elisp/mcp-emacs.el` that returns, for each file-visiting buffer, its file path, buffer name, and modified flag (empty list when none)
+- [x] 1.2 Add `mcp-emacs-check-document-dirty` helper that resolves the buffer visiting a given path and returns its dirty state, reporting not-open/not-dirty when no live buffer visits it
+- [x] 1.3 Register `list_open_editors` and `check_document_dirty` tool descriptors in `elisp/mcp-emacs-server.el` (`:name`, `:description`, `:schema`, `:handler`)
+
+## 2. Interactive diff/apply helper
+
+- [x] 2.1 Add `defcustom`s for the apply-diff default and max timeout (mirroring `mcp-emacs-org-task-wait-*`), reusing the existing poll interval
+- [x] 2.2 Implement `mcp-emacs-apply-diff` in `elisp/mcp-emacs.el`: create Buffer A from the file's current content and Buffer B from the proposed content, save the window configuration, capture Buffer A's entry content, and launch `ediff-buffers`
+- [x] 2.3 Install a buffer-local `ediff-quit-hook` on the control buffer that records the outcome into a per-call result cell captured in the closure (per design D2)
+- [x] 2.4 On quit, determine outcome by comparing Buffer A's final content to its entry content: changed → `applied` (return final content, leave saving to the human); unchanged → `rejected` (per design D3)
+- [x] 2.5 Spin the cooperative wait loop with `accept-process-output` and a bounded deadline until the result cell is set or the timeout elapses (per design D1)
+- [x] 2.6 On timeout, force-quit any live ediff control buffer (`ediff-really-quit` guarded, else kill it), restore the saved window configuration, leave Buffer A unmodified, and return `timeout` (per design D4)
+- [x] 2.7 Register the `apply_diff` tool descriptor in `elisp/mcp-emacs-server.el` (schema: required `path` + `new_content`, optional `timeout`)
+
+## 3. Cleanup and robustness
+
+- [x] 3.1 Ensure temporary Buffer B and any diff buffers are cleaned up on all exit paths (applied, rejected, timeout, error)
+- [x] 3.2 Handle the missing-file / non-Org-agnostic cases gracefully (Buffer A for a nonexistent path, unreadable path) with clear error text rather than a raw signal
+
+## 4. Verification and docs
+
+- [x] 4.1 Byte-compile both elisp files clean (only the known optional-feature warnings), confirming the new hooks/closures parse
+- [ ] 4.2 Manually exercise each tool against the live server: `apply_diff` accept, reject, human-edit, and timeout paths; `list_open_editors`; `check_document_dirty`
+- [x] 4.3 Update `README.md` tool list and mention `apply_diff` in the relevant skills (`edit-at-point`, `review-diagnostics`)

--- a/skills/edit-at-point/SKILL.md
+++ b/skills/edit-at-point/SKILL.md
@@ -30,6 +30,11 @@ instead of asking for a path or guessing.
   character in the file is line 1, column 0.
 - `goto_line` — move point to a line/column, or jump to a named function via
   imenu, before an insert.
+- `apply_diff` — for a larger, whole-file rewrite, propose the new content and
+  let the user review it in an `ediff` session; it returns `applied` (with the
+  final, possibly human-edited content), `rejected`, or `timeout`. Prefer this
+  over a blind `edit_file_region` when the change is big enough that the user
+  should see it before it lands.
 
 ## After editing
 

--- a/skills/review-diagnostics/SKILL.md
+++ b/skills/review-diagnostics/SKILL.md
@@ -28,7 +28,8 @@ skill.
 2. For each one you intend to fix, open/goto the location (`goto_line`,
    `open_file`) and inspect with `get_buffer_content` / `treesit_info`.
 3. Apply the fix via `edit_file_region` or `insert_at_point`
-   (Emacs coords: lines 1-based, columns 0-based).
+   (Emacs coords: lines 1-based, columns 0-based). For a larger rewrite, use
+   `apply_diff` so the user reviews the change in `ediff` before it lands.
 4. Re-run `get_diagnostics` to confirm the diagnostic cleared before moving on.
 
 ## Rules


### PR DESCRIPTION
Port the pull-model subset of claude-code-ide over plain MCP: apply_diff (interactive ediff review of a proposed change, returning applied/rejected/timeout via a cooperative bounded wait), list_open_editors, and check_document_dirty. The CLI-specific IDE WebSocket protocol stays out of scope. Includes OpenSpec artifacts and docs.

Note: query tools smoke-tested headless; apply_diff still needs a manual live test (accept/reject/edit/timeout) before archiving.