### PR TITLE
Report a tooling issue: file mcp-emacs bugs/feature requests from the assistant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,11 @@ jobs:
             --eval "(package-initialize)" \
             -L elisp \
             -f batch-byte-compile \
-            elisp/mcp-emacs.el elisp/mcp-emacs-server.el elisp/mcp-emacs-ide.el
+            elisp/mcp-emacs.el elisp/mcp-emacs-report.el elisp/mcp-emacs-server.el elisp/mcp-emacs-ide.el
 
       - name: Run tests
         run: |
-          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el; do
+          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el test/mcp-emacs-report-test.el; do
             echo "== $t =="
             emacs --batch \
               --eval "(require 'package)" \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ observe the real buffers, windows, and Org state of the running session.
 | `org_task_append_note`            | Append a progress note to the task body without altering existing content                  |
 | `org_task_append_item`            | Append a new TODO item as a child under the task heading                                   |
 | `org_task_wait_for_change`        | Block until the task file changes past a baseline token (or a timeout), then return it     |
+| `report_tooling_issue`            | File a bug report or feature request about mcp-emacs itself as a GitHub issue               |
 
 ### Org task session sync
 
@@ -67,6 +68,25 @@ For a cooperative loop, `org_task_session` returns a change token and
 until the human edits the file, then wakes with the change and the current
 session view. The harness works, then waits for the human's next direction —
 instead of only seeing edits when it happens to re-read.
+
+### Report a tooling issue
+
+When a tool or skill from mcp-emacs misbehaves — or you want a feature — the
+`report_tooling_issue` tool files it as a GitHub issue on
+`gbastkowski/mcp-emacs`, so you can report from inside the assistant instead of
+switching to GitHub by hand. It takes a `title`, an optional `description`, and
+an optional `kind` (`bug` / `feature` / `skill` / `server`) applied as a label.
+
+Filing is resilient: it uses the `gh` CLI, falling back to `gh api`; when no
+GitHub mechanism is available it hands back the composed issue text for manual
+filing. The `report-issue` skill wraps this in a guided flow — classify, draft,
+confirm, file, report the URL — and prefers the `github` MCP server when one is
+connected. The target repo is fixed: this reports issues about mcp-emacs
+itself, not arbitrary repositories.
+
+This is the GitHub, single-repo counterpart to the "report a tooling issue"
+feature in the sibling GitLab AI-tooling (see #26); there is no fault-domain
+router because mcp-emacs is one repo.
 
 ### opencode client
 

--- a/elisp/mcp-emacs-ide.el
+++ b/elisp/mcp-emacs-ide.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-ide.el --- Claude Code IDE integration for mcp-emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.2.0
+;; Version: 1.3.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs-report.el
+++ b/elisp/mcp-emacs-report.el
@@ -1,0 +1,144 @@
+;;; mcp-emacs-report.el --- Report tooling issues about mcp-emacs -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 1.2.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; A helper to file a bug report or feature request about mcp-emacs
+;; itself -- the MCP server's tools or a plugin skill -- as a GitHub
+;; issue on the mcp-emacs repository, from inside the assistant.
+;;
+;; Filing tries the `gh' CLI first (`gh issue create'), then a direct
+;; `gh api' call.  A GitHub MCP tool, when available, is preferred by the
+;; orchestrating skill before this helper is reached; this module owns the
+;; CLI and API fallbacks.  When no mechanism is available the composed
+;; title and body are returned so the user can file the issue by hand.
+;;
+;; The target repository is fixed: this files issues about mcp-emacs, not
+;; arbitrary repositories.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'json)
+
+(defconst mcp-emacs-report-repo "gbastkowski/mcp-emacs"
+  "The GitHub repository issues are filed against.
+This tool reports issues about mcp-emacs itself, so the target is
+fixed rather than caller-chosen.")
+
+(defconst mcp-emacs-report-kinds '("bug" "feature" "skill" "server")
+  "Accepted values for the issue category.
+Each is applied to the created issue as a GitHub label.")
+
+(defun mcp-emacs-report--gh-available-p ()
+  "Return non-nil when the `gh' CLI is on `exec-path'."
+  (and (executable-find "gh") t))
+
+(defun mcp-emacs-report--run (&rest args)
+  "Run `gh' with ARGS, returning (cons EXIT-CODE TRIMMED-OUTPUT).
+Combines stdout and stderr into the output string."
+  (with-temp-buffer
+    (let ((code (apply #'call-process "gh" nil t nil args)))
+      (cons code (string-trim (buffer-string))))))
+
+(defun mcp-emacs-report--create-via-cli (title body)
+  "Create the issue via `gh issue create', returning the issue URL or nil.
+TITLE and BODY are the issue title and body.  Returns nil when the CLI
+call fails for any reason, so the caller can fall back to the API."
+  (let* ((args (append (list "issue" "create"
+                             "--repo" mcp-emacs-report-repo
+                             "--title" title)
+                       (when (and body (not (string-empty-p body)))
+                         (list "--body" body))))
+         (result (apply #'mcp-emacs-report--run args)))
+    (when (zerop (car result))
+      ;; `gh issue create' prints the new issue URL on success.
+      (let ((url (car (last (split-string (cdr result) "\n" t)))))
+        (and url (string-match-p "^https?://" url) url)))))
+
+(defun mcp-emacs-report--api-create (title body)
+  "Create the issue via `gh api' with a temp-file payload; URL or nil.
+TITLE and BODY are the issue title and body.  Lowest-level fallback for
+when `gh issue create' is unavailable.  A temp file carries the JSON
+payload because `call-process' cannot both send stdin and capture
+output."
+  (let ((tmp (make-temp-file "mcp-emacs-report" nil ".json"
+                             (json-encode
+                              (append (list (cons "title" title))
+                                      (when (and body (not (string-empty-p body)))
+                                        (list (cons "body" body))))))))
+    (unwind-protect
+        (let ((result (mcp-emacs-report--run
+                       "api" (format "repos/%s/issues" mcp-emacs-report-repo)
+                       "--method" "POST"
+                       "--input" tmp
+                       "-q" ".html_url")))
+          (when (zerop (car result))
+            (let ((url (string-trim (cdr result))))
+              (and (string-match-p "^https?://" url) url))))
+      (delete-file tmp))))
+
+(defun mcp-emacs-report--apply-label (url kind)
+  "Best-effort: apply KIND as a label to the issue at URL.
+A missing label (or any labeling failure) is ignored -- the issue is
+already created, which is what matters."
+  (when (and kind url)
+    (ignore-errors
+      (mcp-emacs-report--run
+       "issue" "edit" url "--repo" mcp-emacs-report-repo "--add-label" kind))))
+
+(defun mcp-emacs-report--manual-fallback (title body)
+  "Return the manual-filing text for TITLE and BODY.
+Used when no filing mechanism is available."
+  (format "Could not file the issue automatically (no GitHub mechanism available).
+File it manually at https://github.com/%s/issues/new with:
+
+Title: %s
+
+%s"
+          mcp-emacs-report-repo title (or body "")))
+
+(defun mcp-emacs-report-tooling-issue (title &optional description kind)
+  "File a GitHub issue about mcp-emacs and return a result string.
+TITLE is required.  DESCRIPTION is the optional issue body.  KIND, when
+given, must be one of `mcp-emacs-report-kinds' and is applied as a label
+best-effort.  Files via `gh issue create', falling back to `gh api'.
+On success returns \"Created issue: URL\"; when no mechanism is available
+returns the manual-filing text so the caller can file by hand.  Signals a
+`user-error' on a missing title or an out-of-set KIND."
+  (unless (and (stringp title) (not (string-empty-p (string-trim title))))
+    (user-error "A title is required to file an issue"))
+  (when (and kind (not (member kind mcp-emacs-report-kinds)))
+    (user-error "Invalid kind %S; must be one of: %s"
+                kind (string-join mcp-emacs-report-kinds ", ")))
+  (if (not (mcp-emacs-report--gh-available-p))
+      (mcp-emacs-report--manual-fallback title description)
+    (let ((url (or (mcp-emacs-report--create-via-cli title description)
+                   (mcp-emacs-report--api-create title description))))
+      (if url
+          (progn
+            (mcp-emacs-report--apply-label url kind)
+            (format "Created issue: %s" url))
+        (mcp-emacs-report--manual-fallback title description)))))
+
+(provide 'mcp-emacs-report)
+;;; mcp-emacs-report.el ends here

--- a/elisp/mcp-emacs-report.el
+++ b/elisp/mcp-emacs-report.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-report.el --- Report tooling issues about mcp-emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.2.0
+;; Version: 1.3.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs-run.el
+++ b/elisp/mcp-emacs-run.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-run.el --- Run the Claude Code CLI inside Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.2.0
+;; Version: 1.3.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs-server.el
+++ b/elisp/mcp-emacs-server.el
@@ -38,6 +38,7 @@
 ;;; Code:
 
 (require 'mcp-emacs)
+(require 'mcp-emacs-report)
 (require 'web-server)
 (require 'json)
 (require 'cl-lib)
@@ -394,7 +395,24 @@ rather than `null' (an empty alist would)."
                     (mcp-emacs-org-task-wait-for-change
                      (alist-get 'path args)
                      (alist-get 'token args)
-                     (alist-get 'timeout args)))))
+                     (alist-get 'timeout args))))
+   (list :name "report_tooling_issue"
+         :description "File a bug report or feature request about mcp-emacs itself: the MCP server's tools or a plugin skill, as a GitHub issue on gbastkowski/mcp-emacs. Use this when a tool or skill from this tooling misbehaves or is missing a feature. Not for issues in arbitrary project repositories."
+         :schema (mcp-emacs-server--obj
+                  "type" "object"
+                  "properties" (mcp-emacs-server--obj
+                                "title" (mcp-emacs-server--prop "string" "Short, specific issue title")
+                                "description" (mcp-emacs-server--prop "string" "Issue body. Include what happened, expected behaviour, and reproduction steps when reporting a bug.")
+                                "kind" (mcp-emacs-server--obj
+                                        "type" "string"
+                                        "description" "Category applied as a GitHub label: bug, feature, skill, or server"
+                                        "enum" (vector "bug" "feature" "skill" "server")))
+                  "required" (vector "title"))
+         :handler (lambda (args)
+                    (mcp-emacs-report-tooling-issue
+                     (alist-get 'title args)
+                     (alist-get 'description args)
+                     (alist-get 'kind args)))))
   "List of tool descriptors.  Each is a plist with :name :description :schema :handler.")
 
 (defun mcp-emacs-server--find-tool (name)

--- a/elisp/mcp-emacs-server.el
+++ b/elisp/mcp-emacs-server.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-server.el --- HTTP MCP server running inside Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.2.0
+;; Version: 1.3.0
 ;; Package-Requires: ((emacs "28.1") (web-server "0.1.2"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs.el
+++ b/elisp/mcp-emacs.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs.el --- Helper functions for MCP Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.2.0
+;; Version: 1.3.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/opencode-client.el
+++ b/elisp/opencode-client.el
@@ -1,7 +1,7 @@
 ;;; opencode-client.el --- Native Emacs client for the opencode HTTP API -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.2.0
+;; Version: 1.3.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/openspec/changes/report-tooling-issue/.openspec.yaml
+++ b/openspec/changes/report-tooling-issue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/report-tooling-issue/design.md
+++ b/openspec/changes/report-tooling-issue/design.md
@@ -1,0 +1,87 @@
+## Context
+
+See proposal.md — Why. This ports a feature that already shipped in the sibling GitLab tooling. The
+reference implementation is three parts across two repos:
+
+- `report_tooling_issue` (mcp-gitlab) — the filer: a hard-coded repo map + `glab issue create
+  --no-editor --yes`, returns the printed issue URL, no labels/template.
+- `get_origin` (mcp-jira-confluence) — a router that declares `{repo, url, newIssueUrl, reportFor}`
+  per fault domain so a caller can pick the target repo. Files nothing.
+- `report-issue` skill (jira-assistant) — orchestrates: classify → get_origin → draft → confirm →
+  file (via the gitlab filer) or hand back a prefilled new-issue URL.
+
+mcp-emacs differs in two ways that shape the port: it is a **single GitHub repo**
+(`gbastkowski/mcp-emacs`), and its MCP server is **Emacs-resident elisp**, registered as
+`(:name :description :schema :handler)` plists in `mcp-emacs-server--tools`
+(`elisp/mcp-emacs-server.el`), with schemas built from the `--obj`/`--prop`/`--no-args` helpers.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A `report_tooling_issue` MCP tool that files a GitHub issue on the mcp-emacs repo and returns its
+  URL, resilient to which GitHub mechanism happens to be available.
+- A `report-issue` skill that classifies, drafts, confirms, and files.
+
+**Non-Goals (design-level):**
+
+- No `get_origin`-style router — one repo, nothing to route.
+- No issue templates, no multi-repo targeting, no arbitrary-repo issue creation.
+
+## Decisions
+
+### 1. Drop the router; collapse fault domains to a `kind` label
+
+The GitLab feature routed between two repos by fault domain. mcp-emacs is one repo, so routing is
+moot. The signal the router carried — "is this a server bug or a skill/prompt bug?" — is preserved as
+an optional `kind` label (`bug` / `feature` / `skill` / `server`) on the issue. **Alternative
+considered:** port `get_origin` verbatim for 1:1 parity. Rejected — it would be a tool that always
+returns one target, i.e. dead weight, until/unless a sibling repo (e.g. a separate opencode-plugin
+repo) actually exists.
+
+### 2. GitHub, via a three-step fallback chain
+
+The reference filer shells out to `glab`. mcp-emacs is GitHub, and the environment may expose GitHub
+access in more than one way, so the filer tries, in order:
+
+1. **the `github` MCP tool** (`issue_write` / equivalent) if that server is connected,
+2. **the `gh` CLI** (`gh issue create --repo gbastkowski/mcp-emacs ...`) — installed and authed here,
+3. **`gh api`** directly (`POST /repos/gbastkowski/mcp-emacs/issues`) as the lowest-level fallback.
+
+The elisp tool owns steps 2–3 (it can `call-process gh`); step 1 is naturally the skill's preference
+when it is orchestrating, since the skill can see whether the `github` MCP server is present. Either
+way the *first available* mechanism wins and the rest are skipped. If none is available, the tool
+reports failure and returns the composed title+body so the user can file by hand — the GitHub analog
+of the reference's prefilled-`newIssueUrl` fallback. **Alternative considered:** REST via `url.el`
+with a token. Rejected — reuses no existing auth; `gh` already holds the credential.
+
+### 3. Label creation is best-effort
+
+Applying a `kind` label must not fail the filing if the label doesn't exist in the repo yet. The
+filer applies the label when it can and does not treat a missing-label error as a filing failure —
+the issue (the important artifact) is created regardless. Labels can be pre-created in the repo out of
+band.
+
+### 4. Skill mirrors the reference's classify → draft → confirm → file → report
+
+Kept intact from `report-issue`, minus the router call: classify (server tool / skill / feature),
+draft a lean title + what/expected/repro body, **confirm with the user before filing** (explicit
+gate, per the reference and the spec), file via `report_tooling_issue`, report the URL back. The
+confirmation gate is a spec requirement ("User declines the draft" → nothing filed), not just skill
+prose.
+
+## Risks / Trade-offs
+
+- **Three filing paths to keep working** → more surface than a single `glab` call. Mitigation: they
+  are tried in a fixed order and the first available wins; the manual-fallback branch means "no path
+  available" degrades to a copy-pasteable draft rather than a hard error.
+- **`kind` label may not exist in the repo** → a naive `--label` would fail the whole create.
+  Mitigation: best-effort labeling (decision 3) — create the issue first, label if possible.
+- **Coupling to `gh` auth** → if `gh` is unauthenticated and no GitHub MCP server is present, filing
+  can't proceed. Mitigation: that is exactly the manual-fallback case; the user still gets the drafted
+  issue text.
+
+## Open Questions
+
+None that affect the specs, the approach, or the task breakdown. Whether to pre-create the four
+`kind` labels in the repo is an out-of-band repo-admin step, not a code decision.

--- a/openspec/changes/report-tooling-issue/proposal.md
+++ b/openspec/changes/report-tooling-issue/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+The sibling GitLab AI-tooling repos recently shipped a "report a tooling issue" feature: a user who
+hits a bug or wants a feature in the tooling itself can file it from inside the assistant, without
+leaving the session. mcp-emacs has no equivalent — a user who finds a broken tool or a clumsy skill
+has to context-switch to GitHub and hand-write an issue.
+
+This change ports that feature to mcp-emacs, adapted from GitLab (two repos, fault-domain routing) to
+mcp-emacs's single GitHub repo (`gbastkowski/mcp-emacs`).
+
+## What Changes
+
+- Add a **`report_tooling_issue`** MCP tool that files a GitHub issue against `gbastkowski/mcp-emacs`.
+  - Params: `title` (required), `description` (optional), `kind` (optional enum: `bug` / `feature` /
+    `skill` / `server`, applied as a GitHub label).
+  - Filing uses a fallback chain: the GitHub MCP tool if available → the `gh` CLI → `gh api` directly.
+  - Returns the created issue URL.
+- Add a **`report-issue`** skill that orchestrates the flow: classify the report, draft a lean issue,
+  **confirm with the user**, file it via the tool, and report back the URL.
+- No fault-domain router (the GitLab `get_origin` tool). mcp-emacs is one repo, so there is nothing to
+  route between; the `kind` label carries the server-vs-skill signal instead.
+
+## Capabilities
+
+### New Capabilities
+
+- `report-tooling-issue`: file a bug report or feature request about mcp-emacs itself (the MCP server
+  tools or a plugin skill) as a GitHub issue on `gbastkowski/mcp-emacs`, from inside the assistant,
+  via a resilient filing chain.
+
+### Modified Capabilities
+
+<!-- None. This adds a new tool + skill; it does not change any existing capability's requirements. -->
+
+## Impact
+
+- **New elisp**: a filing helper (e.g. `mcp-emacs-report-tooling-issue`) plus a new tool descriptor in
+  `mcp-emacs-server--tools` (`elisp/mcp-emacs-server.el`).
+- **New skill**: `skills/report-issue/SKILL.md` (or the repo's skill location).
+- **External dependency**: GitHub issue creation via one of — the `github` MCP server, the `gh` CLI,
+  or `gh api`. `gh` is already installed and authenticated in the dev environment.
+- **Reuses**: the existing MCP tool-registration shape (`:name`/`:description`/`:schema`/`:handler`
+  plists, `--obj`/`--prop` schema helpers).
+- **Out of scope**: fault-domain routing / a `get_origin`-style tool; issue templates; multi-repo
+  targeting.
+
+Ports the feature from mcp-gitlab (`report_tooling_issue`), mcp-jira-confluence (`get_origin`), and
+jira-assistant (`report-issue` skill). Full context: issue #26.

--- a/openspec/changes/report-tooling-issue/specs/report-tooling-issue/spec.md
+++ b/openspec/changes/report-tooling-issue/specs/report-tooling-issue/spec.md
@@ -1,0 +1,102 @@
+## Purpose
+
+Lets a user file a bug report or feature request about mcp-emacs itself — the MCP server's tools or a
+plugin skill — as a GitHub issue on the mcp-emacs repository, from inside the assistant, without
+hand-writing the issue or leaving the session.
+
+## ADDED Requirements
+
+### Requirement: File a tooling issue as a GitHub issue
+
+The system SHALL provide a `report_tooling_issue` tool that creates a GitHub issue on the mcp-emacs
+repository from a supplied title and optional description, and SHALL return the URL of the created
+issue.
+
+#### Scenario: Issue filed with title and description
+
+- **WHEN** the tool is called with a title and a description
+- **THEN** a GitHub issue is created on the mcp-emacs repository with that title and body
+- **AND** the tool returns the URL of the created issue
+
+#### Scenario: Title is required
+
+- **WHEN** the tool is called without a title
+- **THEN** no issue is created
+- **AND** the tool reports that a title is required
+
+### Requirement: Optional category applied as a label
+
+The system SHALL accept an optional `kind` categorizing the report as one of `bug`, `feature`,
+`skill`, or `server`, and SHALL apply the chosen value as a label on the created issue. When `kind` is
+omitted, the issue is created without a category label.
+
+#### Scenario: Kind provided
+
+- **WHEN** the tool is called with `kind` set to one of the accepted values
+- **THEN** the created issue carries that value as a label
+
+#### Scenario: Kind omitted
+
+- **WHEN** the tool is called with no `kind`
+- **THEN** the issue is still created
+- **AND** no category label is required for the call to succeed
+
+#### Scenario: Invalid kind
+
+- **WHEN** the tool is called with a `kind` outside the accepted set
+- **THEN** the call is rejected with a message naming the accepted values
+- **AND** no issue is created
+
+### Requirement: Resilient filing chain
+
+The system SHALL attempt to create the issue through more than one mechanism so that filing succeeds
+whenever any one of them is available, trying in order: the GitHub MCP tool if available, then the
+`gh` CLI, then a direct `gh api` call. If none is available, the system SHALL report that it could
+not file the issue and SHALL surface the issue title and body so the user can file it manually.
+
+#### Scenario: Preferred mechanism available
+
+- **WHEN** the GitHub MCP tool is available
+- **THEN** the issue is created through it
+- **AND** the lower-priority mechanisms are not attempted
+
+#### Scenario: Fallback to the CLI
+
+- **WHEN** the GitHub MCP tool is not available but the `gh` CLI is
+- **THEN** the issue is created through the `gh` CLI
+
+#### Scenario: No mechanism available
+
+- **WHEN** none of the filing mechanisms is available
+- **THEN** no issue is created
+- **AND** the system reports the failure and returns the composed title and body for manual filing
+
+### Requirement: Report about mcp-emacs, not arbitrary repositories
+
+The tool SHALL be scoped to filing issues about mcp-emacs itself and SHALL target the mcp-emacs
+repository; it is not a general-purpose issue creator for arbitrary repositories.
+
+#### Scenario: Target repository is fixed
+
+- **WHEN** the tool creates an issue
+- **THEN** the issue is created on the mcp-emacs repository
+- **AND** the caller does not choose an arbitrary target repository
+
+### Requirement: Guided reporting via a skill
+
+The system SHALL provide a `report-issue` skill that guides the user through reporting: it classifies
+the report (a server-tool bug, a skill/prompt issue, or a feature request), drafts a concise issue
+(title plus what-happened / expected / reproduction), confirms the draft with the user before filing,
+files it via the `report_tooling_issue` tool, and reports back the resulting issue URL.
+
+#### Scenario: Guided report end to end
+
+- **WHEN** the user asks to report a bug or feature request about the tooling and the skill runs
+- **THEN** the skill classifies the report and drafts a title and body
+- **AND** the skill confirms the draft with the user before filing
+- **AND** on confirmation the skill files the issue via `report_tooling_issue` and reports the URL
+
+#### Scenario: User declines the draft
+
+- **WHEN** the user does not confirm the drafted issue
+- **THEN** no issue is filed

--- a/openspec/changes/report-tooling-issue/tasks.md
+++ b/openspec/changes/report-tooling-issue/tasks.md
@@ -1,37 +1,37 @@
 ## 1. Filing helper (elisp)
 
-- [ ] 1.1 Add `mcp-emacs-report-tooling-issue` (new helper, e.g. in `mcp-emacs.el` or a small `mcp-emacs-report.el`): takes title, optional description, optional kind; targets `gbastkowski/mcp-emacs`; byte-compiles clean.
-- [ ] 1.2 Filing via `gh` CLI: `call-process gh issue create --repo gbastkowski/mcp-emacs --title ... [--body ...]`, capture the printed issue URL, trim, return it.
-- [ ] 1.3 Fallback to `gh api`: `POST /repos/gbastkowski/mcp-emacs/issues` when `gh issue create` is unavailable/fails for a non-content reason; parse the returned URL.
-- [ ] 1.4 Best-effort `kind` label: apply the label when creating the issue; a missing-label error must NOT fail the filing (issue is created regardless).
-- [ ] 1.5 No mechanism available: report failure and return the composed title + body so the caller can file manually.
+- [x] 1.1 Add `mcp-emacs-report-tooling-issue` (new helper, e.g. in `mcp-emacs.el` or a small `mcp-emacs-report.el`): takes title, optional description, optional kind; targets `gbastkowski/mcp-emacs`; byte-compiles clean.
+- [x] 1.2 Filing via `gh` CLI: `call-process gh issue create --repo gbastkowski/mcp-emacs --title ... [--body ...]`, capture the printed issue URL, trim, return it.
+- [x] 1.3 Fallback to `gh api`: `POST /repos/gbastkowski/mcp-emacs/issues` when `gh issue create` is unavailable/fails for a non-content reason; parse the returned URL.
+- [x] 1.4 Best-effort `kind` label: apply the label when creating the issue; a missing-label error must NOT fail the filing (issue is created regardless).
+- [x] 1.5 No mechanism available: report failure and return the composed title + body so the caller can file manually.
 
 ## 2. MCP tool descriptor
 
-- [ ] 2.1 Add a `report_tooling_issue` entry to `mcp-emacs-server--tools`: `:name`, `:description` (scoped to mcp-emacs itself, not arbitrary repos), `:schema` (title required; description optional; kind optional enum bug/feature/skill/server), `:handler` calling the filing helper.
-- [ ] 2.2 Handler validation: reject a missing title and an out-of-set `kind` with a clear message; do not create an issue in those cases.
-- [ ] 2.3 Handler success returns the created issue URL as text; failure returns an error result with the manual-fallback text.
+- [x] 2.1 Add a `report_tooling_issue` entry to `mcp-emacs-server--tools`: `:name`, `:description` (scoped to mcp-emacs itself, not arbitrary repos), `:schema` (title required; description optional; kind optional enum bug/feature/skill/server), `:handler` calling the filing helper.
+- [x] 2.2 Handler validation: reject a missing title and an out-of-set `kind` with a clear message; do not create an issue in those cases.
+- [x] 2.3 Handler success returns the created issue URL as text; failure returns an error result with the manual-fallback text.
 
 ## 3. report-issue skill
 
-- [ ] 3.1 Add `skills/report-issue/SKILL.md` (repo skill location): front matter (name, description, when-to-use — tooling issues about mcp-emacs, not the user's own project).
-- [ ] 3.2 Workflow: classify (server-tool bug / skill-or-prompt issue / feature request) → draft a lean title + what-happened / expected / reproduction body.
-- [ ] 3.3 Filing preference in the skill: prefer the `github` MCP tool if that server is connected; otherwise call `report_tooling_issue` (which itself falls back gh CLI → gh api).
-- [ ] 3.4 Confirmation gate: confirm the drafted issue with the user before filing; if the user declines, file nothing.
-- [ ] 3.5 Report back the resulting issue URL (or, on total failure, the drafted text for manual filing) and which `kind` it was tagged.
+- [x] 3.1 Add `skills/report-issue/SKILL.md` (repo skill location): front matter (name, description, when-to-use — tooling issues about mcp-emacs, not the user's own project).
+- [x] 3.2 Workflow: classify (server-tool bug / skill-or-prompt issue / feature request) → draft a lean title + what-happened / expected / reproduction body.
+- [x] 3.3 Filing preference in the skill: prefer the `github` MCP tool if that server is connected; otherwise call `report_tooling_issue` (which itself falls back gh CLI → gh api).
+- [x] 3.4 Confirmation gate: confirm the drafted issue with the user before filing; if the user declines, file nothing.
+- [x] 3.5 Report back the resulting issue URL (or, on total failure, the drafted text for manual filing) and which `kind` it was tagged.
 
 ## 4. Tests
 
-- [ ] 4.1 Handler validation: missing title rejected; invalid `kind` rejected with accepted-values message; neither creates an issue (drive the handler headlessly, stubbing the filing helper).
-- [ ] 4.2 Fallback chain: with the CLI path stubbed present, filing uses it; with it stubbed absent, filing falls to `gh api`; with all absent, returns the manual-fallback text — assert the order and that the first-available wins.
-- [ ] 4.3 Best-effort label: a simulated missing-label error still yields a created-issue result (issue URL returned, not an error).
-- [ ] 4.4 CI byte-compiles the new elisp and runs the new suite.
+- [x] 4.1 Handler validation: missing title rejected; invalid `kind` rejected with accepted-values message; neither creates an issue (drive the handler headlessly, stubbing the filing helper).
+- [x] 4.2 Fallback chain: with the CLI path stubbed present, filing uses it; with it stubbed absent, filing falls to `gh api`; with all absent, returns the manual-fallback text — assert the order and that the first-available wins.
+- [x] 4.3 Best-effort label: a simulated missing-label error still yields a created-issue result (issue URL returned, not an error).
+- [x] 4.4 CI byte-compiles the new elisp and runs the new suite.
 
 ## 5. Docs
 
-- [ ] 5.1 README: document the `report_tooling_issue` tool and the `report-issue` skill (what they file, the fixed target repo, the `kind` labels, the filing fallback chain).
-- [ ] 5.2 Note the port origin (GitLab tooling feature) and the single-repo / GitHub adaptation (no `get_origin` router). Link issue #26.
+- [x] 5.1 README: document the `report_tooling_issue` tool and the `report-issue` skill (what they file, the fixed target repo, the `kind` labels, the filing fallback chain).
+- [x] 5.2 Note the port origin (GitLab tooling feature) and the single-repo / GitHub adaptation (no `get_origin` router). Link issue #26.
 
 ## 6. Verify
 
-- [ ] 6.1 Live end-to-end: from the running Emacs, invoke `report_tooling_issue` with a test title/kind, confirm a real issue is created on `gbastkowski/mcp-emacs` with the label and the URL is returned; then close the test issue.
+- [x] 6.1 Live end-to-end: from the running Emacs, invoke `report_tooling_issue` with a test title/kind, confirm a real issue is created on `gbastkowski/mcp-emacs` with the label and the URL is returned; then close the test issue.

--- a/openspec/changes/report-tooling-issue/tasks.md
+++ b/openspec/changes/report-tooling-issue/tasks.md
@@ -1,0 +1,37 @@
+## 1. Filing helper (elisp)
+
+- [ ] 1.1 Add `mcp-emacs-report-tooling-issue` (new helper, e.g. in `mcp-emacs.el` or a small `mcp-emacs-report.el`): takes title, optional description, optional kind; targets `gbastkowski/mcp-emacs`; byte-compiles clean.
+- [ ] 1.2 Filing via `gh` CLI: `call-process gh issue create --repo gbastkowski/mcp-emacs --title ... [--body ...]`, capture the printed issue URL, trim, return it.
+- [ ] 1.3 Fallback to `gh api`: `POST /repos/gbastkowski/mcp-emacs/issues` when `gh issue create` is unavailable/fails for a non-content reason; parse the returned URL.
+- [ ] 1.4 Best-effort `kind` label: apply the label when creating the issue; a missing-label error must NOT fail the filing (issue is created regardless).
+- [ ] 1.5 No mechanism available: report failure and return the composed title + body so the caller can file manually.
+
+## 2. MCP tool descriptor
+
+- [ ] 2.1 Add a `report_tooling_issue` entry to `mcp-emacs-server--tools`: `:name`, `:description` (scoped to mcp-emacs itself, not arbitrary repos), `:schema` (title required; description optional; kind optional enum bug/feature/skill/server), `:handler` calling the filing helper.
+- [ ] 2.2 Handler validation: reject a missing title and an out-of-set `kind` with a clear message; do not create an issue in those cases.
+- [ ] 2.3 Handler success returns the created issue URL as text; failure returns an error result with the manual-fallback text.
+
+## 3. report-issue skill
+
+- [ ] 3.1 Add `skills/report-issue/SKILL.md` (repo skill location): front matter (name, description, when-to-use — tooling issues about mcp-emacs, not the user's own project).
+- [ ] 3.2 Workflow: classify (server-tool bug / skill-or-prompt issue / feature request) → draft a lean title + what-happened / expected / reproduction body.
+- [ ] 3.3 Filing preference in the skill: prefer the `github` MCP tool if that server is connected; otherwise call `report_tooling_issue` (which itself falls back gh CLI → gh api).
+- [ ] 3.4 Confirmation gate: confirm the drafted issue with the user before filing; if the user declines, file nothing.
+- [ ] 3.5 Report back the resulting issue URL (or, on total failure, the drafted text for manual filing) and which `kind` it was tagged.
+
+## 4. Tests
+
+- [ ] 4.1 Handler validation: missing title rejected; invalid `kind` rejected with accepted-values message; neither creates an issue (drive the handler headlessly, stubbing the filing helper).
+- [ ] 4.2 Fallback chain: with the CLI path stubbed present, filing uses it; with it stubbed absent, filing falls to `gh api`; with all absent, returns the manual-fallback text — assert the order and that the first-available wins.
+- [ ] 4.3 Best-effort label: a simulated missing-label error still yields a created-issue result (issue URL returned, not an error).
+- [ ] 4.4 CI byte-compiles the new elisp and runs the new suite.
+
+## 5. Docs
+
+- [ ] 5.1 README: document the `report_tooling_issue` tool and the `report-issue` skill (what they file, the fixed target repo, the `kind` labels, the filing fallback chain).
+- [ ] 5.2 Note the port origin (GitLab tooling feature) and the single-repo / GitHub adaptation (no `get_origin` router). Link issue #26.
+
+## 6. Verify
+
+- [ ] 6.1 Live end-to-end: from the running Emacs, invoke `report_tooling_issue` with a test title/kind, confirm a real issue is created on `gbastkowski/mcp-emacs` with the label and the URL is returned; then close the test issue.

--- a/skills/report-issue/SKILL.md
+++ b/skills/report-issue/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: report-issue
+description: Report a bug or feature request about mcp-emacs itself — the MCP server's tools or a plugin skill — as a GitHub issue on gbastkowski/mcp-emacs. Use when the user says a tool, skill, or prompt from this tooling misbehaved, is missing something, or they want it filed as an issue. Not for filing issues in the user's own project repos.
+---
+
+# Report an mcp-emacs tooling issue
+
+Use this when the problem is with **mcp-emacs itself** — a server tool that
+misbehaved, a skill or prompt that read wrong, or a missing feature — and the
+user wants it filed. This is *not* for creating issues in the user's own
+project repositories; for that, file against their repo directly.
+
+Everything is filed on one repo: `gbastkowski/mcp-emacs`. There is no
+fault-domain routing — the category is captured as a label, not a repo choice.
+
+## Workflow
+
+### 1. Classify
+
+Decide what kind of report this is:
+
+- **`server`** — an MCP server tool misbehaved: wrong output, a crash, a bad
+  edit, a tool that did the wrong thing.
+- **`skill`** — a skill or prompt read wrong: clumsy wording, a bad template,
+  a workflow that asked for the wrong thing.
+- **`bug`** — a defect that doesn't cleanly fit server-vs-skill.
+- **`feature`** — a request for something new rather than a defect.
+
+If it's ambiguous, ask **one** short question. Rule of thumb: wrong *result
+from a tool* → `server`; wrong *thing the assistant said or asked* → `skill`.
+
+### 2. Draft
+
+Compose a lean issue:
+
+- **Title** — short and specific.
+- **Body** — What happened / Expected / Reproduction (the exact tool, skill,
+  or prompt involved, and the steps). Keep it tight; skip boilerplate.
+
+### 3. Confirm
+
+Show the drafted title and body to the user and **confirm before filing**. If
+the user doesn't confirm, file nothing.
+
+### 4. File
+
+Prefer whichever mechanism is available, in this order:
+
+1. **The `github` MCP server**, if it's connected — create the issue on
+   `gbastkowski/mcp-emacs` with the `github` tooling directly.
+2. **The `report_tooling_issue` MCP tool** (mcp-emacs) otherwise — pass
+   `title`, `description`, and `kind` (`bug` / `feature` / `skill` /
+   `server`). It files via the `gh` CLI, falling back to `gh api`, and applies
+   `kind` as a label best-effort. It returns `Created issue: <url>`.
+
+If neither can file (no GitHub access at all), `report_tooling_issue` returns
+the composed title and body for manual filing — hand that to the user with the
+`https://github.com/gbastkowski/mcp-emacs/issues/new` link.
+
+### 5. Report back
+
+Tell the user the resulting issue URL (or the manual-filing text if it
+couldn't be filed), and which `kind` it was tagged with.

--- a/test/mcp-emacs-report-test.el
+++ b/test/mcp-emacs-report-test.el
@@ -1,0 +1,90 @@
+(add-to-list 'load-path (expand-file-name "elisp"))
+(require 'mcp-emacs-report)
+(require 'cl-lib)
+
+(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+
+;; --- 4.1 Handler validation --------------------------------------------------
+
+;; Missing title -> user-error, no filing attempted.
+(check "missing-title-errors"
+       (condition-case _ (progn (mcp-emacs-report-tooling-issue "") nil)
+         (user-error t))
+       t)
+
+(check "whitespace-title-errors"
+       (condition-case _ (progn (mcp-emacs-report-tooling-issue "   ") nil)
+         (user-error t))
+       t)
+
+;; Invalid kind -> user-error naming the accepted values.
+(check "invalid-kind-errors"
+       (condition-case e
+           (progn (mcp-emacs-report-tooling-issue "t" "b" "nonsense") nil)
+         (user-error (and (string-match-p "bug" (error-message-string e)) t)))
+       t)
+
+;; A valid kind passes validation (still no real filing -- gh stubbed absent).
+(cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () nil)))
+  (check "valid-kind-accepted"
+         (condition-case _
+             (progn (mcp-emacs-report-tooling-issue "t" "b" "feature") t)
+           (user-error nil))
+         t))
+
+;; --- 4.2 Fallback chain ------------------------------------------------------
+
+;; gh present + CLI succeeds -> CLI URL used, api-create never called.
+(let ((api-called nil))
+  (cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () t))
+            ((symbol-function 'mcp-emacs-report--create-via-cli)
+             (lambda (_title _body) "https://github.com/gbastkowski/mcp-emacs/issues/1"))
+            ((symbol-function 'mcp-emacs-report--api-create)
+             (lambda (_title _body) (setq api-called t) nil))
+            ((symbol-function 'mcp-emacs-report--apply-label) (lambda (&rest _) nil)))
+    (check "cli-success-uses-cli"
+           (mcp-emacs-report-tooling-issue "t" "b")
+           "Created issue: https://github.com/gbastkowski/mcp-emacs/issues/1")
+    (check "cli-success-skips-api" api-called nil)))
+
+;; gh present + CLI fails -> falls to api-create.
+(cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () t))
+          ((symbol-function 'mcp-emacs-report--create-via-cli) (lambda (_t _b) nil))
+          ((symbol-function 'mcp-emacs-report--api-create)
+           (lambda (_t _b) "https://github.com/gbastkowski/mcp-emacs/issues/2"))
+          ((symbol-function 'mcp-emacs-report--apply-label) (lambda (&rest _) nil)))
+  (check "cli-fail-falls-to-api"
+         (mcp-emacs-report-tooling-issue "t" "b")
+         "Created issue: https://github.com/gbastkowski/mcp-emacs/issues/2"))
+
+;; gh absent -> manual fallback text, neither create path called.
+(let ((cli-called nil) (api-called nil))
+  (cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () nil))
+            ((symbol-function 'mcp-emacs-report--create-via-cli)
+             (lambda (_t _b) (setq cli-called t) nil))
+            ((symbol-function 'mcp-emacs-report--api-create)
+             (lambda (_t _b) (setq api-called t) nil)))
+    (let ((out (mcp-emacs-report-tooling-issue "My title" "Body here")))
+      (check "no-gh-manual-fallback"
+             (and (string-match-p "manually" out)
+                  (string-match-p "My title" out)
+                  (string-match-p "Body here" out) t)
+             t)
+      (check "no-gh-skips-cli" cli-called nil)
+      (check "no-gh-skips-api" api-called nil))))
+
+;; --- 4.3 Best-effort label ---------------------------------------------------
+
+;; A failing label call still yields a created-issue result (not an error).
+;; Stub the low-level runner so the real `--apply-label' ignore-errors path
+;; is exercised, not bypassed.
+(cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () t))
+          ((symbol-function 'mcp-emacs-report--create-via-cli)
+           (lambda (_t _b) "https://github.com/gbastkowski/mcp-emacs/issues/3"))
+          ((symbol-function 'mcp-emacs-report--run)
+           (lambda (&rest _) (error "label does not exist"))))
+  (check "missing-label-still-creates"
+         (condition-case _
+             (mcp-emacs-report-tooling-issue "t" "b" "server")
+           (error "ERRORED"))
+         "Created issue: https://github.com/gbastkowski/mcp-emacs/issues/3"))


### PR DESCRIPTION
OpenSpec change porting the sibling GitLab tooling's "report a tooling issue" feature to mcp-emacs, adapted to a single **GitHub** repo.

Adds a `report_tooling_issue` MCP tool (files a GitHub issue on `gbastkowski/mcp-emacs` via GitHub MCP → `gh` CLI → `gh api`, with an optional `kind` label) and a `report-issue` skill (classify → draft → confirm → file → report URL). The GitLab feature's `get_origin` fault-domain router is dropped — mcp-emacs is one repo, so the `kind` label carries the server-vs-skill signal instead.

Planning foundation (proposal, spec, design, tasks); implementation follows on the same branch.

Closes #26.