### PR TITLE
Add Claude Code CLI runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ Configure `opencode-client-host`, `-port`, and optional `-password`, then:
   turn), `C-c C-k` to interrupt. Permission and question requests are answered
   from Emacs.
 
+### Claude runner
+
+`elisp/mcp-emacs-run.el` runs the Claude Code CLI inside Emacs. The CLI is a
+full-screen TUI, so it runs in an [`eat`](https://codeberg.org/akib/emacs-eat)
+terminal buffer (eat is an optional dependency, loaded only when present). The
+runner is project-aware, keeps one primary session per project, and manages a
+side window. Editor-tool integration is provided to the CLI through the
+`mcp-emacs` MCP server via your own MCP configuration (e.g. `.mcp.json`); the
+runner only launches and places the terminal.
+
+Configure `mcp-emacs-run-executable` and `-flags`, then:
+
+- `M-x mcp-emacs-run` — start (or switch to) the runner for the current project.
+- `M-x mcp-emacs-run-continue` / `-resume` — pick up a prior conversation.
+- `M-x mcp-emacs-run-toggle` — show/hide the runner side window.
+- `M-x mcp-emacs-run-list` / `-switch` / `-kill` — manage sessions.
+
 ### Resources
 
 | Resource            | Description                                                                               |

--- a/elisp/mcp-emacs-run.el
+++ b/elisp/mcp-emacs-run.el
@@ -1,0 +1,221 @@
+;;; mcp-emacs-run.el --- Run the Claude Code CLI inside Emacs -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 1.0.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; A terminal runner for the Claude Code CLI, hosted inside Emacs.  The
+;; CLI is a full-screen ANSI TUI, so it runs in an eat terminal buffer
+;; (eat is a soft dependency, loaded only when present).  The runner is
+;; project-aware, keeps one primary session per project, manages a side
+;; window, and supports continue/resume.  Editor-tool integration is
+;; provided to the CLI through the mcp-emacs MCP server (via the user's
+;; MCP configuration), not by this runner.
+;;
+;; This file is separate from the MCP server so the server stays pure.
+
+;;; Code:
+
+(require 'project nil t)
+(require 'eat nil t)
+
+(declare-function eat-make "eat" (name program &optional startfile &rest switches))
+(declare-function project-current "project" (&optional maybe-prompt directory))
+(declare-function project-root "project" (project))
+
+;;;; Customization
+
+(defgroup mcp-emacs-run nil
+  "Run the Claude Code CLI inside Emacs."
+  :group 'tools
+  :prefix "mcp-emacs-run-")
+
+(defcustom mcp-emacs-run-executable "claude"
+  "Path to the Claude Code CLI executable."
+  :type 'string
+  :group 'mcp-emacs-run)
+
+(defcustom mcp-emacs-run-flags nil
+  "Extra command-line flags passed to the Claude Code CLI."
+  :type '(repeat string)
+  :group 'mcp-emacs-run)
+
+(defcustom mcp-emacs-run-focus-on-show t
+  "When non-nil, showing the runner window also selects it."
+  :type 'boolean
+  :group 'mcp-emacs-run)
+
+(defcustom mcp-emacs-run-window-side 'right
+  "Side of the frame the runner window is displayed on."
+  :type '(choice (const left) (const right) (const top) (const bottom))
+  :group 'mcp-emacs-run)
+
+(defcustom mcp-emacs-run-window-width 0.4
+  "Width of the runner side window, as a fraction of the frame."
+  :type 'number
+  :group 'mcp-emacs-run)
+
+;;;; State
+
+(defvar mcp-emacs-run--sessions (make-hash-table :test 'equal)
+  "Registry mapping a project root to its runner buffer.")
+
+;;;; Helpers
+
+(defun mcp-emacs-run--ensure-eat ()
+  "Signal a clear error unless eat is available."
+  (unless (featurep 'eat)
+    (user-error "mcp-emacs-run requires the `eat' package; please install it")))
+
+(defun mcp-emacs-run--project-root ()
+  "Return the current project root, or the buffer's directory as a fallback."
+  (or (when (and (featurep 'project) (fboundp 'project-current))
+        (when-let ((proj (project-current nil)))
+          (expand-file-name (project-root proj))))
+      (expand-file-name default-directory)))
+
+(defun mcp-emacs-run--project-name (root)
+  "Return a short name for the project at ROOT."
+  (file-name-nondirectory (directory-file-name root)))
+
+(defun mcp-emacs-run--buffer-name (root)
+  "Return the runner buffer name for project ROOT."
+  (format "*claude:%s*" (mcp-emacs-run--project-name root)))
+
+(defun mcp-emacs-run--live-buffer (root)
+  "Return the live runner buffer registered for ROOT, or nil."
+  (let ((buf (gethash root mcp-emacs-run--sessions)))
+    (if (buffer-live-p buf)
+        buf
+      (remhash root mcp-emacs-run--sessions)
+      nil)))
+
+(defun mcp-emacs-run--display (buffer)
+  "Display BUFFER in a side window, honouring the focus preference."
+  (let ((window
+         (display-buffer
+          buffer
+          `((display-buffer-in-side-window)
+            (side . ,mcp-emacs-run-window-side)
+            (window-width . ,mcp-emacs-run-window-width)))))
+    (when (and window mcp-emacs-run-focus-on-show)
+      (select-window window))
+    window))
+
+(defun mcp-emacs-run--launch (root &rest extra-switches)
+  "Launch the CLI for project ROOT in an eat buffer, and display it.
+EXTRA-SWITCHES are appended to the configured flags (e.g. continue/resume)."
+  (mcp-emacs-run--ensure-eat)
+  (let* ((default-directory (file-name-as-directory root))
+         (name (substring (mcp-emacs-run--buffer-name root) 1 -1)) ; eat-make wraps in *...*
+         (switches (append mcp-emacs-run-flags extra-switches))
+         (buffer (apply #'eat-make name mcp-emacs-run-executable nil switches)))
+    (puthash root buffer mcp-emacs-run--sessions)
+    (mcp-emacs-run--display buffer)
+    buffer))
+
+;;;; Commands
+
+;;;###autoload
+(defun mcp-emacs-run (&rest extra-switches)
+  "Start (or switch to) the Claude Code runner for the current project.
+Reuses a live session for the project instead of launching a duplicate.
+EXTRA-SWITCHES, when given, are passed to a fresh launch."
+  (interactive)
+  (mcp-emacs-run--ensure-eat)
+  (let* ((root (mcp-emacs-run--project-root))
+         (existing (mcp-emacs-run--live-buffer root)))
+    (if (and existing (null extra-switches))
+        (progn (mcp-emacs-run--display existing) existing)
+      (apply #'mcp-emacs-run--launch root extra-switches))))
+
+;;;###autoload
+(defun mcp-emacs-run-continue ()
+  "Start the runner continuing the most recent conversation."
+  (interactive)
+  (apply #'mcp-emacs-run--launch (mcp-emacs-run--project-root) '("--continue")))
+
+;;;###autoload
+(defun mcp-emacs-run-resume ()
+  "Start the runner resuming a prior conversation."
+  (interactive)
+  (apply #'mcp-emacs-run--launch (mcp-emacs-run--project-root) '("--resume")))
+
+;;;###autoload
+(defun mcp-emacs-run-list ()
+  "Message the live runner sessions."
+  (interactive)
+  (let (entries)
+    (maphash (lambda (root buf)
+               (when (buffer-live-p buf)
+                 (push (format "  %s  ->  %s" (mcp-emacs-run--project-name root)
+                               (buffer-name buf))
+                       entries)))
+             mcp-emacs-run--sessions)
+    (if entries
+        (message "Claude runner sessions:\n%s" (string-join (nreverse entries) "\n"))
+      (message "No live Claude runner sessions"))))
+
+;;;###autoload
+(defun mcp-emacs-run-switch ()
+  "Choose a live runner session and display it."
+  (interactive)
+  (let (choices)
+    (maphash (lambda (root buf)
+               (when (buffer-live-p buf)
+                 (push (cons (mcp-emacs-run--project-name root) buf) choices)))
+             mcp-emacs-run--sessions)
+    (unless choices (user-error "No live Claude runner sessions"))
+    (let* ((pick (completing-read "Runner session: " choices nil t))
+           (buf (cdr (assoc pick choices))))
+      (mcp-emacs-run--display buf))))
+
+;;;###autoload
+(defun mcp-emacs-run-kill ()
+  "Kill the runner session for the current project."
+  (interactive)
+  (let* ((root (mcp-emacs-run--project-root))
+         (buf (mcp-emacs-run--live-buffer root)))
+    (unless buf (user-error "No live runner session for this project"))
+    (when-let ((proc (get-buffer-process buf)))
+      (ignore-errors (delete-process proc)))
+    (kill-buffer buf)
+    (remhash root mcp-emacs-run--sessions)
+    (message "Killed Claude runner session for %s"
+             (mcp-emacs-run--project-name root))))
+
+;;;###autoload
+(defun mcp-emacs-run-toggle ()
+  "Toggle the runner window for the current project.
+Hides the window when visible (without killing the process); shows it
+otherwise, starting the runner if there is no session yet."
+  (interactive)
+  (let* ((root (mcp-emacs-run--project-root))
+         (buf (mcp-emacs-run--live-buffer root)))
+    (cond
+     ((null buf) (mcp-emacs-run))
+     ((get-buffer-window buf)
+      (delete-window (get-buffer-window buf)))
+     (t (mcp-emacs-run--display buf)))))
+
+(provide 'mcp-emacs-run)
+
+;;; mcp-emacs-run.el ends here

--- a/openspec/changes/add-claude-runner/design.md
+++ b/openspec/changes/add-claude-runner/design.md
@@ -1,0 +1,95 @@
+## Context
+
+`mcp-emacs` now provides Claude's editor tools over MCP; the missing piece for
+retiring `claude-code-ide.el` is a way to *run* the Claude CLI inside Emacs. The
+CLI is a full-screen ANSI TUI, so it needs a real terminal emulator, not a
+comint line-mode. eat is chosen (pure Elisp, no C dependency, rewraps on resize,
+low flicker) and is already the terminal the user runs.
+
+eat exposes a single launch primitive:
+`eat-make NAME PROGRAM &optional STARTFILE &rest SWITCHES` — it creates a buffer
+`*NAME*` running PROGRAM (with SWITCHES) in an eat terminal and returns that
+buffer. The process inherits `default-directory` as its working directory. This
+is the same entry point `claude-code.el` uses.
+
+The runner lives in a new file, `elisp/mcp-emacs-run.el`, separate from the MCP
+server so the server stays pure. eat is a soft dependency (`featurep`-guarded,
+`declare-function` for `eat-make`), so loading `mcp-emacs` never requires eat.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Launch the Claude CLI in an eat buffer, project-aware, with a configurable
+  executable and flags.
+- One primary session per project, with list/switch/kill.
+- Show/hide/toggle a side-window for the runner.
+- Continue/resume prior conversations.
+- No hard dependency on eat.
+
+**Non-Goals:**
+- The IDE WebSocket protocol and push notifications (editor tools come from
+  mcp-emacs over MCP).
+- Reading or parsing the CLI's output (it is an opaque TUI); the runner only
+  launches, places, and manages the terminal.
+- Any shared abstraction with the opencode client (deliberately separate — the
+  two are architecturally different).
+
+## Decisions
+
+### D1: Launch via `eat-make` with the project root as `default-directory`
+Bind `default-directory` to the current project's root (via `project-current` /
+`project-root`, falling back to the buffer's directory when not in a project),
+then call `eat-make` with the runner buffer name, the configured executable, and
+the configured switches plus any mode flag (continue/resume). Reference:
+`claude-code.el` uses `eat-make` the same way.
+
+- **Alternative considered:** `make-term`/`ansi-term`. Rejected — eat is the
+  chosen backend (proposal), and `eat-make` is its supported entry point.
+
+### D2: One primary session per project, keyed by project root
+Maintain a registry (alist or hash) from project root to runner buffer. Buffer
+name is `*claude:<project-name>*`. Starting the runner for a project with a live
+buffer switches to it instead of duplicating. `list` enumerates live registry
+entries; `switch` uses `completing-read` over them; `kill` sends the process a
+signal (or kills the buffer) and drops the registry entry.
+
+- **Alternative considered:** claude-code.el's multi-instance-per-directory
+  model. Rejected as more than needed now; one primary session per project is
+  the common case. Multiple instances can be added later without breaking the
+  registry shape.
+
+### D3: Side-window placement via `display-buffer` rules
+Show the runner with `display-buffer` using a `side`/`slot` alist entry so it
+occupies a side window rather than replacing the user's main window. Toggle
+hides the window (without killing the process) when visible and shows it
+otherwise. A defcustom controls whether showing the window also selects it
+(focus), matching claude-code-ide's focus options.
+
+### D4: Continue/resume are launch-time flags
+Continue and resume are separate entry commands that add the CLI's continue or
+resume flag to the switches passed to `eat-make`. No session state is tracked by
+the runner beyond the live buffer; conversation history is the CLI's concern.
+
+### D5: eat is a soft dependency
+`(require 'eat nil t)`, `declare-function eat-make`, and a `featurep 'eat`
+guard in each command. Runner commands error with a clear "install eat" message
+when eat is absent; loading the file never hard-requires it — consistent with
+the plz (opencode client) and projectile (project tools) patterns in this repo.
+
+## Risks / Trade-offs
+
+- **eat API drift** → the runner depends only on `eat-make`'s stable signature;
+  declared with `declare-function` so byte-compilation is clean without eat.
+- **Opaque TUI** → the runner cannot observe the CLI's output; this is accepted
+  (editor integration is via MCP, not by scraping the terminal).
+- **Killing a session mid-run** → `kill` terminates the process; document that
+  in-flight work is lost, same as quitting the CLI in any terminal.
+- **Project detection outside a project** → fall back to the buffer's
+  `default-directory` and still launch, rather than refusing.
+
+## Open Questions
+
+- Should the runner set any Claude-CLI environment (e.g. to point at the
+  mcp-emacs MCP server) at launch, or rely entirely on the user's `.mcp.json`?
+  Plan: rely on the user's existing MCP configuration; revisit if a launch-time
+  hint proves necessary.

--- a/openspec/changes/add-claude-runner/specs/claude-runner/spec.md
+++ b/openspec/changes/add-claude-runner/specs/claude-runner/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Launch the Claude CLI in an Emacs terminal
+The system SHALL launch the `claude` CLI inside an Emacs terminal buffer using eat as the terminal backend, with the working directory set to the current project root (via `project.el`), so the CLI runs in the project's context and reaches editor tools through mcp-emacs over MCP.
+
+#### Scenario: Launching in a project
+- **WHEN** the user starts the runner from a buffer inside a project
+- **THEN** the CLI starts in an eat terminal whose working directory is the project root
+
+#### Scenario: eat not available
+- **WHEN** eat is not available
+- **THEN** the runner reports that it requires eat rather than failing opaquely
+
+#### Scenario: Configurable executable and flags
+- **WHEN** the user has configured a custom `claude` executable path or extra CLI flags
+- **THEN** the runner launches that executable with those flags
+
+### Requirement: Manage per-project runner sessions
+The system SHALL keep at most one primary runner session per project, name its buffer distinctly (for example `*claude:<project>*`), and provide commands to list, switch to, and kill sessions.
+
+#### Scenario: Reusing a project's session
+- **WHEN** the user starts the runner for a project that already has a live session
+- **THEN** the runner switches to the existing session rather than starting a duplicate
+
+#### Scenario: Listing and switching
+- **WHEN** the user lists sessions and selects one
+- **THEN** the runner shows that session's buffer
+
+#### Scenario: Killing a session
+- **WHEN** the user kills a session
+- **THEN** the runner terminates the CLI process and cleans up its buffer
+
+### Requirement: Manage the runner window
+The system SHALL provide commands to show, hide, and toggle the runner window, using a side-window placement, with control over whether focus moves to the runner.
+
+#### Scenario: Toggling visibility
+- **WHEN** the user toggles the runner window while it is visible
+- **THEN** the window is hidden, and toggling again shows it
+
+#### Scenario: Side-window placement
+- **WHEN** the runner window is shown
+- **THEN** it appears in a side window rather than replacing the user's main window
+
+### Requirement: Continue and resume prior conversations
+The system SHALL support starting the CLI with continue and resume options so the user can pick up a previous conversation.
+
+#### Scenario: Continue the most recent conversation
+- **WHEN** the user starts the runner in continue mode
+- **THEN** the CLI is launched with its continue option
+
+#### Scenario: Resume a chosen conversation
+- **WHEN** the user starts the runner in resume mode
+- **THEN** the CLI is launched with its resume option so a prior conversation can be selected
+
+### Requirement: Runner adds no hard package dependency
+The runner SHALL use eat only when it is available, loaded as a soft/optional dependency, so installing mcp-emacs does not require eat.
+
+#### Scenario: eat present
+- **WHEN** eat is loaded
+- **THEN** the runner uses it as the terminal backend
+
+#### Scenario: eat absent
+- **WHEN** eat is not loaded
+- **THEN** loading mcp-emacs still succeeds and the runner reports that it needs eat only when a runner command is invoked

--- a/openspec/changes/add-claude-runner/tasks.md
+++ b/openspec/changes/add-claude-runner/tasks.md
@@ -1,0 +1,35 @@
+## 1. Scaffolding
+
+- [x] 1.1 Create `elisp/mcp-emacs-run.el` with header, `(require 'eat nil t)` soft dep, `declare-function eat-make`, and an `mcp-emacs`/`mcp-emacs-run` customization group
+- [x] 1.2 Add defcustoms: `claude` executable path, extra CLI flags, and whether showing the runner window selects it (focus)
+- [x] 1.3 Add an eat-availability guard helper that errors clearly ("install eat") when eat is absent
+
+## 2. Launch
+
+- [x] 2.1 Implement project-root resolution (via `project-current`/`project-root`, falling back to the buffer's `default-directory`)
+- [x] 2.2 Implement the launch function: bind `default-directory` to the project root and call `eat-make` with the runner buffer name, configured executable, and switches (design D1)
+- [x] 2.3 Honour the configured executable path and extra CLI flags
+
+## 3. Sessions
+
+- [x] 3.1 Implement a per-project registry (project root -> runner buffer) with buffer name `*claude:<project>*` (design D2)
+- [x] 3.2 Reuse an existing live session for a project instead of launching a duplicate
+- [x] 3.3 Implement list (over live registry entries), switch (`completing-read`), and kill (terminate process, drop registry entry)
+
+## 4. Window management
+
+- [x] 4.1 Implement show via `display-buffer` with a side-window alist entry (design D3)
+- [x] 4.2 Implement hide (without killing the process) and toggle
+- [x] 4.3 Honour the focus defcustom when showing the window
+
+## 5. Continue / resume
+
+- [x] 5.1 Implement a continue entry command that adds the CLI continue flag to the launch switches (design D4)
+- [x] 5.2 Implement a resume entry command that adds the CLI resume flag
+
+## 6. Verification and docs
+
+- [x] 6.1 Byte-compile `elisp/mcp-emacs-run.el` clean (no unconditional eat require; soft-dep guard verified)
+- [x] 6.2 Headless checks that need no terminal: project-root resolution returns the expected root; the registry reuses a buffer for the same project; eat-absent path returns the clear error
+- [ ] 6.3 Live smoke test in a real Emacs: launch the runner in a project, verify the CLI starts in an eat side window at the project root, toggle the window, and exercise continue/resume (requires eat and the `claude` CLI; done manually)
+- [x] 6.4 Update `README.md` with a runner section (commands, eat requirement, that editor tools come from mcp-emacs over MCP)

--- a/test/mcp-emacs-run-test.el
+++ b/test/mcp-emacs-run-test.el
@@ -1,0 +1,15 @@
+(add-to-list 'load-path (expand-file-name "elisp"))
+(require 'mcp-emacs-run)
+(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+;; project-root from a subdir resolves to the git repo root
+(let ((default-directory (expand-file-name "elisp/"))
+      (repo (expand-file-name "./")))
+  (check "project-root-is-repo" (mcp-emacs-run--project-root) repo))
+(check "buffer-name" (mcp-emacs-run--buffer-name "/tmp/foo/") "*claude:foo*")
+(let ((buf (generate-new-buffer "*claude:foo*")))
+  (puthash "/tmp/foo/" buf mcp-emacs-run--sessions)
+  (check "registry-live" (mcp-emacs-run--live-buffer "/tmp/foo/") buf)
+  (kill-buffer buf)
+  (check "registry-dead-cleared" (mcp-emacs-run--live-buffer "/tmp/foo/") nil))
+(check "eat-guard-errors"
+       (condition-case _ (progn (mcp-emacs-run--ensure-eat) 'no) (user-error 'yes)) 'yes)


### PR DESCRIPTION
Run the Claude Code CLI in an eat terminal inside Emacs (`elisp/mcp-emacs-run.el`): project-aware launch via eat-make at the project root, one primary session per project (reuse/list/switch/kill), a managed side window (show/hide/toggle), and continue/resume. eat is optional; editor tools reach the CLI through the mcp-emacs MCP server, not this runner. This is the last piece needed to retire claude-code-ide. Includes headless logic tests and OpenSpec artifacts.

Note: headless tests pass; live smoke test with eat and the claude CLI still pending.