### PR TITLE
Add headless runner launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ runner only launches and places the terminal.
 Configure `mcp-emacs-run-executable` and `-flags`, then:
 
 - `M-x mcp-emacs-run` — start (or switch to) the runner for the current project.
+- `M-x mcp-emacs-run-start` — start the runner hidden (no window, no focus); reveal it later with `-toggle` or `-switch`.
 - `M-x mcp-emacs-run-continue` / `-resume` — pick up a prior conversation.
 - `M-x mcp-emacs-run-toggle` — show/hide the runner side window.
 - `M-x mcp-emacs-run-list` / `-switch` / `-kill` — manage sessions.

--- a/elisp/mcp-emacs-run.el
+++ b/elisp/mcp-emacs-run.el
@@ -68,6 +68,7 @@
   :type '(choice (const left) (const right) (const top) (const bottom))
   :group 'mcp-emacs-run)
 
+;; TODO specify width in columns
 (defcustom mcp-emacs-run-window-width 0.4
   "Width of the runner side window, as a fraction of the frame."
   :type 'number
@@ -80,11 +81,13 @@
 
 ;;;; Helpers
 
+;; TODO isn't this already covered by require further up?
 (defun mcp-emacs-run--ensure-eat ()
   "Signal a clear error unless eat is available."
   (unless (featurep 'eat)
     (user-error "mcp-emacs-run requires the `eat' package; please install it")))
 
+;; TODO maybe replace when-let with if-let as when-let looks almost deprecated?
 (defun mcp-emacs-run--project-root ()
   "Return the current project root, or the buffer's directory as a fallback."
   (or (when (and (featurep 'project) (fboundp 'project-current))
@@ -120,8 +123,9 @@
       (select-window window))
     window))
 
-(defun mcp-emacs-run--launch (root &rest extra-switches)
-  "Launch the CLI for project ROOT in an eat buffer, and display it.
+(defun mcp-emacs-run--launch (root no-display &rest extra-switches)
+  "Launch the CLI for project ROOT in an eat buffer.
+Unless NO-DISPLAY is non-nil, the buffer is shown in the runner window.
 EXTRA-SWITCHES are appended to the configured flags (e.g. continue/resume)."
   (mcp-emacs-run--ensure-eat)
   (let* ((default-directory (file-name-as-directory root))
@@ -129,7 +133,8 @@ EXTRA-SWITCHES are appended to the configured flags (e.g. continue/resume)."
          (switches (append mcp-emacs-run-flags extra-switches))
          (buffer (apply #'eat-make name mcp-emacs-run-executable nil switches)))
     (puthash root buffer mcp-emacs-run--sessions)
-    (mcp-emacs-run--display buffer)
+    (unless no-display
+      (mcp-emacs-run--display buffer))
     buffer))
 
 ;;;; Commands
@@ -145,19 +150,34 @@ EXTRA-SWITCHES, when given, are passed to a fresh launch."
          (existing (mcp-emacs-run--live-buffer root)))
     (if (and existing (null extra-switches))
         (progn (mcp-emacs-run--display existing) existing)
-      (apply #'mcp-emacs-run--launch root extra-switches))))
+      (apply #'mcp-emacs-run--launch root nil extra-switches))))
+
+;;;###autoload
+(defun mcp-emacs-run-start ()
+  "Start the Claude Code runner for the current project without showing it.
+Reuses a live session if one exists; otherwise launches the CLI in a
+registered eat buffer without displaying any window or moving focus.
+Reveal the session later with `mcp-emacs-run-toggle' or
+`mcp-emacs-run-switch'."
+  (interactive)
+  (mcp-emacs-run--ensure-eat)
+  (let* ((root (mcp-emacs-run--project-root))
+         (existing (mcp-emacs-run--live-buffer root)))
+    (prog1 (or existing (mcp-emacs-run--launch root t))
+      (message "Claude runner started (hidden) for %s"
+               (mcp-emacs-run--project-name root)))))
 
 ;;;###autoload
 (defun mcp-emacs-run-continue ()
   "Start the runner continuing the most recent conversation."
   (interactive)
-  (apply #'mcp-emacs-run--launch (mcp-emacs-run--project-root) '("--continue")))
+  (apply #'mcp-emacs-run--launch (mcp-emacs-run--project-root) nil '("--continue")))
 
 ;;;###autoload
 (defun mcp-emacs-run-resume ()
   "Start the runner resuming a prior conversation."
   (interactive)
-  (apply #'mcp-emacs-run--launch (mcp-emacs-run--project-root) '("--resume")))
+  (apply #'mcp-emacs-run--launch (mcp-emacs-run--project-root) nil '("--resume")))
 
 ;;;###autoload
 (defun mcp-emacs-run-list ()

--- a/openspec/changes/add-headless-runner-launch/.openspec.yaml
+++ b/openspec/changes/add-headless-runner-launch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/add-headless-runner-launch/design.md
+++ b/openspec/changes/add-headless-runner-launch/design.md
@@ -1,0 +1,27 @@
+## Context
+
+`mcp-emacs-run--launch` currently does three things unconditionally: create the eat buffer, register it in `mcp-emacs-run--sessions`, and call `mcp-emacs-run--display` to show it in a side window (moving focus per `mcp-emacs-run-focus-on-show`).
+Display is baked into the launch path, so there is no way to bring up a session that runs but stays hidden.
+The reveal machinery already exists: `mcp-emacs-run-toggle` and `mcp-emacs-run-switch` display any registered live buffer, and both already handle the "buffer exists, no window" case.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Start a project's session with the CLI running and registered, but no window shown and no focus change.
+- Reuse the existing session-reuse and reveal paths unchanged — a headless session is an ordinary session that simply wasn't displayed yet.
+
+**Non-Goals:**
+- No change to the default `mcp-emacs-run` behavior (still displays).
+- No new "hide without killing" beyond what `-toggle` already does.
+- No headless variants of continue/resume for now (can follow if wanted).
+
+## Decisions
+
+- **Make display optional in the launch helper.** Add an optional `no-display` parameter to `mcp-emacs-run--launch`; when non-nil it skips `mcp-emacs-run--display` but still registers the session and returns the buffer. `extra-switches` stays a trailing rest arg — reorder to `(root no-display &rest extra-switches)` and update the two existing callers to pass `nil` for `no-display`.
+- **New command `mcp-emacs-run-start`.** Mirrors `mcp-emacs-run`'s reuse check (reuse a live session without displaying), otherwise launches headless. Autoloaded and interactive like the other commands.
+- **Reveal is unchanged.** `-toggle`/`-switch` already display a registered-but-hidden buffer, so a headless session reveals with no new code.
+
+## Risks / Trade-offs
+
+- Reordering `mcp-emacs-run--launch`'s signature touches its two callers; internal helper, so no external contract broken. Covered by updating both callers in the same change.
+- A headless session gives no visible feedback on start; mitigate with a `message` naming the project and noting it started hidden.

--- a/openspec/changes/add-headless-runner-launch/proposal.md
+++ b/openspec/changes/add-headless-runner-launch/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The runner always displays the session in a side window on launch.
+There is no way to start a project's Claude CLI session in the background — running and reachable, but without stealing a window or focus — to be revealed later when the user wants it.
+
+## What Changes
+
+- Add a command to start a project's runner session headless: the CLI runs in its eat buffer and is registered as the project's session, but no window is displayed and focus does not move.
+- Reuse the existing session model: a later toggle/switch reveals the headless buffer exactly as it reveals any other live session, and starting headless when a live session already exists is a no-op reuse (no duplicate).
+- Factor the internal launch so displaying the buffer is optional rather than unconditional.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `claude-runner`: add a requirement for starting a session without displaying its window (headless start), alongside the existing launch/manage/window requirements.
+
+## Impact
+
+- `elisp/mcp-emacs-run.el`: internal launch helper gains an optional no-display path; new headless start command.
+- `test/mcp-emacs-run-test.el`: coverage for headless start (buffer registered, no window) and reveal-after.
+- No new package dependency. No breaking change to existing commands.

--- a/openspec/changes/add-headless-runner-launch/specs/claude-runner/spec.md
+++ b/openspec/changes/add-headless-runner-launch/specs/claude-runner/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Start a session without displaying its window
+The system SHALL provide a command to start a project's runner session headless: the CLI runs in its eat buffer and is registered as the project's primary session, but no window is displayed and focus does not move to it. The headless buffer SHALL be revealable afterwards through the existing show/toggle/switch commands, and SHALL participate in the one-session-per-project reuse model.
+
+#### Scenario: Starting headless
+- **WHEN** the user starts the runner headless from a buffer inside a project that has no live session
+- **THEN** the CLI starts in an eat buffer registered as that project's session, and no window for it is displayed
+
+#### Scenario: Revealing a headless session
+- **WHEN** the user toggles or switches to a session that was started headless
+- **THEN** the session's buffer is displayed in the runner window
+
+#### Scenario: Starting headless when a session already exists
+- **WHEN** the user starts the runner headless for a project that already has a live session
+- **THEN** the existing session is reused and no duplicate is started, and no window is displayed

--- a/openspec/changes/add-headless-runner-launch/tasks.md
+++ b/openspec/changes/add-headless-runner-launch/tasks.md
@@ -1,0 +1,19 @@
+## 1. Launch helper
+
+- [x] 1.1 Add optional `no-display` param to `mcp-emacs-run--launch` (signature `(root no-display &rest extra-switches)`); skip `mcp-emacs-run--display` when non-nil, still register the session and return the buffer.
+- [x] 1.2 Update the two existing callers (`mcp-emacs-run`, continue/resume path) to pass `nil` for `no-display`.
+
+## 2. Headless command
+
+- [x] 2.1 Add autoloaded interactive `mcp-emacs-run-start`: reuse a live session without displaying, else launch headless; `message` naming the project and that it started hidden.
+
+## 3. Tests
+
+- [x] 3.1 Test: headless start registers the session buffer and displays no window.
+- [x] 3.2 Test: revealing a headless session via toggle/switch displays its buffer.
+- [x] 3.3 Test: headless start with an existing live session reuses it and displays no window.
+
+## 4. Wire-up & docs
+
+- [x] 4.1 Bind `mcp-emacs-run-start` under the Doom `SPC E` runner prefix in dotfiles.
+- [x] 4.2 Note the headless command in the README runner section.

--- a/test/mcp-emacs-run-test.el
+++ b/test/mcp-emacs-run-test.el
@@ -1,4 +1,5 @@
 (add-to-list 'load-path (expand-file-name "elisp"))
+(require 'cl-lib)
 (require 'mcp-emacs-run)
 (defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
 ;; project-root from a subdir resolves to the git repo root
@@ -13,3 +14,29 @@
   (check "registry-dead-cleared" (mcp-emacs-run--live-buffer "/tmp/foo/") nil))
 (check "eat-guard-errors"
        (condition-case _ (progn (mcp-emacs-run--ensure-eat) 'no) (user-error 'yes)) 'yes)
+
+;; Headless launch: stub eat so no real terminal is spawned.  eat-make returns a
+;; plain buffer; ensure-eat is satisfied via a faked `eat' feature.
+(let ((root "/tmp/headless-proj/")
+      made)
+  (clrhash mcp-emacs-run--sessions)
+  (cl-letf (((symbol-function 'eat-make)
+             (lambda (name &rest _) (setq made (generate-new-buffer (format "*%s*" name)))))
+            ((symbol-function 'mcp-emacs-run--ensure-eat) #'ignore)
+            ((symbol-function 'mcp-emacs-run--project-root) (lambda () root)))
+    (unwind-protect
+        (progn
+          ;; headless start registers a session but shows no window
+          (let ((buf (mcp-emacs-run-start)))
+            (check "headless-registers" (mcp-emacs-run--live-buffer root) buf)
+            (check "headless-no-window" (get-buffer-window buf) nil)
+            ;; starting again reuses the same buffer, still no window
+            (let ((again (mcp-emacs-run-start)))
+              (check "headless-reuses" again buf)
+              (check "headless-reuse-no-window" (get-buffer-window again) nil))
+            ;; toggle reveals the hidden session
+            (mcp-emacs-run-toggle)
+            (check "headless-toggle-reveals" (and (get-buffer-window buf) t) t)
+            (when (get-buffer-window buf) (delete-window (get-buffer-window buf)))))
+      (when (buffer-live-p made) (kill-buffer made))
+      (clrhash mcp-emacs-run--sessions))))


### PR DESCRIPTION
Adds `mcp-emacs-run-start`, which launches a project's Claude CLI session in a registered eat buffer without displaying any window or moving focus, so it runs in the background and can be revealed later with the existing toggle/switch commands. Follows the OpenSpec change `add-headless-runner-launch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)