### PR TITLE
Name the ediff control buffer after the diff tab

### DIFF
--- a/elisp/mcp-emacs-ide.el
+++ b/elisp/mcp-emacs-ide.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-ide.el --- Claude Code IDE integration for mcp-emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.1.0
+;; Version: 1.1.1
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs-run.el
+++ b/elisp/mcp-emacs-run.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-run.el --- Run the Claude Code CLI inside Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.1.0
+;; Version: 1.1.1
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs-server.el
+++ b/elisp/mcp-emacs-server.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-server.el --- HTTP MCP server running inside Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.1.0
+;; Version: 1.1.1
 ;; Package-Requires: ((emacs "28.1") (web-server "0.1.2"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs.el
+++ b/elisp/mcp-emacs.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs.el --- Helper functions for MCP Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.1.0
+;; Version: 1.1.1
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs.el
+++ b/elisp/mcp-emacs.el
@@ -974,7 +974,6 @@ hand-edited content.  Set the RESULT cell's car to `applied'."
 
 (defvar ediff-window-setup-function)
 (defvar ediff-split-window-function)
-(defvar ediff-control-buffer-suffix)
 
 (defun mcp-emacs--ediff-review (buffer-a buffer-b entry-content result
                                          &optional on-resolve tab-name)
@@ -992,8 +991,10 @@ This lets deferred callers (the IDE `openDiff' flow) respond
 asynchronously; the synchronous `mcp-emacs-apply-diff' caller instead
 polls the RESULT cell and passes no ON-RESOLVE.
 
-TAB-NAME, when given, is used to make the ediff control buffer name
-unique so concurrent reviews do not collide.
+TAB-NAME, when given, renames the ediff control buffer to
+\"*mcp diff: TAB-NAME*\" (done in the setup hook, since ediff overwrites
+its own suffix during setup) so concurrent reviews are distinguishable;
+if that name is taken, ediff's own unique name is kept.
 
 Side windows (e.g. Treemacs) are deleted and ediff is forced into its
 plain, single-frame window layout before setup; otherwise `ediff-buffers'
@@ -1010,12 +1011,21 @@ timeout."
       (ignore-errors (delete-window window))))
   (let (control
         (ediff-window-setup-function 'ediff-setup-windows-plain)
-        (ediff-split-window-function 'split-window-horizontally)
-        (ediff-control-buffer-suffix (if tab-name (format "<%s>" tab-name) "")))
+        (ediff-split-window-function 'split-window-horizontally))
     (ediff-buffers
      buffer-a buffer-b
      (list (lambda ()
              (setq control ediff-control-buffer)
+             ;; Give the control buffer a tab-scoped name.  Ediff derives
+             ;; its own name (and clobbers `ediff-control-buffer-suffix')
+             ;; during setup, so the only reliable point to inject TAB-NAME
+             ;; is here, once the control buffer exists.  Fall back to the
+             ;; ediff-chosen name if that name is already taken.
+             (when tab-name
+               (let ((wanted (format "*mcp diff: %s*" tab-name)))
+                 (unless (get-buffer wanted)
+                   (with-current-buffer ediff-control-buffer
+                     (rename-buffer wanted)))))
              (with-current-buffer ediff-control-buffer
                ;; Accept/reject record the decision, then quit.  The
                ;; quit hook below is the single place that fires

--- a/elisp/opencode-client.el
+++ b/elisp/opencode-client.el
@@ -1,7 +1,7 @@
 ;;; opencode-client.el --- Native Emacs client for the opencode HTTP API -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.1.0
+;; Version: 1.1.1
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/test/orgspec-fold-spike-test.el
+++ b/test/orgspec-fold-spike-test.el
@@ -1,0 +1,92 @@
+;;; orgspec-fold-spike-test.el --- de-risk the orgspec fold re-leveling  -*- lexical-binding: t; -*-
+
+;; Issue #5, step 1 — the one real unknown of the orgspec port: can a delta
+;; requirement, stored at L2/L3 under a `* Delta` heading in a change file, be
+;; folded into a spec file (where requirements are L1 and scenarios L2) with
+;; correct re-leveling, the TODO keyword stripped, the op tag dropped, and the
+;; :IMPL: traceability drawer kept?
+;;
+;; This is a spike, not the real fold — it proves the org primitives behave, so
+;; orgspec-fold.el can be built on `org-copy-subtree` + `org-paste-subtree`
+;; rather than a hand-rolled promote/demote loop. Run with:
+;;   emacs --batch -L elisp -l test/orgspec-fold-spike-test.el
+;; A FAIL line in the output fails the run (CI greps for FAIL).
+
+(require 'org)
+(require 'org-element)
+
+(defun check (l g w)
+  (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+
+;; A delta requirement as stored in a change file: L2 headline carrying a TODO
+;; keyword and an :ADDED: op tag, an :AREA: routing property, an :IMPL: drawer,
+;; and an L3 scenario.
+(defvar orgspec-fold-spike--change "\
+* Delta
+** TODO Notify on account lockout                    :ADDED:
+:PROPERTIES:
+:AREA: auth
+:END:
+:IMPL:
+[[file:auth.el::defun lockout][lockout]]
+:END:
+The system SHALL send a notification email when an account is locked out.
+*** Lockout triggered
+- GIVEN an account just crossed the failed-attempt threshold
+- WHEN the lockout is applied
+- THEN a notification email is sent to the account address
+")
+
+;; The target spec file: an existing L1 requirement with an L2 scenario.
+(defvar orgspec-fold-spike--spec "\
+* Existing requirement
+The system SHALL already do a thing.
+** Existing scenario
+- GIVEN x
+- WHEN y
+- THEN z
+")
+
+(let ((org-todo-keywords '((sequence "TODO" "|" "DONE")))
+      cut-text)
+  ;; 1. Cut the delta requirement subtree from the change buffer.
+  (with-temp-buffer
+    (let ((org-inhibit-startup t)) (org-mode))
+    (insert orgspec-fold-spike--change)
+    (goto-char (point-min))
+    (re-search-forward "^\\*\\* .*Notify on account lockout")
+    (org-back-to-heading t)
+    (org-copy-subtree)
+    (setq cut-text (current-kill 0)))
+
+  ;; 2. Paste into the spec buffer forced to L1; org re-levels the whole subtree.
+  (with-temp-buffer
+    (let ((org-inhibit-startup t)) (org-mode))
+    (insert orgspec-fold-spike--spec)
+    (goto-char (point-max))
+    (org-paste-subtree 1 cut-text)
+
+    ;; 3. Apply the fold rules on the pasted subtree.
+    (goto-char (point-min))
+    (re-search-forward "Notify on account lockout")
+    (org-back-to-heading t)
+    (org-todo 'none)                    ; strip TODO keyword
+    (org-set-tags nil)                  ; drop :ADDED: op tag
+
+    (let ((result (buffer-string)))
+      ;; requirement re-leveled L2 -> L1, scenario L3 -> L2
+      (check "requirement is L1"
+             (and (string-match-p "^\\* Notify on account lockout" result) t) t)
+      (check "scenario is L2"
+             (and (string-match-p "^\\*\\* Lockout triggered" result) t) t)
+      ;; workflow state removed from the durable spec
+      (check "TODO stripped" (string-match-p "\\* TODO " result) nil)
+      (check "op tag dropped" (string-match-p ":ADDED:" result) nil)
+      ;; traceability kept
+      (check "IMPL drawer kept"
+             (and (string-match-p ":IMPL:" result) t) t)
+      ;; existing content untouched
+      (check "existing requirement intact"
+             (and (string-match-p "^\\* Existing requirement" result) t) t))))
+
+;;; orgspec-fold-spike-test.el ends here


### PR DESCRIPTION
Follow-up to #20. The let-bound `ediff-control-buffer-suffix` in `mcp-emacs--ediff-review` never took effect — ediff overwrites that variable during setup from its own generated buffer name, so control buffers uniquified as `<2>` instead of by tab. The rename now happens in the setup hook, where the control buffer first exists, and falls back to ediff's own name if the target is taken. Verified live in the running Emacs: an openDiff control buffer is named `*mcp diff: <tab_name>*`. Also drops the now-dead forward `defvar`.