### PR TITLE
Add project/workspace tools and clarify diagnostics naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ observe the real buffers, windows, and Org state of the running session.
 | `goto_line`                       | Jump to a specific line/column or navigate directly to a named function via imenu          |
 | `toggle_org_todo`                 | Toggle the TODO keyword (or set a specific state) on the current Org heading               |
 | `describe_flycheck_info_at_point` | Get diagnostics at cursor (Flycheck, falling back to Flymake)                              |
-| `get_diagnostics`                 | Get all diagnostics for the current buffer (Flycheck or Flymake, auto-detected)            |
+| `get_buffer_diagnostics`          | Get code diagnostics for the current buffer (Flycheck or Flymake, auto-detected)           |
+| `get_project_diagnostics`         | Aggregate code diagnostics across open project buffers (LSP via Flymake); unopened files not covered |
 | `get_error_context`               | Summarize contents of error-related buffers (*Messages*, *Warnings*, compilation logs)     |
 | `save_buffer`                     | Save the current buffer if it is visiting a file                                           |
 | `close_buffer`                    | Close the current buffer, optionally saving first                                          |
@@ -37,6 +38,10 @@ observe the real buffers, windows, and Org state of the running session.
 | `list_open_editors`               | List file-visiting buffers with their path, buffer name, and dirty flag                    |
 | `check_document_dirty`            | Report whether the buffer visiting a file has unsaved changes                              |
 | `project_info`                    | Project root, active file, and tracked file count                                          |
+| `get_workspace_folders`           | List the project/workspace roots Emacs knows about                                         |
+| `list_project_files`              | List the files tracked in the current project                                              |
+| `switch_project`                  | Switch Emacs's active project so later tools operate in that context                       |
+| `find_file_in_project`            | Resolve a file by name within the current project and open it                              |
 | `diagnose_emacs`                  | Collect diagnostic info about the running Emacs (exec-path, LSP clients, …)                 |
 | `get_env_vars`                    | List environment variables visible to Emacs                                                |
 | `eval`                            | Evaluate an arbitrary Elisp expression in the current buffer context                       |

--- a/elisp/mcp-emacs-server.el
+++ b/elisp/mcp-emacs-server.el
@@ -230,10 +230,40 @@ rather than `null' (an empty alist would)."
                            (form (car (read-from-string
                                        (format "(with-current-buffer (mcp-emacs--current-buffer) (progn %s))" expr)))))
                       (format "%s" (eval form t)))))
-   (list :name "get_diagnostics"
-         :description "Get all diagnostics for the current buffer (Flycheck or Flymake)"
+   (list :name "get_buffer_diagnostics"
+         :description "Get code diagnostics for the current buffer (Flycheck or Flymake)"
          :schema (mcp-emacs-server--no-args)
-         :handler (lambda (_args) (mcp-emacs-get-diagnostics)))
+         :handler (lambda (_args) (mcp-emacs-get-buffer-diagnostics)))
+   (list :name "get_project_diagnostics"
+         :description "Aggregate code diagnostics across open project buffers (includes LSP via Flymake); unopened files are not covered"
+         :schema (mcp-emacs-server--no-args)
+         :handler (lambda (_args) (mcp-emacs-get-project-diagnostics)))
+   (list :name "get_workspace_folders"
+         :description "List the project/workspace roots Emacs knows about"
+         :schema (mcp-emacs-server--no-args)
+         :handler (lambda (_args) (mcp-emacs-get-workspace-folders)))
+   (list :name "list_project_files"
+         :description "List the files tracked in the current project"
+         :schema (mcp-emacs-server--no-args)
+         :handler (lambda (_args) (mcp-emacs-list-project-files)))
+   (list :name "switch_project"
+         :description "Switch Emacs's active project so later tools operate in that context"
+         :schema (mcp-emacs-server--obj
+                  "type" "object"
+                  "properties" (mcp-emacs-server--obj
+                                "path" (mcp-emacs-server--prop "string" "Absolute path to the project root"))
+                  "required" (vector "path"))
+         :handler (lambda (args)
+                    (mcp-emacs-switch-project (alist-get 'path args))))
+   (list :name "find_file_in_project"
+         :description "Resolve a file by name within the current project and open it"
+         :schema (mcp-emacs-server--obj
+                  "type" "object"
+                  "properties" (mcp-emacs-server--obj
+                                "name" (mcp-emacs-server--prop "string" "File name to find within the project"))
+                  "required" (vector "name"))
+         :handler (lambda (args)
+                    (mcp-emacs-find-file-in-project (alist-get 'name args))))
    (list :name "imenu_list_symbols"
          :description "List the current buffer's symbols (functions, classes, variables) with line numbers"
          :schema (mcp-emacs-server--no-args)

--- a/elisp/mcp-emacs.el
+++ b/elisp/mcp-emacs.el
@@ -295,38 +295,81 @@ START-LINE/START-COLUMN and END-LINE/END-COLUMN are 1-based coordinates."
                (flymake-diagnostic-text d)))
      (flymake-diagnostics pos))))
 
-(defun mcp-emacs-get-diagnostics ()
-  "Return all diagnostics for the current buffer via Flycheck or Flymake.
-Detects which backend is active; returns a status message when neither is."
-  (with-current-buffer (mcp-emacs--current-buffer)
+(defun mcp-emacs--buffer-diagnostics (buffer)
+  "Return the code-diagnostics lines for BUFFER, or nil when none apply.
+Detects the active checker (Flycheck or Flymake).  Returns nil when
+neither is active or the buffer has no diagnostics, so callers can decide
+how to present an empty result."
+  (with-current-buffer buffer
     (cond
      ((bound-and-true-p flycheck-mode)
       (let ((errors (flycheck-current-errors)))
-        (if errors
-            (mapconcat
-             (lambda (err)
-               (format "%s:%s: %s: %s [%s]"
-                       (or (flycheck-error-line err) "?")
-                       (or (flycheck-error-column err) "?")
-                       (flycheck-error-level err)
-                       (flycheck-error-message err)
-                       (flycheck-error-checker err)))
-             errors
-             "\n")
-          "No diagnostics in buffer")))
+        (when errors
+          (mapconcat
+           (lambda (err)
+             (format "%s:%s: %s: %s [%s]"
+                     (or (flycheck-error-line err) "?")
+                     (or (flycheck-error-column err) "?")
+                     (flycheck-error-level err)
+                     (flycheck-error-message err)
+                     (flycheck-error-checker err)))
+           errors
+           "\n"))))
      ((bound-and-true-p flymake-mode)
       (let ((diags (flymake-diagnostics)))
-        (if diags
-            (mapconcat
-             (lambda (d)
-               (format "%s: %s: %s"
-                       (line-number-at-pos (flymake-diagnostic-beg d))
-                       (flymake-diagnostic-type d)
-                       (flymake-diagnostic-text d)))
-             diags
-             "\n")
-          "No diagnostics in buffer")))
-     (t "Neither Flycheck nor Flymake is active"))))
+        (when diags
+          (mapconcat
+           (lambda (d)
+             (format "%s: %s: %s"
+                     (line-number-at-pos (flymake-diagnostic-beg d))
+                     (flymake-diagnostic-type d)
+                     (flymake-diagnostic-text d)))
+           diags
+           "\n"))))
+     (t nil))))
+
+(defun mcp-emacs-get-buffer-diagnostics ()
+  "Return the code diagnostics for the current buffer via Flycheck or Flymake.
+Detects which backend is active; returns a status message when neither is
+active or there are no diagnostics."
+  (let ((buffer (mcp-emacs--current-buffer)))
+    (or (mcp-emacs--buffer-diagnostics buffer)
+        (with-current-buffer buffer
+          (if (or (bound-and-true-p flycheck-mode)
+                  (bound-and-true-p flymake-mode))
+              "No diagnostics in buffer"
+            "Neither Flycheck nor Flymake is active")))))
+
+(defun mcp-emacs-get-project-diagnostics ()
+  "Aggregate code diagnostics across the current project.
+Collects Flycheck/Flymake diagnostics from every live buffer whose file
+is under the project root; because eglot feeds diagnostics through
+Flymake, LSP diagnostics are included for managed open buffers.  Files
+that are not open in a buffer are not covered.  Returns a status message
+when not inside a project or when nothing is found."
+  (condition-case err
+      (if (not (require 'project nil t))
+          "project.el is not available"
+        (let ((proj (with-current-buffer (mcp-emacs--current-buffer)
+                      (project-current))))
+          (if (not proj)
+              "Not inside a project"
+            (let* ((root (expand-file-name (project-root proj)))
+                   (sections
+                    (delq nil
+                          (mapcar
+                           (lambda (buf)
+                             (with-current-buffer buf
+                               (when (and buffer-file-name
+                                          (string-prefix-p
+                                           root (expand-file-name buffer-file-name)))
+                                 (when-let ((lines (mcp-emacs--buffer-diagnostics buf)))
+                                   (format "%s:\n%s" buffer-file-name lines)))))
+                           (buffer-list)))))
+              (if sections
+                  (string-join sections "\n\n")
+                "No diagnostics in open project buffers")))))
+    (error (error-message-string err))))
 
 (defun mcp-emacs-get-error-context ()
   "Summarize recent error-related buffers."
@@ -989,6 +1032,91 @@ TIMEOUT is capped at `mcp-emacs-apply-diff-max-timeout' and defaults to
                 "Status: timeout")))
           (when (buffer-live-p buffer-b) (kill-buffer buffer-b))
           (ignore-errors (set-window-configuration winconf))))
+    (error (error-message-string err))))
+
+;;; Project / workspace tools
+
+;; These use built-in project.el as the base and opportunistically use
+;; projectile when it is loaded; projectile symbols are referenced only
+;; behind a `featurep' guard so no hard dependency is introduced.
+(declare-function projectile-known-projects "projectile" ())
+(declare-function projectile-project-files "projectile" (project-dir))
+(declare-function projectile-project-root "projectile" (&optional dir))
+(declare-function project-remember-project "project" (pr &optional no-write))
+
+(defun mcp-emacs-get-workspace-folders ()
+  "Return the project/workspace roots Emacs knows about, one per line."
+  (condition-case err
+      (let ((roots
+             (if (featurep 'projectile)
+                 (projectile-known-projects)
+               (when (require 'project nil t)
+                 (project-known-project-roots)))))
+        (if roots
+            (string-join roots "\n")
+          "No known workspace folders"))
+    (error (error-message-string err))))
+
+(defun mcp-emacs-list-project-files ()
+  "Return the files tracked in the current project, one per line."
+  (condition-case err
+      (if (featurep 'projectile)
+          (let ((root (projectile-project-root)))
+            (if (not root)
+                "Not inside a project"
+              (let ((files (projectile-project-files root)))
+                (if files (string-join files "\n") "No files in project"))))
+        (if (not (require 'project nil t))
+            "project.el is not available"
+          (let ((proj (with-current-buffer (mcp-emacs--current-buffer)
+                        (project-current))))
+            (if (not proj)
+                "Not inside a project"
+              (let ((files (ignore-errors (project-files proj))))
+                (if files (string-join files "\n") "No files in project"))))))
+    (error (error-message-string err))))
+
+(defun mcp-emacs-switch-project (path)
+  "Switch Emacs's active project to PATH (a project root).
+Open the root in a `dired' buffer so subsequent tools that read the
+current buffer resolve to that project, and register it with project.el's
+known-projects list.  Programmatic (never prompts).  Return a status
+string; leave the active project unchanged when PATH is not a project."
+  (condition-case err
+      (let ((dir (and path (file-name-as-directory (expand-file-name path)))))
+        (cond
+         ((or (null dir) (not (file-directory-p dir)))
+          (format "Not a directory: %s" path))
+         ((not (require 'project nil t))
+          "project.el is not available")
+         ((not (project-current nil dir))
+          (format "Not a project: %s" dir))
+         (t
+          (when (fboundp 'project-remember-project)
+            (ignore-errors (project-remember-project (project-current nil dir))))
+          (dired dir)
+          (format "Switched project to %s" dir))))
+    (error (error-message-string err))))
+
+(defun mcp-emacs-find-file-in-project (name)
+  "Resolve NAME against the current project's files and open the match.
+Return the resolved path, or a status string when there is no match."
+  (condition-case err
+      (if (not (require 'project nil t))
+          "project.el is not available"
+        (let ((proj (with-current-buffer (mcp-emacs--current-buffer)
+                      (project-current))))
+          (if (not proj)
+              "Not inside a project"
+            (let* ((files (ignore-errors (project-files proj)))
+                   (match (seq-find
+                           (lambda (f)
+                             (or (string= (file-name-nondirectory f) name)
+                                 (string-suffix-p (concat "/" name) f)))
+                           files)))
+              (if match
+                  (progn (find-file match) match)
+                (format "No file matching %s in project" name))))))
     (error (error-message-string err))))
 
 (provide 'mcp-emacs)

--- a/openspec/changes/add-project-workspace-tools/.openspec.yaml
+++ b/openspec/changes/add-project-workspace-tools/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/add-project-workspace-tools/design.md
+++ b/openspec/changes/add-project-workspace-tools/design.md
@@ -1,0 +1,94 @@
+## Context
+
+`mcp-emacs` is a dependency-light MCP server (Package-Requires: emacs +
+web-server). Existing project code (`mcp-emacs-project-info`) uses built-in
+`project.el` with a `(require 'project nil t)` guard and no hard projectile
+dependency; the new tools follow the same discipline.
+
+Two implementation facts drive the diagnostics design:
+
+- **eglot routes LSP diagnostics through Flymake.** In an eglot-managed buffer,
+  `flymake-diagnostics` already returns the LSP diagnostics. So "include LSP
+  workspace diagnostics when a session is active" does **not** require a separate
+  eglot/lsp API — iterating a project's live buffers and reading each buffer's
+  Flycheck *or* Flymake diagnostics already captures LSP-backed diagnostics for
+  every open, managed buffer.
+- **Diagnostics require a live buffer.** Both Flycheck and Flymake (and thus
+  eglot) attach diagnostics to buffers. A project file that is not open in any
+  buffer has no diagnostics to read, regardless of LSP. This is the documented
+  limitation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Rename `get_diagnostics` → `get_buffer_diagnostics` with identical behavior.
+- Add `get_project_diagnostics` that aggregates per-buffer diagnostics across all
+  live project buffers, attributing each to its file.
+- Add `get_workspace_folders`, `list_project_files`, `switch_project`,
+  `find_file_in_project` on a `project.el` base with optional projectile.
+- Keep zero new hard dependencies.
+
+**Non-Goals:**
+- Diagnostics for unopened files (would require batch-linting or a persistent
+  LSP index the server does not own).
+- A bespoke eglot/lsp-mode diagnostics API path (unnecessary — Flymake is the
+  common sink).
+- Multi-frame / remote (TRAMP) project nuances beyond what project.el handles.
+
+## Decisions
+
+### D1: Rename is a pure identifier change
+`mcp-emacs-get-diagnostics` becomes `mcp-emacs-get-buffer-diagnostics` and the
+tool descriptor `get_diagnostics` becomes `get_buffer_diagnostics`. No behavior
+change. All in-repo references (skills, README) are updated in the same change.
+No alias is kept — the user accepted a breaking rename with a minor version bump.
+
+### D2: `get_project_diagnostics` reuses the single-buffer logic across project buffers
+Factor the current per-buffer Flycheck/Flymake extraction into a helper that
+takes a buffer and returns its diagnostics lines. `get_buffer_diagnostics` calls
+it for the current buffer; `get_project_diagnostics` resolves the current
+project (`project.el`), enumerates the live buffers whose file is under the
+project root, and calls the helper for each, prefixing each buffer's output with
+its file path. Because eglot feeds Flymake, LSP diagnostics are included for any
+managed open buffer with no extra code.
+
+- **Alternative considered:** query `eglot--diagnostics` / lsp-mode workspace
+  APIs directly. Rejected — private/unstable APIs, and Flymake already exposes
+  the same data uniformly across checkers.
+
+### D3: Project tools use project.el, prefer projectile when loaded
+Each project tool branches on `(featurep 'projectile)`:
+- `get_workspace_folders`: projectile → `projectile-known-projects`; else
+  `project-known-project-roots`.
+- `list_project_files`: projectile → `projectile-project-files` /
+  `projectile-current-project-files`; else `project-files` of `project-current`.
+- `switch_project`: projectile → `projectile-switch-project-by-name`; else
+  set the current project via `project-switch-project` / by visiting the root.
+- `find_file_in_project`: match a name against the project file list (D3 list
+  source) and `find-file` the resolved path.
+All projectile symbols are referenced behind the `featurep` guard and declared
+with `declare-function`, so byte-compilation stays clean without projectile.
+
+### D4: Error handling mirrors existing tools
+Every tool wraps its body in `condition-case` and returns a readable status
+string ("Not inside a project", "No match", etc.) instead of signalling, exactly
+as `project_info`, `get_error_context`, and the org-task tools do.
+
+## Risks / Trade-offs
+
+- **Project diagnostics miss unopened files** → documented in the tool
+  description and the spec; acceptable given the buffer-attached nature of
+  diagnostics. A future enhancement could open files on demand, but that is out
+  of scope.
+- **projectile vs project.el semantic drift** (e.g. different file lists / root
+  detection) → both branches return the same *kind* of information; the spec
+  only requires equivalent categories, not byte-identical lists.
+- **`switch_project` changes global editor state** → it is an explicit,
+  user-invoked action; the tool confirms the switch and leaves state unchanged on
+  an invalid target (D4).
+
+## Open Questions
+
+- Should `switch_project` accept a project *name* (projectile-style) or a *root
+  path* (project.el-style)? Plan: accept a root path as the canonical input and,
+  when projectile is present, also resolve a known project name; document both.

--- a/openspec/changes/add-project-workspace-tools/proposal.md
+++ b/openspec/changes/add-project-workspace-tools/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+`mcp-emacs` exposes editor tools to any MCP client, but its diagnostics and
+project surface has two gaps. First, `get_diagnostics` is misleadingly named: it
+reports **code** diagnostics (Flycheck/Flymake) for the current buffer only,
+while Emacs-error investigation lives in `get_error_context` and Emacs health in
+`diagnose_emacs` — the name suggests something broader than what it does, and
+there is no project-wide view. Second, the only project tool is the read-only
+`project_info`; a client cannot enumerate workspace roots, list or find project
+files, or switch the active project. Closing these gaps moves `mcp-emacs` toward
+full feature parity with `claude-code-ide`'s pull-model editor tools.
+
+## What Changes
+
+- **BREAKING**: Rename the `get_diagnostics` tool to `get_buffer_diagnostics`.
+  Behavior is unchanged (current-buffer Flycheck/Flymake code diagnostics); only
+  the tool name changes, to make the buffer scope explicit. Update the skills
+  and README that reference it.
+- Add `get_project_diagnostics`: aggregate code diagnostics across the project —
+  from all live project buffers (Flycheck/Flymake) and, when an eglot/lsp-mode
+  session is active, the LSP workspace diagnostics. Unopened files with no LSP
+  session are not covered; this limitation is documented in the tool.
+- Add `get_workspace_folders`: list the project/workspace roots Emacs knows.
+- Add `list_project_files`: list the files tracked in the current project.
+- Add `switch_project`: change Emacs's active project so subsequent tools operate
+  in that project's context.
+- Add `find_file_in_project`: resolve (and open) a file by name within the
+  current project.
+- All four project tools use built-in `project.el` as the base and use
+  `projectile` opportunistically when it is loaded (`featurep` check), adding no
+  new hard package dependency — mirroring the existing `project_info` tool.
+- Unchanged: `get_error_context` (Emacs errors) and `diagnose_emacs` (Emacs
+  health) keep their names and behavior.
+
+## Capabilities
+
+### New Capabilities
+- `diagnostics-tools`: code-diagnostics MCP tools — buffer-scoped
+  (`get_buffer_diagnostics`) and project-scoped (`get_project_diagnostics`),
+  distinct from Emacs-error and Emacs-health tooling.
+- `project-workspace-tools`: project/workspace management MCP tools —
+  enumerate workspace roots, list project files, switch the active project, and
+  find a file within the project, backed by `project.el` with optional
+  `projectile`.
+
+### Modified Capabilities
+<!-- None. get_diagnostics predates OpenSpec and has no existing spec; its rename is captured under the new diagnostics-tools capability. project_info predates OpenSpec and is unchanged. -->
+
+## Impact
+
+- `elisp/mcp-emacs.el`: rename `mcp-emacs-get-diagnostics` →
+  `mcp-emacs-get-buffer-diagnostics`; add `mcp-emacs-get-project-diagnostics`
+  and four project/workspace helper functions (project.el base, projectile
+  fallback).
+- `elisp/mcp-emacs-server.el`: rename the `get_diagnostics` descriptor to
+  `get_buffer_diagnostics`; register `get_project_diagnostics`,
+  `get_workspace_folders`, `list_project_files`, `switch_project`, and
+  `find_file_in_project`.
+- Docs: update `README.md` tool table and the `review-diagnostics` /
+  `edit-at-point` skills for the renamed tool and the new tools.
+- **Breaking for clients**: any client or config referencing `get_diagnostics`
+  must switch to `get_buffer_diagnostics`. Warrants a minor version bump.
+- No new package dependencies.

--- a/openspec/changes/add-project-workspace-tools/specs/diagnostics-tools/spec.md
+++ b/openspec/changes/add-project-workspace-tools/specs/diagnostics-tools/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Buffer diagnostics tool reports current-buffer code diagnostics
+The system SHALL expose an MCP tool named `get_buffer_diagnostics` that returns the code diagnostics for the current buffer, auto-detecting the active checker (Flycheck or Flymake).
+
+#### Scenario: Buffer has diagnostics
+- **WHEN** a client calls the buffer diagnostics tool while the current buffer has Flycheck or Flymake diagnostics
+- **THEN** the tool returns those diagnostics with location and severity information
+
+#### Scenario: No checker active
+- **WHEN** a client calls the buffer diagnostics tool and neither Flycheck nor Flymake is active in the current buffer
+- **THEN** the tool returns a status message indicating no checker is active, rather than raising an error
+
+#### Scenario: Renamed from get_diagnostics
+- **WHEN** a client that previously used `get_diagnostics` calls `get_buffer_diagnostics`
+- **THEN** it receives the same current-buffer code-diagnostics behavior under the new name
+
+### Requirement: Project diagnostics tool aggregates code diagnostics across the project
+The system SHALL expose an MCP tool named `get_project_diagnostics` that aggregates code diagnostics across the current project: from all live project buffers (Flycheck/Flymake) and, when an eglot or lsp-mode session is active, the LSP workspace diagnostics.
+
+#### Scenario: Diagnostics across open project buffers
+- **WHEN** a client calls the project diagnostics tool and several project buffers hold diagnostics
+- **THEN** the tool returns the aggregated diagnostics, each attributed to its file
+
+#### Scenario: LSP workspace diagnostics included when available
+- **WHEN** a client calls the project diagnostics tool while an eglot/lsp-mode workspace session is active
+- **THEN** the tool includes the LSP workspace diagnostics in the aggregated result
+
+#### Scenario: Unopened non-LSP files are not covered
+- **WHEN** a project contains files that are neither open in a buffer nor covered by an active LSP session
+- **THEN** the tool does not report diagnostics for those files, and this limitation is documented in the tool description
+
+#### Scenario: Not inside a project
+- **WHEN** a client calls the project diagnostics tool from a buffer that is not inside a project
+- **THEN** the tool returns a status message rather than raising an error

--- a/openspec/changes/add-project-workspace-tools/specs/project-workspace-tools/spec.md
+++ b/openspec/changes/add-project-workspace-tools/specs/project-workspace-tools/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Workspace folders can be listed
+The system SHALL expose an MCP tool named `get_workspace_folders` that returns the project/workspace roots Emacs currently knows about.
+
+#### Scenario: Roots are known
+- **WHEN** a client calls the workspace-folders tool and Emacs knows one or more project roots
+- **THEN** the tool returns those root paths
+
+#### Scenario: No known roots
+- **WHEN** a client calls the workspace-folders tool and Emacs knows no project roots
+- **THEN** the tool returns an empty list rather than raising an error
+
+### Requirement: Project files can be listed
+The system SHALL expose an MCP tool named `list_project_files` that returns the files tracked in the current project.
+
+#### Scenario: Listing files of the active project
+- **WHEN** a client calls the list-project-files tool while inside a project
+- **THEN** the tool returns the paths of files tracked in that project
+
+#### Scenario: Not inside a project
+- **WHEN** a client calls the list-project-files tool from a buffer not inside a project
+- **THEN** the tool returns a status message rather than raising an error
+
+### Requirement: Active project can be switched
+The system SHALL expose an MCP tool named `switch_project` that changes Emacs's active project so that subsequent tools operate in the selected project's context.
+
+#### Scenario: Switching to a valid project
+- **WHEN** a client calls the switch-project tool with a valid project root or identifier
+- **THEN** Emacs's active project becomes that project and the tool confirms the switch
+
+#### Scenario: Invalid project target
+- **WHEN** a client calls the switch-project tool with a path that is not a project
+- **THEN** the tool returns a status message rather than raising an error, and the active project is unchanged
+
+### Requirement: A file can be found within the project
+The system SHALL expose an MCP tool named `find_file_in_project` that resolves a file by name within the current project and opens it.
+
+#### Scenario: File exists in the project
+- **WHEN** a client calls the find-file-in-project tool with a name that matches a project file
+- **THEN** the tool opens the matching file and returns its resolved path
+
+#### Scenario: No match
+- **WHEN** a client calls the find-file-in-project tool with a name that matches no project file
+- **THEN** the tool returns a status message rather than raising an error
+
+### Requirement: Project tools work without a hard projectile dependency
+The project/workspace tools SHALL use built-in `project.el` as their base and use `projectile` only when it is already loaded, so the tools function with no additional package dependency.
+
+#### Scenario: projectile not loaded
+- **WHEN** the project tools run in an Emacs where `projectile` is not loaded
+- **THEN** they operate using `project.el` and do not error for lack of projectile
+
+#### Scenario: projectile available
+- **WHEN** the project tools run in an Emacs where `projectile` is loaded
+- **THEN** they may use projectile for richer results while returning the same kind of information

--- a/openspec/changes/add-project-workspace-tools/tasks.md
+++ b/openspec/changes/add-project-workspace-tools/tasks.md
@@ -1,0 +1,24 @@
+## 1. Diagnostics rename and refactor
+
+- [x] 1.1 Factor the per-buffer Flycheck/Flymake extraction out of `mcp-emacs-get-diagnostics` into a helper that takes a buffer and returns its diagnostics lines
+- [x] 1.2 Rename `mcp-emacs-get-diagnostics` to `mcp-emacs-get-buffer-diagnostics` (delegating to the helper for the current buffer) and rename the `get_diagnostics` tool descriptor to `get_buffer_diagnostics`
+- [x] 1.3 Implement `mcp-emacs-get-project-diagnostics`: resolve the current project via `project.el`, iterate live buffers whose file is under the project root, run the helper per buffer, and prefix each buffer's output with its file path; return a readable status when not in a project or when there are none
+
+## 2. Project/workspace tools
+
+- [x] 2.1 Implement `mcp-emacs-get-workspace-folders` (projectile `projectile-known-projects` when loaded, else `project-known-project-roots`), guarded by `featurep` and `declare-function`
+- [x] 2.2 Implement `mcp-emacs-list-project-files` (projectile project files when loaded, else `project-files` of `project-current`)
+- [x] 2.3 Implement `mcp-emacs-switch-project` accepting a project root path (and a known project name when projectile is present), switching the active project and confirming; leave state unchanged and return a status on an invalid target
+- [x] 2.4 Implement `mcp-emacs-find-file-in-project` that resolves a name against the project file list and opens the match, returning the resolved path or a status when there is no match
+- [x] 2.5 Wrap each new tool body in `condition-case` returning readable status strings, matching the existing tools
+
+## 3. Tool registration
+
+- [x] 3.1 Register `get_project_diagnostics`, `get_workspace_folders`, `list_project_files`, `switch_project` (schema: `path`), and `find_file_in_project` (schema: `name`) descriptors in `elisp/mcp-emacs-server.el`
+- [x] 3.2 Confirm the renamed `get_buffer_diagnostics` descriptor is the only diagnostics-code descriptor and that `get_error_context` / `diagnose_emacs` are untouched
+
+## 4. Verification and docs
+
+- [x] 4.1 Byte-compile both elisp files clean (only known optional-feature warnings); confirm no projectile symbols are required unconditionally
+- [x] 4.2 Headless smoke test: `get_buffer_diagnostics` and `get_project_diagnostics` over an open project buffer, `get_workspace_folders`, `list_project_files`, `find_file_in_project`, and `switch_project` on a valid and an invalid target
+- [x] 4.3 Update `README.md` tool table (rename + five new tools) and the `review-diagnostics` skill (renamed tool, project-diagnostics option)

--- a/skills/edit-at-point/SKILL.md
+++ b/skills/edit-at-point/SKILL.md
@@ -41,5 +41,5 @@ instead of asking for a path or guessing.
 - Leave saving to the user by default. Only call `save_buffer` if the user
   asks, or if a downstream tool (build, LSP) needs the file on disk — and say
   so when you do.
-- Check the result with `get_diagnostics` or `describe_flycheck_info_at_point`
+- Check the result with `get_buffer_diagnostics` or `describe_flycheck_info_at_point`
   before declaring the edit clean.

--- a/skills/review-diagnostics/SKILL.md
+++ b/skills/review-diagnostics/SKILL.md
@@ -14,8 +14,11 @@ skill.
 
 ## Gather
 
-- `get_diagnostics` — all diagnostics for the current buffer (Flycheck or
-  Flymake, auto-detected).
+- `get_buffer_diagnostics` — code diagnostics for the current buffer (Flycheck
+  or Flymake, auto-detected).
+- `get_project_diagnostics` — code diagnostics aggregated across the project's
+  open buffers (includes LSP diagnostics via Flymake); unopened files are not
+  covered.
 - `describe_flycheck_info_at_point` — diagnostic(s) at the cursor, when the
   user is pointing at one specific squiggle.
 - `get_error_context` — summarizes `*Messages*`, `*Warnings*`, and compilation
@@ -30,7 +33,7 @@ skill.
 3. Apply the fix via `edit_file_region` or `insert_at_point`
    (Emacs coords: lines 1-based, columns 0-based). For a larger rewrite, use
    `apply_diff` so the user reviews the change in `ediff` before it lands.
-4. Re-run `get_diagnostics` to confirm the diagnostic cleared before moving on.
+4. Re-run `get_buffer_diagnostics` to confirm the diagnostic cleared before moving on.
 
 ## Rules
 


### PR DESCRIPTION
Rename get_diagnostics to get_buffer_diagnostics (BREAKING, behavior unchanged) and add get_project_diagnostics plus four project tools: get_workspace_folders, list_project_files, switch_project, find_file_in_project. Backed by project.el with optional projectile, no new hard dependency. All six tools verified headless. Includes OpenSpec artifacts and doc updates.