### PR TITLE
Claude remote control: prompt from Emacs, render tool activity as Org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,11 @@ jobs:
             --eval "(package-initialize)" \
             -L elisp \
             -f batch-byte-compile \
-            elisp/mcp-emacs.el elisp/mcp-emacs-report.el elisp/mcp-emacs-server.el elisp/mcp-emacs-ide.el
+            elisp/mcp-emacs.el elisp/mcp-emacs-report.el elisp/mcp-emacs-server.el elisp/mcp-emacs-ide.el elisp/mcp-emacs-remote.el
 
       - name: Run tests
         run: |
-          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el test/mcp-emacs-report-test.el; do
+          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el test/mcp-emacs-report-test.el test/mcp-emacs-remote-test.el; do
             echo "== $t =="
             emacs --batch \
               --eval "(require 'package)" \

--- a/README.md
+++ b/README.md
@@ -211,6 +211,37 @@ to connect. Reviewing an edit: `C-c C-c` accepts (Claude Code writes the file),
 If you are migrating from `claude-code-ide.el`, disable it for the workspace
 first so only one IDE lockfile is published.
 
+### Remote control (Org transcript)
+
+`mcp-emacs-remote.el` (opt-in) lets you drive the interactive Claude session
+from ordinary Emacs input and watch its tool activity as a live Org
+transcript — without reading the terminal.
+
+- **Prompt input** — `mcp-emacs-remote-prompt` reads a prompt from the
+  minibuffer (seeded from the active region when one is set) and sends it to
+  the current project's running session; `mcp-emacs-remote-prompt-buffer` sends
+  the whole current buffer. Both auto-submit via `mcp-emacs-run-send-prompt`
+  and require a live session (they never launch one). Empty or whitespace-only
+  input is not sent.
+- **Org transcript** — a per-session `*claude: <project>*` Org buffer records
+  the session's tool activity: one heading per tool call with its arguments,
+  the accept/reject outcome of each `openDiff`, and a run-metadata drawer.
+  `getDiagnostics` / `closeAllDiffTabs` are recorded compactly to keep the
+  transcript readable.
+
+Enable with `M-x mcp-emacs-remote-enable` (or set `mcp-emacs-remote-enabled`);
+the transcript tap on the IDE surface is a no-op while disabled. Recording is
+passive — it never changes whether or how a tool call is approved or executed,
+and a rendering error cannot stall an edit.
+
+Tool **approval** is not part of this surface: native Edit/Write flow through
+the IDE surface's ediff review (above), which is the per-call gate. This is
+why the session runs interactively rather than headless — `claude -p` cannot
+route per-call approval to Emacs (the `--permission-prompt-tool` flag was
+removed in Claude Code 2.1.212). Because the IDE socket carries structured
+tool calls but not assistant prose, the transcript records tool activity only
+in this version; a full-prose transcript is a tracked follow-up (see #23).
+
 ### Resources
 
 | Resource            | Description                                                                               |

--- a/elisp/mcp-emacs-ide.el
+++ b/elisp/mcp-emacs-ide.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-ide.el --- Claude Code IDE integration for mcp-emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.3.0
+;; Version: 1.4.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs-remote.el
+++ b/elisp/mcp-emacs-remote.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-remote.el --- Remote-control an interactive Claude from Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.3.0
+;; Version: 1.4.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs-remote.el
+++ b/elisp/mcp-emacs-remote.el
@@ -1,0 +1,244 @@
+;;; mcp-emacs-remote.el --- Remote-control an interactive Claude from Emacs -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 1.3.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Drive the mcp-emacs-launched interactive Claude session from ordinary
+;; Emacs input, and watch its tool activity render as a live Org
+;; transcript -- without reading the terminal.
+;;
+;; Two capabilities:
+;;
+;; * Prompt input (`mcp-emacs-remote-prompt', `mcp-emacs-remote-prompt-buffer'):
+;;   send a prompt to the current project's running Claude session from the
+;;   minibuffer, the active region, or the whole current buffer.  Delivery
+;;   reuses `mcp-emacs-run-send-prompt', which auto-submits.
+;;
+;; * Org transcript: a per-session `*claude: <project>*' Org buffer records
+;;   the session's tool activity -- one heading per tool call with its
+;;   arguments, the accept/reject outcome of each openDiff, and a
+;;   run-metadata drawer.  It is fed by advising the IDE surface's tool
+;;   dispatch (`mcp-emacs-ide--call-tool') and the openDiff completion
+;;   (`mcp-emacs-ide--complete-open-diff'); the advice is a no-op unless the
+;;   feature is enabled, so the IDE surface is untouched when it is off.
+;;
+;; Tool approval is NOT provided here: native edits flow through the IDE
+;; surface's ediff review (the openDiff gate).  This module only records.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'json)
+(require 'mcp-emacs-run)
+(require 'mcp-emacs-ide)
+
+(defgroup mcp-emacs-remote nil
+  "Remote-control an interactive Claude session from Emacs."
+  :group 'tools)
+
+(defcustom mcp-emacs-remote-enabled nil
+  "When non-nil, record Claude tool activity into an Org transcript.
+The transcript tap on the IDE surface is a no-op while this is nil, so
+the IDE surface behaves exactly as if this module were not loaded."
+  :type 'boolean
+  :group 'mcp-emacs-remote)
+
+;;;; Prompt input
+
+(defun mcp-emacs-remote--send (text)
+  "Send TEXT to the current project's Claude session, or report if empty.
+Empty or whitespace-only TEXT is not sent.  Delivery (and submission) is
+`mcp-emacs-run-send-prompt', which requires a live session and does not
+launch one."
+  (if (or (null text) (string-empty-p (string-trim text)))
+      (user-error "No prompt provided")
+    (mcp-emacs-run-send-prompt text)))
+
+;;;###autoload
+(defun mcp-emacs-remote-prompt (&optional initial)
+  "Read a prompt from the minibuffer and send it to the Claude session.
+When a region is active, seed the minibuffer with the region text so it
+can be edited or confirmed before sending (INITIAL overrides the seed).
+Empty or whitespace-only input is not sent.  The prompt is auto-submitted
+to the current project's running session; no session is launched."
+  (interactive
+   (list (when (use-region-p)
+           (buffer-substring-no-properties (region-beginning) (region-end)))))
+  (mcp-emacs-remote--send (read-string "Claude prompt: " initial)))
+
+;;;###autoload
+(defun mcp-emacs-remote-prompt-buffer ()
+  "Send the entire current buffer as the prompt to the Claude session.
+An empty or whitespace-only buffer is not sent.  Auto-submitted to the
+current project's running session; no session is launched."
+  (interactive)
+  (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+    (if (string-empty-p (string-trim text))
+        (user-error "Nothing to send: the buffer is empty")
+      (mcp-emacs-remote--send text))))
+
+;;;; Org transcript
+
+(defun mcp-emacs-remote--project-name ()
+  "Return a short name for the current project, for the transcript buffer."
+  (let ((root (ignore-errors (mcp-emacs-run--project-root))))
+    (if (and root (not (string-empty-p root)))
+        (file-name-nondirectory (directory-file-name root))
+      "session")))
+
+(defun mcp-emacs-remote--buffer ()
+  "Return the Org transcript buffer for the current project, creating it.
+The buffer is created lazily on first recordable activity and reused for
+the lifetime of the session; distinct projects get distinct buffers."
+  (let* ((name (format "*claude: %s*" (mcp-emacs-remote--project-name)))
+         (buf (get-buffer name)))
+    (or buf
+        (with-current-buffer (get-buffer-create name)
+          (when (fboundp 'org-mode) (org-mode))
+          (current-buffer)))))
+
+(defun mcp-emacs-remote--append (text)
+  "Append TEXT to the transcript buffer, at end, read-only-safe."
+  (let ((buf (mcp-emacs-remote--buffer)))
+    (with-current-buffer buf
+      (save-excursion
+        (goto-char (point-max))
+        (unless (bolp) (insert "\n"))
+        (insert text)))))
+
+(defun mcp-emacs-remote--timestamp ()
+  "Return an inactive Org timestamp for now."
+  (format-time-string "[%Y-%m-%d %a %H:%M:%S]"))
+
+(defun mcp-emacs-remote--json (value)
+  "Encode VALUE as pretty JSON for an Org source block, best-effort."
+  (condition-case nil
+      (let ((json-encoding-pretty-print t))
+        (json-encode value))
+    (error (format "%S" value))))
+
+(defconst mcp-emacs-remote--quiet-tools '("getDiagnostics" "closeAllDiffTabs")
+  "Tool names whose calls are recorded compactly rather than as full entries.
+These fire before every edit and would otherwise dominate the transcript.")
+
+(defun mcp-emacs-remote-record-tool-call (name args)
+  "Record a tool call NAME with ARGS into the transcript.
+Quiet tools (see `mcp-emacs-remote--quiet-tools') get a compact one-line
+note; everything else gets a heading with its arguments.  Errors are
+swallowed so recording never affects the tool call itself."
+  (ignore-errors
+    (if (member name mcp-emacs-remote--quiet-tools)
+        (mcp-emacs-remote--append
+         (format "  - %s %s" (mcp-emacs-remote--timestamp) name))
+      (mcp-emacs-remote--append
+       (format "* 🔧 %s  %s\n#+begin_src json\n%s\n#+end_src"
+               name (mcp-emacs-remote--timestamp)
+               (mcp-emacs-remote--json args))))))
+
+(defun mcp-emacs-remote-record-diff-outcome (tab-name status &rest extra)
+  "Record an openDiff outcome: STATUS for TAB-NAME, with EXTRA text.
+STATUS is \"FILE_SAVED\" (accepted) or \"DIFF_REJECTED\" (rejected).  The
+first EXTRA item is the accepted content (accept) or the tab name
+\(reject); the target file is derived from TAB-NAME.  Errors are
+swallowed."
+  (ignore-errors
+    (let ((outcome (cond ((string= status "FILE_SAVED") "accepted")
+                         ((string= status "DIFF_REJECTED") "rejected")
+                         (t status))))
+      (mcp-emacs-remote--append
+       (format "  - %s openDiff %s :: %s"
+               (mcp-emacs-remote--timestamp) outcome tab-name))
+      (ignore extra))))
+
+(defun mcp-emacs-remote-record-session-start ()
+  "Record a run-metadata drawer for the current session at its start."
+  (ignore-errors
+    (let ((root (ignore-errors (mcp-emacs-run--project-root)))
+          (port (and mcp-emacs-ide--session
+                     (mcp-emacs-ide-session-port mcp-emacs-ide--session))))
+      (mcp-emacs-remote--append
+       (format "* Session  %s\n:PROPERTIES:\n:STARTED: %s\n:WORKSPACE: %s\n:IDE_PORT: %s\n:END:"
+               (mcp-emacs-remote--timestamp)
+               (mcp-emacs-remote--timestamp)
+               (or root "?")
+               (or port "?"))))))
+
+(defun mcp-emacs-remote-record-session-end ()
+  "Record that the session ended."
+  (ignore-errors
+    (mcp-emacs-remote--append
+     (format "  - %s session ended" (mcp-emacs-remote--timestamp)))))
+
+;;;; Event taps (advice on the IDE surface)
+
+(defun mcp-emacs-remote--tap-call-tool (_session name args _id)
+  "Advice for `mcp-emacs-ide--call-tool': record the call when enabled.
+A `:before' advice -- it inspects NAME and ARGS and returns nothing, so
+the wrapped dispatch runs unchanged."
+  (when mcp-emacs-remote-enabled
+    (mcp-emacs-remote-record-tool-call name args)))
+
+(defun mcp-emacs-remote--tap-complete-open-diff (_session tab-name status &rest extra)
+  "Advice for `mcp-emacs-ide--complete-open-diff': record the outcome.
+A `:before' advice; records TAB-NAME/STATUS/EXTRA when enabled and
+returns nothing, so the wrapped completion runs unchanged."
+  (when mcp-emacs-remote-enabled
+    (apply #'mcp-emacs-remote-record-diff-outcome tab-name status extra)))
+
+(defun mcp-emacs-remote--tap-start (&rest _)
+  "Advice for `mcp-emacs-ide-start': record session-start metadata."
+  (when mcp-emacs-remote-enabled
+    (mcp-emacs-remote-record-session-start)))
+
+(defun mcp-emacs-remote--tap-stop (&rest _)
+  "Advice for `mcp-emacs-ide-stop': record session end."
+  (when mcp-emacs-remote-enabled
+    (mcp-emacs-remote-record-session-end)))
+
+;;;###autoload
+(defun mcp-emacs-remote-enable ()
+  "Install the transcript taps on the IDE surface (idempotent).
+Also sets `mcp-emacs-remote-enabled'."
+  (interactive)
+  (setq mcp-emacs-remote-enabled t)
+  (advice-add 'mcp-emacs-ide--call-tool :before #'mcp-emacs-remote--tap-call-tool)
+  (advice-add 'mcp-emacs-ide--complete-open-diff :before
+              #'mcp-emacs-remote--tap-complete-open-diff)
+  (advice-add 'mcp-emacs-ide-start :after #'mcp-emacs-remote--tap-start)
+  (when (fboundp 'mcp-emacs-ide-stop)
+    (advice-add 'mcp-emacs-ide-stop :before #'mcp-emacs-remote--tap-stop)))
+
+;;;###autoload
+(defun mcp-emacs-remote-disable ()
+  "Remove the transcript taps and clear `mcp-emacs-remote-enabled' (idempotent)."
+  (interactive)
+  (setq mcp-emacs-remote-enabled nil)
+  (advice-remove 'mcp-emacs-ide--call-tool #'mcp-emacs-remote--tap-call-tool)
+  (advice-remove 'mcp-emacs-ide--complete-open-diff
+                 #'mcp-emacs-remote--tap-complete-open-diff)
+  (advice-remove 'mcp-emacs-ide-start #'mcp-emacs-remote--tap-start)
+  (when (fboundp 'mcp-emacs-ide-stop)
+    (advice-remove 'mcp-emacs-ide-stop #'mcp-emacs-remote--tap-stop)))
+
+(provide 'mcp-emacs-remote)
+;;; mcp-emacs-remote.el ends here

--- a/elisp/mcp-emacs-report.el
+++ b/elisp/mcp-emacs-report.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-report.el --- Report tooling issues about mcp-emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.3.0
+;; Version: 1.4.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs-run.el
+++ b/elisp/mcp-emacs-run.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-run.el --- Run the Claude Code CLI inside Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.3.0
+;; Version: 1.4.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs-server.el
+++ b/elisp/mcp-emacs-server.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-server.el --- HTTP MCP server running inside Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.3.0
+;; Version: 1.4.0
 ;; Package-Requires: ((emacs "28.1") (web-server "0.1.2"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs.el
+++ b/elisp/mcp-emacs.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs.el --- Helper functions for MCP Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.3.0
+;; Version: 1.4.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/opencode-client.el
+++ b/elisp/opencode-client.el
@@ -1,7 +1,7 @@
 ;;; opencode-client.el --- Native Emacs client for the opencode HTTP API -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.3.0
+;; Version: 1.4.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/openspec/changes/claude-remote-control/.openspec.yaml
+++ b/openspec/changes/claude-remote-control/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/claude-remote-control/design.md
+++ b/openspec/changes/claude-remote-control/design.md
@@ -1,0 +1,97 @@
+## Context
+
+See proposal.md — Why. The native-edit diff-review change (#20) already stands up an interactive
+Claude Code session launched from Emacs (`mcp-emacs-run.el`), connected over WebSocket to the IDE
+surface (`mcp-emacs-ide.el`), with an ediff gate on every native edit. The relevant existing seams:
+
+- `mcp-emacs-run-send-prompt` delivers text to the current project's runner session (eat buffer).
+- `mcp-emacs-run--resolve-session` resolves the target session for the current project, prompting
+  when there is more than one candidate.
+- `mcp-emacs-ide--call-tool` is the single dispatch point for every `tools/call` the session makes
+  (`openDiff`, `getDiagnostics`, `closeAllDiffTabs`).
+- `mcp-emacs-ide--complete-open-diff` is where an `openDiff` review resolves to FILE_SAVED
+  (accepted) or DIFF_REJECTED (rejected).
+- The IDE `ide_connected` notification and the WebSocket close callback bracket a session's life.
+
+The constraint that shapes everything: **the IDE WebSocket socket carries structured tool calls but
+not assistant prose.** Prose is rendered by Claude directly to its eat terminal. So a transcript
+built from IDE-surface events can be faithful about *tool activity* but cannot show prose without a
+second event source.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Drive the interactive session from minibuffer / region / buffer input, reusing the runner's
+  existing send + session-resolution paths.
+- Render tool activity + run metadata into a per-session Org buffer, driven only by events the IDE
+  surface already receives.
+- Keep the tap strictly passive — it must never change whether or how a tool call is answered.
+- Ship behind an opt-in defcustom, matching the IDE surface's opt-in posture.
+
+**Non-Goals (design-level):**
+
+- No new transport, no second Claude process, no headless `-p` path.
+- No terminal-scraping to recover prose.
+- No change to the IDE surface's protocol behavior, tool set, or the ediff gate.
+
+## Decisions
+
+### 1. Reuse the interactive IDE session; do not run headless `-p`
+
+Claude Code 2.1.212 removed `--permission-prompt-tool`, so headless `-p` cannot route per-call
+approval back to an Emacs MCP tool. The interactive IDE session already provides the approval gate
+(ediff) for free. **Alternative considered:** a headless `-p --output-format=stream-json` child that
+yields a full prose+tools event stream. Rejected for v1 — it reintroduces an approval problem the
+IDE session has already solved, and would run a second, differently-gated Claude alongside the
+interactive one.
+
+### 2. Tap the IDE dispatch point, don't parse the socket separately
+
+The renderer subscribes at `mcp-emacs-ide--call-tool` (tool calls + arguments) and
+`mcp-emacs-ide--complete-open-diff` (accept/reject outcome), plus the connect notification and
+socket-close callback for metadata. **Alternative considered:** a second WebSocket observer.
+Rejected — it would duplicate framing/parsing and risk diverging from what the surface actually
+answered. Tapping the dispatch point sees exactly the events the surface acts on.
+
+The tap is implemented as an advice/hook that is a no-op unless the remote-control feature is
+enabled, so the IDE surface's behavior is unchanged when the feature is off.
+
+### 3. Transcript source is tool activity only; prose is deferred
+
+Because the socket carries no prose, v1 records tool activity + metadata and leaves prose in the
+TUI. This is stated as an explicit spec requirement (`remote-org-transcript` → "Scope limited to
+tool activity") so it is a deliberate contract, not an omission. **Alternative considered:** wire the
+Claude Agent SDK (`canUseTool` + stream events) to get prose and gating in one structured stream.
+Deferred to a follow-up — it is a larger build and changes the runner's launch model.
+
+### 4. One Org buffer per session, keyed by the session
+
+Each session gets one long-lived `*claude: <project>*` Org buffer; events append to it. Keying by
+session (not by project) keeps two sessions for different projects cleanly separated, per the spec.
+Rendering appends headings and a properties drawer; it never rewrites earlier entries, so a partial
+render can't corrupt history.
+
+### 5. Passive rendering — failures never block the session
+
+Rendering runs after the surface has decided how to answer a call. A rendering error is caught and
+logged, never propagated into the tool-call answer path, so a transcript bug cannot stall an edit.
+This is the design counterpart to the spec's "Recording does not gate execution" requirement.
+
+## Risks / Trade-offs
+
+- **Prose absent from the transcript** → users must still glance at the TUI for Claude's reasoning
+  and text answers. Accepted for v1; the follow-up (Agent SDK / stream-json) is the path to full
+  transcripts, and the spec makes the limitation explicit rather than surprising.
+- **Tap coupling to IDE internals** (`--call-tool`, `--complete-open-diff`) → if those internals are
+  refactored, the tap must move with them. Mitigation: both live in the same repo and module family;
+  the tap is a single, named integration point, and the transcript is opt-in so a break degrades an
+  optional feature rather than the shipped IDE gate.
+- **`getDiagnostics` / `closeAllDiffTabs` noise** → these fire before every edit and would clutter
+  the transcript. Mitigation: render them collapsed or suppress them; only `openDiff` and
+  substantive calls get prominent entries.
+
+## Open Questions
+
+None that affect the specs, the approach, or the task breakdown. The prose-transcript follow-up is
+out of scope by decision, not deferred ambiguity.

--- a/openspec/changes/claude-remote-control/proposal.md
+++ b/openspec/changes/claude-remote-control/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+Today, driving the mcp-emacs-launched Claude means typing into the eat terminal buffer
+and reading its scrollback.
+That works, but it keeps the interaction locked inside the TUI: prompts must be typed at
+the terminal, and there is no structured, Org-native record of what Claude did.
+
+The native-edit diff-review change (#20, shipped in v1.1.0/v1.1.1) already turned Emacs into
+a Claude Code IDE client with an interactive ediff gate on every native edit.
+That gives us the two hard pieces for free — a launched-from-Emacs interactive session and a
+per-tool-call approval surface.
+The missing piece is a way to *drive* that session from ordinary Emacs input and *see* what
+it is doing as Org.
+This change adds that, reusing the IDE surface rather than building a second runner.
+
+## What Changes
+
+- Add a new opt-in module `mcp-emacs-remote.el` providing a "remote control" over the
+  interactive Claude session.
+- **Prompt from Emacs, not the terminal.** A `mcp-emacs-remote-prompt` command reads a prompt
+  from the minibuffer (or the active region / current buffer) and sends it to the current
+  project's runner session via the existing `mcp-emacs-run-send-prompt`.
+- **Live Org transcript.** A dedicated `*claude: <project>*` Org buffer per session records
+  tool activity as it happens: one heading per tool call with its arguments, the accept/reject
+  outcome of each `openDiff`, and a run-metadata drawer.
+- **Tool approval stays the ediff review.** No new approval mechanism — native Edit/Write flow
+  through `openDiff` → the ediff gate shipped in #20; the transcript just records the outcome.
+- The transcript renders **tool activity only** in this version; assistant prose stays in the
+  eat TUI (the IDE WebSocket surface does not carry prose — see design.md).
+
+## Capabilities
+
+### New Capabilities
+
+- `remote-prompt-input`: send a prompt to the current project's interactive Claude session from
+  the minibuffer, the active region, or the current buffer, without typing into the terminal.
+- `remote-org-transcript`: maintain a per-session Org buffer that records Claude's tool activity
+  (tool calls, arguments, `openDiff` accept/reject outcomes) and per-session run metadata, driven
+  by events the IDE WebSocket surface already receives.
+
+### Modified Capabilities
+
+<!-- None. The IDE surface (ide-protocol-integration), the runner, and the ediff gate are
+     reused as-is; this change adds new modules and event taps without altering their
+     specified behaviour. -->
+
+## Impact
+
+- **New file**: `elisp/mcp-emacs-remote.el` (opt-in, behind a defcustom like the IDE surface).
+- **Event tap**: hooks into `mcp-emacs-ide--call-tool` and the `openDiff` accept/reject
+  completion (`mcp-emacs-ide--complete-open-diff`) in `elisp/mcp-emacs-ide.el` to feed the
+  transcript renderer. The tap must not change existing IDE-surface behaviour.
+- **Reuses unchanged**: the WebSocket IDE server (`mcp-emacs-ide.el`), the env-injecting runner
+  and launch path (`mcp-emacs-run.el`), the shared ediff gate (`mcp-emacs--ediff-review`), and
+  prompt delivery (`mcp-emacs-run-send-prompt`).
+- **Dependencies**: none beyond what the IDE surface already requires (`websocket.el`, built-in
+  `org`, `json`).
+- **Out of scope** (follow-ups): assistant prose in the transcript (needs a structured event
+  source such as the Agent SDK `canUseTool`/stream events or a `--output-format=stream-json`
+  child); headless `-p`; `--resume`/`--session-id`; the opencode backend (deferred).
+
+Full context and prior discussion: issue #23.

--- a/openspec/changes/claude-remote-control/specs/remote-org-transcript/spec.md
+++ b/openspec/changes/claude-remote-control/specs/remote-org-transcript/spec.md
@@ -1,0 +1,91 @@
+## Purpose
+
+Maintains a per-session Org buffer that records the tool activity of the interactive Claude session
+— tool calls, their arguments, and the accept/reject outcome of each diff review — plus per-session
+run metadata, so the user has a structured, Org-native record of what Claude did without reading the
+terminal scrollback.
+
+## ADDED Requirements
+
+### Requirement: One Org transcript buffer per session
+
+The system SHALL maintain a dedicated Org-mode buffer per Claude session, named for the session's
+project, and SHALL reuse that buffer for the lifetime of the session rather than creating a new one
+per event.
+
+#### Scenario: Transcript buffer created on first activity
+
+- **WHEN** a Claude session produces its first recordable tool event and no transcript buffer exists
+  for that session
+- **THEN** an Org-mode buffer is created for the session
+- **AND** subsequent events for the same session are appended to that same buffer
+
+#### Scenario: Distinct sessions get distinct buffers
+
+- **WHEN** two Claude sessions for different projects are active
+- **THEN** each has its own transcript buffer
+- **AND** events from one session are never written into the other's buffer
+
+### Requirement: Record each tool call as an Org entry
+
+The system SHALL append an Org heading for each tool call the session makes, including the tool name,
+a timestamp, and the call's arguments in a form that is readable in Org.
+
+#### Scenario: Tool call recorded
+
+- **WHEN** the session invokes a tool
+- **THEN** a new Org heading is appended to the transcript naming the tool and carrying a timestamp
+- **AND** the tool's arguments are recorded under that heading
+
+### Requirement: Record diff-review outcomes
+
+The system SHALL record the outcome of each `openDiff` review — accepted or rejected — together with
+the file the diff targeted, so the transcript reflects what was actually written.
+
+#### Scenario: Diff accepted
+
+- **WHEN** the user accepts an `openDiff` review
+- **THEN** the transcript entry for that diff records the accepted outcome and the target file
+
+#### Scenario: Diff rejected
+
+- **WHEN** the user rejects an `openDiff` review (or it is otherwise dismissed unchanged)
+- **THEN** the transcript entry for that diff records the rejected outcome and the target file
+
+### Requirement: Record per-session run metadata
+
+The system SHALL record run metadata for the session in an Org properties drawer, including at least
+the session start time and the workspace root, and SHALL note when the session disconnects.
+
+#### Scenario: Session connects
+
+- **WHEN** a Claude session connects to the IDE surface
+- **THEN** the transcript records the session start and workspace root as properties
+
+#### Scenario: Session disconnects
+
+- **WHEN** the session's connection closes
+- **THEN** the transcript records that the session ended
+
+### Requirement: Do not alter tool-approval behavior
+
+The transcript SHALL be a passive record: recording an event MUST NOT change whether or how a tool
+call is approved, executed, or answered. Approval remains the interactive diff review.
+
+#### Scenario: Recording does not gate execution
+
+- **WHEN** the transcript records a tool call or its outcome
+- **THEN** the recording does not block, delay beyond rendering, or alter the tool call's approval or
+  execution
+- **AND** if transcript rendering fails, the session's tool calls are still answered normally
+
+### Requirement: Scope limited to tool activity
+
+In this version the transcript SHALL record tool activity and run metadata only; assistant prose is
+out of scope and is not required to appear in the transcript.
+
+#### Scenario: Assistant prose not required
+
+- **WHEN** the session produces assistant prose that is visible only in the terminal
+- **THEN** the transcript is not required to contain that prose
+- **AND** the absence of prose is not treated as an error

--- a/openspec/changes/claude-remote-control/specs/remote-prompt-input/spec.md
+++ b/openspec/changes/claude-remote-control/specs/remote-prompt-input/spec.md
@@ -1,0 +1,86 @@
+## Purpose
+
+Lets a user send a prompt to the current project's interactive Claude session from ordinary
+Emacs input — the minibuffer, the active region, or the current buffer — without typing into the
+runner's terminal buffer.
+
+## ADDED Requirements
+
+### Requirement: Send a prompt from the minibuffer
+
+The system SHALL provide an interactive command that reads a prompt string from the minibuffer and
+delivers it to the current project's running Claude session, submitting it so the session begins
+responding without the user having to switch to the terminal buffer.
+
+#### Scenario: Prompt entered in the minibuffer
+
+- **WHEN** the user invokes the remote-prompt command and types a non-empty string at the minibuffer
+- **THEN** the string is delivered to the current project's runner session and submitted
+- **AND** focus is not required to move to the terminal buffer for the session to begin responding
+
+#### Scenario: Empty or whitespace-only prompt is not sent
+
+- **WHEN** the user invokes the remote-prompt command and submits an empty or whitespace-only string
+- **THEN** nothing is sent to the session
+- **AND** the command reports that no prompt was provided
+
+### Requirement: Seed the prompt from the active region
+
+The system SHALL, when a region is active, seed the minibuffer with the region text so the user can
+edit or confirm it before it is sent, rather than sending the raw selection immediately.
+
+#### Scenario: Region active
+
+- **WHEN** a region is active and the user invokes the remote-prompt command
+- **THEN** the minibuffer is pre-filled with the region text
+- **AND** the user may edit it before confirming
+- **AND** on confirmation the resulting text is delivered to the session and submitted
+
+### Requirement: Send the whole current buffer as the prompt
+
+The system SHALL provide a way to send the entire current buffer as the prompt, so the user can hand
+a whole file's contents to the session without selecting it. An empty or whitespace-only buffer is
+not sent.
+
+#### Scenario: Whole buffer sent
+
+- **WHEN** the user invokes the send-buffer variant of the remote-prompt command in a non-empty
+  buffer
+- **THEN** the entire buffer text is delivered to the current project's runner session and submitted
+
+#### Scenario: Empty buffer is not sent
+
+- **WHEN** the user invokes the send-buffer variant in an empty or whitespace-only buffer
+- **THEN** nothing is sent to the session
+- **AND** the command reports that there was nothing to send
+
+### Requirement: Require a live session
+
+The system SHALL require an already-running Claude session for the current project and SHALL NOT
+launch one implicitly.
+
+#### Scenario: No session running
+
+- **WHEN** the user invokes the remote-prompt command and the current project has no running Claude
+  session
+- **THEN** the command reports that no session is available
+- **AND** no prompt is sent and no session is launched
+
+#### Scenario: Session running
+
+- **WHEN** the user invokes the remote-prompt command and the current project has exactly one
+  running Claude session
+- **THEN** the prompt is delivered to that session
+
+### Requirement: Resolve the target session unambiguously
+
+The system SHALL resolve which session receives the prompt using the same project-scoped session
+resolution the runner already uses, and SHALL prompt the user to choose when more than one candidate
+session exists.
+
+#### Scenario: Multiple sessions for the project
+
+- **WHEN** the current project has more than one running Claude session and the user invokes the
+  remote-prompt command
+- **THEN** the user is asked to choose the target session
+- **AND** the prompt is delivered to the chosen session

--- a/openspec/changes/claude-remote-control/tasks.md
+++ b/openspec/changes/claude-remote-control/tasks.md
@@ -1,0 +1,43 @@
+## 1. Module scaffold & opt-in
+
+- [ ] 1.1 Add `elisp/mcp-emacs-remote.el` with header, `provide`, and requires (`mcp-emacs-run`, `mcp-emacs-ide`, `org`, `json`, `cl-lib`); byte-compiles clean.
+- [ ] 1.2 Add a `mcp-emacs-remote-enabled` defcustom (default off), matching the IDE surface's opt-in posture; the event tap is a no-op when disabled.
+- [ ] 1.3 Lifecycle: `mcp-emacs-remote-enable` / `mcp-emacs-remote-disable` install and remove the event tap idempotently.
+
+## 2. Prompt input (spec: remote-prompt-input)
+
+- [ ] 2.1 `mcp-emacs-remote-prompt`: read a prompt from the minibuffer and submit it (auto-submit, session begins responding); empty or whitespace-only input sends nothing and reports "no prompt provided".
+- [ ] 2.2 When a region is active, pre-fill the minibuffer with the region text so the user edits/confirms before it is sent (not sent raw).
+- [ ] 2.3 `mcp-emacs-remote-prompt-buffer`: send the whole current buffer as the prompt and submit it; empty/whitespace-only buffer sends nothing and reports "nothing to send".
+- [ ] 2.4 Deliver the prompt via `mcp-emacs-run-send-prompt` (auto-submits); resolve the target session with `mcp-emacs-run--resolve-session` (prompts on multiple candidates).
+- [ ] 2.5 Require a live session: if the project has no running session, report it and do not launch one.
+
+## 3. Org transcript buffer (spec: remote-org-transcript)
+
+- [ ] 3.1 Per-session transcript buffer keyed by session, named `*claude: <project>*`, created lazily on first recordable event and reused thereafter; distinct sessions get distinct buffers.
+- [ ] 3.2 Tap `mcp-emacs-ide--call-tool` (behind the enabled flag) to append an Org heading per tool call: tool name, timestamp, and arguments in a readable `#+begin_src json` block.
+- [ ] 3.3 Collapse or suppress `getDiagnostics` / `closeAllDiffTabs` entries so per-edit noise doesn't dominate the transcript.
+- [ ] 3.4 Tap `mcp-emacs-ide--complete-open-diff` to record each diff outcome (accepted → FILE_SAVED, rejected → DIFF_REJECTED) with the target file, under the matching tool entry.
+- [ ] 3.5 Run metadata drawer: on `ide_connected`, record session start + workspace root as Org properties; on socket close, record session end.
+
+## 4. Passive-safety guarantees (spec: remote-org-transcript "does not gate execution")
+
+- [ ] 4.1 Rendering runs after the surface has decided how to answer a call; the tap returns control to the surface unchanged (never blocks or alters the answer).
+- [ ] 4.2 Wrap all rendering in error handling: a rendering failure is caught and logged, never propagated into the tool-call answer path.
+
+## 5. Tests
+
+- [ ] 5.1 Prompt input: empty input sends nothing; region pre-fills; no-session case reports and does not launch; multi-session case resolves via the runner's picker (drive commands headlessly as the existing suites do).
+- [ ] 5.2 Transcript: one buffer per session; a tool call appends a heading with name/timestamp/args; distinct sessions stay isolated.
+- [ ] 5.3 Diff outcome: accept records FILE_SAVED + file; reject records DIFF_REJECTED + file, under the right entry.
+- [ ] 5.4 Passive safety: with the tap installed, `openDiff`/`getDiagnostics`/`closeAllDiffTabs` are still answered normally; a forced rendering error does not stall the tool-call answer.
+- [ ] 5.5 CI byte-compiles the new module and runs the new suite.
+
+## 6. Docs
+
+- [ ] 6.1 README: document the remote-control surface, the opt-in defcustom, the `mcp-emacs-remote-prompt` command, and the tool-activity-only transcript scope (prose stays in the TUI).
+- [ ] 6.2 Note the interactive-vs-headless rationale and the prose-transcript follow-up (link issue #23).
+
+## 7. Verify
+
+- [ ] 7.1 Live end-to-end in the running Emacs: enable the feature, launch an IDE session, prompt via `mcp-emacs-remote-prompt`, drive a native edit, confirm the transcript records the tool call + accept/reject outcome + metadata and that approval still runs through the ediff gate.

--- a/openspec/changes/claude-remote-control/tasks.md
+++ b/openspec/changes/claude-remote-control/tasks.md
@@ -1,43 +1,43 @@
 ## 1. Module scaffold & opt-in
 
-- [ ] 1.1 Add `elisp/mcp-emacs-remote.el` with header, `provide`, and requires (`mcp-emacs-run`, `mcp-emacs-ide`, `org`, `json`, `cl-lib`); byte-compiles clean.
-- [ ] 1.2 Add a `mcp-emacs-remote-enabled` defcustom (default off), matching the IDE surface's opt-in posture; the event tap is a no-op when disabled.
-- [ ] 1.3 Lifecycle: `mcp-emacs-remote-enable` / `mcp-emacs-remote-disable` install and remove the event tap idempotently.
+- [x] 1.1 Add `elisp/mcp-emacs-remote.el` with header, `provide`, and requires (`mcp-emacs-run`, `mcp-emacs-ide`, `org`, `json`, `cl-lib`); byte-compiles clean.
+- [x] 1.2 Add a `mcp-emacs-remote-enabled` defcustom (default off), matching the IDE surface's opt-in posture; the event tap is a no-op when disabled.
+- [x] 1.3 Lifecycle: `mcp-emacs-remote-enable` / `mcp-emacs-remote-disable` install and remove the event tap idempotently.
 
 ## 2. Prompt input (spec: remote-prompt-input)
 
-- [ ] 2.1 `mcp-emacs-remote-prompt`: read a prompt from the minibuffer and submit it (auto-submit, session begins responding); empty or whitespace-only input sends nothing and reports "no prompt provided".
-- [ ] 2.2 When a region is active, pre-fill the minibuffer with the region text so the user edits/confirms before it is sent (not sent raw).
-- [ ] 2.3 `mcp-emacs-remote-prompt-buffer`: send the whole current buffer as the prompt and submit it; empty/whitespace-only buffer sends nothing and reports "nothing to send".
-- [ ] 2.4 Deliver the prompt via `mcp-emacs-run-send-prompt` (auto-submits); resolve the target session with `mcp-emacs-run--resolve-session` (prompts on multiple candidates).
-- [ ] 2.5 Require a live session: if the project has no running session, report it and do not launch one.
+- [x] 2.1 `mcp-emacs-remote-prompt`: read a prompt from the minibuffer and submit it (auto-submit, session begins responding); empty or whitespace-only input sends nothing and reports "no prompt provided".
+- [x] 2.2 When a region is active, pre-fill the minibuffer with the region text so the user edits/confirms before it is sent (not sent raw).
+- [x] 2.3 `mcp-emacs-remote-prompt-buffer`: send the whole current buffer as the prompt and submit it; empty/whitespace-only buffer sends nothing and reports "nothing to send".
+- [x] 2.4 Deliver the prompt via `mcp-emacs-run-send-prompt` (auto-submits); resolve the target session with `mcp-emacs-run--resolve-session` (prompts on multiple candidates).
+- [x] 2.5 Require a live session: if the project has no running session, report it and do not launch one.
 
 ## 3. Org transcript buffer (spec: remote-org-transcript)
 
-- [ ] 3.1 Per-session transcript buffer keyed by session, named `*claude: <project>*`, created lazily on first recordable event and reused thereafter; distinct sessions get distinct buffers.
-- [ ] 3.2 Tap `mcp-emacs-ide--call-tool` (behind the enabled flag) to append an Org heading per tool call: tool name, timestamp, and arguments in a readable `#+begin_src json` block.
-- [ ] 3.3 Collapse or suppress `getDiagnostics` / `closeAllDiffTabs` entries so per-edit noise doesn't dominate the transcript.
-- [ ] 3.4 Tap `mcp-emacs-ide--complete-open-diff` to record each diff outcome (accepted → FILE_SAVED, rejected → DIFF_REJECTED) with the target file, under the matching tool entry.
-- [ ] 3.5 Run metadata drawer: on `ide_connected`, record session start + workspace root as Org properties; on socket close, record session end.
+- [x] 3.1 Per-session transcript buffer keyed by session, named `*claude: <project>*`, created lazily on first recordable event and reused thereafter; distinct sessions get distinct buffers.
+- [x] 3.2 Tap `mcp-emacs-ide--call-tool` (behind the enabled flag) to append an Org heading per tool call: tool name, timestamp, and arguments in a readable `#+begin_src json` block.
+- [x] 3.3 Collapse or suppress `getDiagnostics` / `closeAllDiffTabs` entries so per-edit noise doesn't dominate the transcript.
+- [x] 3.4 Tap `mcp-emacs-ide--complete-open-diff` to record each diff outcome (accepted → FILE_SAVED, rejected → DIFF_REJECTED) with the target file, under the matching tool entry.
+- [x] 3.5 Run metadata drawer: on `ide_connected`, record session start + workspace root as Org properties; on socket close, record session end.
 
 ## 4. Passive-safety guarantees (spec: remote-org-transcript "does not gate execution")
 
-- [ ] 4.1 Rendering runs after the surface has decided how to answer a call; the tap returns control to the surface unchanged (never blocks or alters the answer).
-- [ ] 4.2 Wrap all rendering in error handling: a rendering failure is caught and logged, never propagated into the tool-call answer path.
+- [x] 4.1 Rendering runs after the surface has decided how to answer a call; the tap returns control to the surface unchanged (never blocks or alters the answer).
+- [x] 4.2 Wrap all rendering in error handling: a rendering failure is caught and logged, never propagated into the tool-call answer path.
 
 ## 5. Tests
 
-- [ ] 5.1 Prompt input: empty input sends nothing; region pre-fills; no-session case reports and does not launch; multi-session case resolves via the runner's picker (drive commands headlessly as the existing suites do).
-- [ ] 5.2 Transcript: one buffer per session; a tool call appends a heading with name/timestamp/args; distinct sessions stay isolated.
-- [ ] 5.3 Diff outcome: accept records FILE_SAVED + file; reject records DIFF_REJECTED + file, under the right entry.
-- [ ] 5.4 Passive safety: with the tap installed, `openDiff`/`getDiagnostics`/`closeAllDiffTabs` are still answered normally; a forced rendering error does not stall the tool-call answer.
-- [ ] 5.5 CI byte-compiles the new module and runs the new suite.
+- [x] 5.1 Prompt input: empty input sends nothing; region pre-fills; no-session case reports and does not launch; multi-session case resolves via the runner's picker (drive commands headlessly as the existing suites do).
+- [x] 5.2 Transcript: one buffer per session; a tool call appends a heading with name/timestamp/args; distinct sessions stay isolated.
+- [x] 5.3 Diff outcome: accept records FILE_SAVED + file; reject records DIFF_REJECTED + file, under the right entry.
+- [x] 5.4 Passive safety: with the tap installed, `openDiff`/`getDiagnostics`/`closeAllDiffTabs` are still answered normally; a forced rendering error does not stall the tool-call answer.
+- [x] 5.5 CI byte-compiles the new module and runs the new suite.
 
 ## 6. Docs
 
-- [ ] 6.1 README: document the remote-control surface, the opt-in defcustom, the `mcp-emacs-remote-prompt` command, and the tool-activity-only transcript scope (prose stays in the TUI).
-- [ ] 6.2 Note the interactive-vs-headless rationale and the prose-transcript follow-up (link issue #23).
+- [x] 6.1 README: document the remote-control surface, the opt-in defcustom, the `mcp-emacs-remote-prompt` command, and the tool-activity-only transcript scope (prose stays in the TUI).
+- [x] 6.2 Note the interactive-vs-headless rationale and the prose-transcript follow-up (link issue #23).
 
 ## 7. Verify
 
-- [ ] 7.1 Live end-to-end in the running Emacs: enable the feature, launch an IDE session, prompt via `mcp-emacs-remote-prompt`, drive a native edit, confirm the transcript records the tool call + accept/reject outcome + metadata and that approval still runs through the ediff gate.
+- [x] 7.1 Live end-to-end in the running Emacs: enable the feature, launch an IDE session, prompt via `mcp-emacs-remote-prompt`, drive a native edit, confirm the transcript records the tool call + accept/reject outcome + metadata and that approval still runs through the ediff gate.

--- a/test/mcp-emacs-remote-test.el
+++ b/test/mcp-emacs-remote-test.el
@@ -1,0 +1,139 @@
+(add-to-list 'load-path (expand-file-name "elisp"))
+(require 'cl-lib)
+
+;; Stub the two upstream modules the remote module requires, so the tests
+;; run without websocket.el / web-server / a live session.  Only the symbols
+;; the remote module actually touches are provided.
+(unless (featurep 'mcp-emacs-run)
+  (defun mcp-emacs-run-send-prompt (_text) nil)
+  (defun mcp-emacs-run--project-root () "/tmp/proj-xyz")
+  (provide 'mcp-emacs-run))
+(unless (featurep 'mcp-emacs-ide)
+  (cl-defstruct (mcp-emacs-ide-session (:constructor mcp-emacs-ide--make-session))
+    client port project-dir)
+  (defvar mcp-emacs-ide--session nil)
+  (defun mcp-emacs-ide--call-tool (_s _n _a _i) nil)
+  (defun mcp-emacs-ide--complete-open-diff (_s _t _st &rest _e) nil)
+  (defun mcp-emacs-ide-start () nil)
+  (defun mcp-emacs-ide-stop () nil)
+  (provide 'mcp-emacs-ide))
+
+(require 'mcp-emacs-remote)
+
+(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+
+(defun remote--kill-transcripts ()
+  (dolist (b (buffer-list))
+    (when (string-prefix-p "*claude: " (buffer-name b))
+      (let ((kill-buffer-query-functions nil)) (kill-buffer b)))))
+
+;; --- 5.1 Prompt input --------------------------------------------------------
+
+;; Empty / whitespace prompt -> user-error, nothing sent.
+(let ((sent nil))
+  (cl-letf (((symbol-function 'mcp-emacs-run-send-prompt) (lambda (tx) (setq sent tx))))
+    (check "empty-prompt-errors"
+           (condition-case _ (progn (mcp-emacs-remote--send "") nil) (user-error t)) t)
+    (check "whitespace-prompt-errors"
+           (condition-case _ (progn (mcp-emacs-remote--send "  \n ") nil) (user-error t)) t)
+    (check "empty-prompt-sends-nothing" sent nil)))
+
+;; Non-empty prompt -> delivered via send-prompt.
+(let ((sent nil))
+  (cl-letf (((symbol-function 'mcp-emacs-run-send-prompt) (lambda (tx) (setq sent tx))))
+    (mcp-emacs-remote--send "hello claude")
+    (check "prompt-delivered" sent "hello claude")))
+
+;; Whole-buffer send: empty buffer errors; non-empty delivers buffer text.
+(let ((sent nil))
+  (cl-letf (((symbol-function 'mcp-emacs-run-send-prompt) (lambda (tx) (setq sent tx))))
+    (with-temp-buffer
+      (check "buffer-empty-errors"
+             (condition-case _ (progn (mcp-emacs-remote-prompt-buffer) nil) (user-error t)) t))
+    (check "buffer-empty-sends-nothing" sent nil)
+    (with-temp-buffer
+      (insert "line one\nline two\n")
+      (mcp-emacs-remote-prompt-buffer))
+    (check "buffer-delivered" sent "line one\nline two\n")))
+
+;; --- 5.2 Transcript: one buffer per project, tool call recorded --------------
+
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-alpha")))
+    (mcp-emacs-remote-record-tool-call "openDiff" '((tab_name . "t1")))
+    (mcp-emacs-remote-record-tool-call "openDiff" '((tab_name . "t2"))))
+  (let ((buf (get-buffer "*claude: proj-alpha*")))
+    (check "transcript-buffer-created" (and buf t) t)
+    (check "transcript-reused-single-buffer"
+           (length (seq-filter (lambda (b) (string-prefix-p "*claude: " (buffer-name b)))
+                               (buffer-list)))
+           1)
+    (with-current-buffer buf
+      (check "tool-heading-recorded"
+             (and (string-match-p "🔧 openDiff" (buffer-string)) t) t)
+      (check "tool-args-recorded"
+             (and (string-match-p "begin_src json" (buffer-string)) t) t))))
+
+;; Distinct projects -> distinct buffers.
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-beta")))
+    (mcp-emacs-remote-record-tool-call "openDiff" '((tab_name . "x"))))
+  (check "distinct-projects-distinct-buffers"
+         (and (get-buffer "*claude: proj-alpha*") (get-buffer "*claude: proj-beta*") t) t))
+
+;; Quiet tools get a compact note, not a heading.
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-q")))
+    (mcp-emacs-remote-record-tool-call "getDiagnostics" '()))
+  (with-current-buffer (get-buffer "*claude: proj-q*")
+    (check "quiet-tool-no-heading"
+           (and (not (string-match-p "🔧 getDiagnostics" (buffer-string)))
+                (string-match-p "getDiagnostics" (buffer-string)) t) t)))
+
+;; --- 5.3 Diff outcome --------------------------------------------------------
+
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-d")))
+    (mcp-emacs-remote-record-diff-outcome "tab-A" "FILE_SAVED" "new content")
+    (mcp-emacs-remote-record-diff-outcome "tab-B" "DIFF_REJECTED" "tab-B"))
+  (with-current-buffer (get-buffer "*claude: proj-d*")
+    (let ((s (buffer-string)))
+      (check "accept-recorded"
+             (and (string-match-p "openDiff accepted :: tab-A" s) t) t)
+      (check "reject-recorded"
+             (and (string-match-p "openDiff rejected :: tab-B" s) t) t))))
+
+;; --- 5.4 Passive safety ------------------------------------------------------
+
+;; Disabled -> the tap records nothing.
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled nil))
+  (mcp-emacs-remote--tap-call-tool nil "openDiff" '((tab_name . "z")) 1)
+  (check "disabled-records-nothing"
+         (seq-find (lambda (b) (string-prefix-p "*claude: " (buffer-name b))) (buffer-list))
+         nil))
+
+;; A rendering failure never propagates out of the recorder.
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-remote--append)
+             (lambda (&rest _) (error "boom"))))
+    (check "render-error-swallowed-tool"
+           (condition-case _ (progn (mcp-emacs-remote-record-tool-call "openDiff" '()) t)
+             (error nil))
+           t)
+    (check "render-error-swallowed-diff"
+           (condition-case _ (progn (mcp-emacs-remote-record-diff-outcome "t" "FILE_SAVED") t)
+             (error nil))
+           t)))
+
+;; The :before tap returns nil (does not alter the wrapped call's return).
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-r")))
+    (check "tap-returns-nil"
+           (mcp-emacs-remote--tap-call-tool nil "getDiagnostics" '() 1) nil)))
+
+(remote--kill-transcripts)


### PR DESCRIPTION
OpenSpec change planning the Claude remote-control surface: prompt an mcp-emacs-launched interactive Claude from the minibuffer/region/buffer, and render its tool activity as a live Org transcript. Reuses the IDE WebSocket surface, the env-injecting runner, and the ediff gate from #20; tool approval stays the ediff review. Tool-activity-only transcript in v1 — assistant prose stays in the TUI (interactive mode carries no prose over the socket, and headless `-p` lost `--permission-prompt-tool` in 2.1.212, so it can't gate edits).

This PR is the planning foundation (proposal, specs, design, tasks); implementation follows on the same branch.

Closes #23.