### PR TITLE
orgspec MVP: model, parser, fold, commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,12 @@ jobs:
             --eval "(package-initialize)" \
             -L elisp \
             -f batch-byte-compile \
-            elisp/mcp-emacs.el elisp/mcp-emacs-report.el elisp/mcp-emacs-server.el elisp/mcp-emacs-ide.el elisp/mcp-emacs-remote.el
+            elisp/mcp-emacs.el elisp/mcp-emacs-report.el elisp/mcp-emacs-server.el elisp/mcp-emacs-ide.el elisp/mcp-emacs-remote.el \
+            elisp/orgspec-model.el elisp/orgspec.el elisp/orgspec-parse.el elisp/orgspec-fold.el elisp/orgspec-commands.el
 
       - name: Run tests
         run: |
-          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el test/mcp-emacs-report-test.el test/mcp-emacs-remote-test.el; do
+          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el test/mcp-emacs-report-test.el test/mcp-emacs-remote-test.el test/orgspec-fold-spike-test.el test/orgspec-parse-test.el test/orgspec-fold-test.el; do
             echo "== $t =="
             emacs --batch \
               --eval "(require 'package)" \

--- a/elisp/mcp-emacs-ide.el
+++ b/elisp/mcp-emacs-ide.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-ide.el --- Claude Code IDE integration for mcp-emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.4.0
+;; Version: 1.5.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs-remote.el
+++ b/elisp/mcp-emacs-remote.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-remote.el --- Remote-control an interactive Claude from Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.4.0
+;; Version: 1.5.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs-report.el
+++ b/elisp/mcp-emacs-report.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-report.el --- Report tooling issues about mcp-emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.4.0
+;; Version: 1.5.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs-run.el
+++ b/elisp/mcp-emacs-run.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-run.el --- Run the Claude Code CLI inside Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.4.0
+;; Version: 1.5.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs-server.el
+++ b/elisp/mcp-emacs-server.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs-server.el --- HTTP MCP server running inside Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.4.0
+;; Version: 1.5.0
 ;; Package-Requires: ((emacs "28.1") (web-server "0.1.2"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/mcp-emacs.el
+++ b/elisp/mcp-emacs.el
@@ -1,7 +1,7 @@
 ;;; mcp-emacs.el --- Helper functions for MCP Emacs -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.4.0
+;; Version: 1.5.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/opencode-client.el
+++ b/elisp/opencode-client.el
@@ -1,7 +1,7 @@
 ;;; opencode-client.el --- Native Emacs client for the opencode HTTP API -*- lexical-binding: t; -*-
 
 ;; Author: Gunnar Bastkowski
-;; Version: 1.4.0
+;; Version: 1.5.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools
 ;; URL: https://github.com/gbastkowski/mcp-emacs

--- a/elisp/orgspec-commands.el
+++ b/elisp/orgspec-commands.el
@@ -1,0 +1,184 @@
+;;; orgspec-commands.el --- Interactive orgspec verbs  -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; The orgspec command verbs (issue #5, step 6): `new', `status', `archive'.
+;; MVP-drivable through mcp-emacs' `eval' tool -- e.g. (orgspec-archive "id").
+;;
+;; Layout under the orgspec root (default `orgspec/'):
+;;   orgspec/specs/<area>.org           accumulating source of truth
+;;   orgspec/changes/<id>/change.org    a change (human sections + `* Delta')
+;;   orgspec/changes/archive/<id>/      archived changes
+;;
+;; `archive' folds a change's delta into the specs with the same
+;; validate-all-then-write-all discipline `orgspec-fold-area' gives per area:
+;; every target spec is rebuilt in memory and the whole set is only written
+;; once all folds succeed, so a late failure leaves `specs/' untouched.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'orgspec)
+(require 'orgspec-model)
+(require 'orgspec-parse)
+(require 'orgspec-fold)
+
+(defcustom orgspec-root "orgspec"
+  "Directory (relative to the project root) holding specs and changes."
+  :type 'string :group 'orgspec)
+
+(defun orgspec-commands--root ()
+  "Return the absolute orgspec root for the current project."
+  (let ((base (or (and (fboundp 'project-current)
+                       (when-let ((p (project-current nil)))
+                         (project-root p)))
+                  default-directory)))
+    (expand-file-name orgspec-root base)))
+
+(defun orgspec-commands--changes-dir () (expand-file-name "changes" (orgspec-commands--root)))
+(defun orgspec-commands--specs-dir () (expand-file-name "specs" (orgspec-commands--root)))
+(defun orgspec-commands--change-file (id)
+  (expand-file-name (format "changes/%s/change.org" id) (orgspec-commands--root)))
+(defun orgspec-commands--spec-file (area)
+  (expand-file-name (format "specs/%s.org" area) (orgspec-commands--root)))
+
+;;;; new
+
+(defconst orgspec-commands--change-template "\
+#+TITLE: %s
+
+* Intent
+* Scope
+* Approach
+* Tasks
+- [ ] first task
+
+* Delta
+")
+
+;;;###autoload
+(defun orgspec-new (id)
+  "Scaffold a new change ID under the orgspec changes directory.
+Creates changes/ID/change.org from the template.  Returns the file path."
+  (interactive "sChange id: ")
+  (let ((file (orgspec-commands--change-file id)))
+    (when (file-exists-p file)
+      (user-error "Change %s already exists" id))
+    (make-directory (file-name-directory file) t)
+    (with-temp-file file
+      (insert (format orgspec-commands--change-template id)))
+    file))
+
+;;;; status
+
+(defun orgspec-commands--count-tasks (file)
+  "Return (DONE . TOTAL) checkbox counts in change FILE."
+  (let ((done 0) (total 0))
+    (when (file-exists-p file)
+      (with-temp-buffer
+        (insert-file-contents file)
+        (goto-char (point-min))
+        (while (re-search-forward "^[ \t]*- \\[\\([ xX]\\)\\]" nil t)
+          (setq total (1+ total))
+          (unless (equal (match-string 1) " ") (setq done (1+ done))))))
+    (cons done total)))
+
+;;;###autoload
+(defun orgspec-status (&optional id)
+  "Report task completion for change ID, or all active changes.
+Returns an alist (ID (DONE . TOTAL) ...); as a command, messages it."
+  (interactive)
+  (let* ((dir (orgspec-commands--changes-dir))
+         (ids (if id (list id)
+                (when (file-directory-p dir)
+                  (seq-filter
+                   (lambda (n) (and (not (member n '("." ".." "archive")))
+                                    (file-directory-p (expand-file-name n dir))))
+                   (directory-files dir)))))
+         (result (mapcar
+                  (lambda (i)
+                    (cons i (orgspec-commands--count-tasks
+                             (orgspec-commands--change-file i))))
+                  ids)))
+    (when (called-interactively-p 'interactive)
+      (message "%s"
+               (mapconcat (lambda (c) (format "%s: %d/%d done"
+                                              (car c) (cadr c) (cddr c)))
+                          result "  ")))
+    result))
+
+;;;; archive
+
+(defun orgspec-commands--read-change (id)
+  "Parse change ID's change.org into an `orgspec-change'."
+  (let ((file (orgspec-commands--change-file id)))
+    (unless (file-exists-p file)
+      (user-error "No change file for %s" id))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (let ((org-inhibit-startup t)) (org-mode))
+      (orgspec-parse-change id))))
+
+(defun orgspec-commands--assert-no-clarifications (id)
+  "Signal a `user-error' if change ID still has a NEEDS CLARIFICATION marker."
+  (let ((file (orgspec-commands--change-file id)))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (goto-char (point-min))
+      (when (re-search-forward orgspec-clarification-regexp nil t)
+        (user-error "Change %s has an unresolved [NEEDS CLARIFICATION] marker" id)))))
+
+;;;###autoload
+(defun orgspec-archive (id)
+  "Fold change ID's delta into the specs, then move the change to archive.
+Validate-all-then-write-all: every affected spec is rebuilt in memory and
+only written once all folds succeed, so a failure leaves specs/ untouched.
+Uses `git mv' to archive the change when the project is a git repo, else a
+plain rename.  Returns the list of spec files written."
+  (interactive "sChange id to archive: ")
+  (orgspec-commands--assert-no-clarifications id)
+  (let* ((change (orgspec-commands--read-change id))
+         (reqs (orgspec-change-requirements change))
+         (groups (orgspec-fold--group-by-area reqs))
+         built)
+    (unless reqs
+      (user-error "Change %s has no delta requirements" id))
+    ;; Build every target spec in memory first (validate-all).
+    (dolist (group groups)
+      (let* ((area (car group))
+             (file (orgspec-commands--spec-file area))
+             (current (when (file-exists-p file)
+                        (with-temp-buffer (insert-file-contents file)
+                                          (buffer-string)))))
+        (push (cons file (orgspec-fold-area current (cdr group))) built)))
+    ;; Write every target (write-all) only after all folds succeeded.
+    (dolist (cell built)
+      (make-directory (file-name-directory (car cell)) t)
+      (with-temp-file (car cell) (insert (cdr cell))))
+    ;; Move the change into archive.
+    (orgspec-commands--archive-move id)
+    (nreverse (mapcar #'car built))))
+
+(defun orgspec-commands--archive-move (id)
+  "Move change ID's directory into changes/archive/, via `git mv' if possible."
+  (let* ((src (expand-file-name id (orgspec-commands--changes-dir)))
+         (archive (expand-file-name "archive" (orgspec-commands--changes-dir)))
+         (dst (expand-file-name id archive)))
+    (make-directory archive t)
+    (if (and (executable-find "git")
+             (zerop (call-process "git" nil nil nil "-C"
+                                  (file-name-directory (directory-file-name src))
+                                  "rev-parse" "--is-inside-work-tree")))
+        (unless (zerop (call-process "git" nil nil nil "mv" src dst))
+          (rename-file src dst))
+      (rename-file src dst))))
+
+(provide 'orgspec-commands)
+;;; orgspec-commands.el ends here

--- a/elisp/orgspec-fold.el
+++ b/elisp/orgspec-fold.el
@@ -1,0 +1,173 @@
+;;; orgspec-fold.el --- Fold a change delta into the spec files  -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; The fold: apply a change's delta requirements to the accumulating spec
+;; files.  This is the load-bearing OpenSpec port (issue #5).
+;;
+;; Design, all ported from OpenSpec / the fold spike:
+;; - Apply order is fixed: RENAMED -> REMOVED -> MODIFIED -> ADDED.
+;; - Subtree surgery on org buffers, not text splicing: cut a delta
+;;   requirement (stored L2 under `* Delta') and `org-paste-subtree'-it into
+;;   the spec at L1, letting org re-level the whole subtree; then strip the
+;;   TODO keyword, the op tag, and the `:AREA:' routing property, and keep the
+;;   `:IMPL:' drawer.  (Proven in test/orgspec-fold-spike-test.el.)
+;; - Validate-all-then-write-all: every target spec is built in a temp buffer
+;;   and the whole set validated before anything is written, so a late failure
+;;   leaves the on-disk specs untouched.
+;; - MODIFIED must not silently drop a scenario present in the current spec
+;;   requirement (port of OpenSpec's findMissingCurrentScenarios) -- a dropped
+;;   scenario is an error, not a silent loss.
+
+;;; Code:
+
+(require 'org)
+(require 'cl-lib)
+(require 'orgspec)
+(require 'orgspec-model)
+(require 'orgspec-parse)
+
+(define-error 'orgspec-fold-error "orgspec fold error")
+
+(defun orgspec-fold--group-by-area (requirements)
+  "Group REQUIREMENTS by their `:AREA:'; return an alist (AREA . REQS).
+Signals `orgspec-fold-error' if any requirement has no area."
+  (let (groups)
+    (dolist (req requirements)
+      (let ((area (orgspec-requirement-area req)))
+        (unless area
+          (signal 'orgspec-fold-error
+                  (list (format "requirement %S has no :AREA:"
+                                (orgspec-requirement-name req)))))
+        (let ((cell (assoc area groups)))
+          (if cell (setcdr cell (cons req (cdr cell)))
+            (push (cons area (list req)) groups)))))
+    (mapcar (lambda (cell) (cons (car cell) (nreverse (cdr cell)))) groups)))
+
+(defun orgspec-fold--find-requirement (name)
+  "Move point to the L1 spec requirement headline named NAME; return non-nil.
+Point is left on the headline.  Returns nil and does not move if absent."
+  (let ((found nil) (pos (point)))
+    (goto-char (point-min))
+    (while (and (not found)
+                (re-search-forward "^\\* \\(.*\\)$" nil t))
+      (when (equal (string-trim (match-string 1)) name)
+        (org-back-to-heading t)
+        (setq found (point))))
+    (unless found (goto-char pos))
+    found))
+
+(defun orgspec-fold--scenario-names-at-point ()
+  "Return the L2 scenario headline names under the L1 requirement at point."
+  (save-excursion
+    (org-back-to-heading t)
+    (let ((end (save-excursion (org-end-of-subtree t t)))
+          names)
+      (forward-line 1)
+      (while (re-search-forward "^\\*\\* \\(.*\\)$" end t)
+        (push (string-trim (match-string 1)) names))
+      (nreverse names))))
+
+(defun orgspec-fold--clean-pasted ()
+  "Clean the requirement subtree at point after a fold paste.
+Strip the TODO keyword, the op tag, and the `:AREA:' routing property;
+keep the `:IMPL:' drawer.  Point must be on the requirement headline."
+  (org-back-to-heading t)
+  (org-todo 'none)
+  (org-set-tags nil)
+  (org-entry-delete (point) orgspec-area-property))
+
+(defun orgspec-fold--paste-requirement (req)
+  "Paste delta requirement REQ into the current spec buffer at L1, cleaned.
+Point should be where the requirement is to land (end of buffer for an
+add).  REQ's subtree text is taken from its stored source region."
+  (org-paste-subtree 1 (orgspec-requirement-source req))
+  (save-excursion
+    (org-back-to-heading t)
+    (orgspec-fold--clean-pasted)))
+
+;;;; Per-op application (operate on the current spec buffer)
+
+(defun orgspec-fold--apply-renamed (req)
+  "Rename the spec requirement from REQ's `:FROM:' to REQ's name."
+  (let ((from (orgspec-requirement-from req))
+        (to (orgspec-requirement-name req)))
+    (unless from
+      (signal 'orgspec-fold-error
+              (list (format "renamed %S has no :FROM:" to))))
+    (unless (orgspec-fold--find-requirement from)
+      (signal 'orgspec-fold-error
+              (list (format "renamed source %S not found" from))))
+    (org-edit-headline to)))
+
+(defun orgspec-fold--apply-removed (req)
+  "Remove the spec requirement named by REQ."
+  (let ((name (orgspec-requirement-name req)))
+    (unless (orgspec-fold--find-requirement name)
+      (signal 'orgspec-fold-error
+              (list (format "removed target %S not found" name))))
+    (org-cut-subtree)))
+
+(defun orgspec-fold--apply-modified (req)
+  "Replace the spec requirement named by REQ, guarding against scenario loss.
+The MODIFIED delta must carry every scenario the current spec requirement
+has; a dropped scenario signals `orgspec-fold-error'."
+  (let ((name (orgspec-requirement-name req)))
+    (unless (orgspec-fold--find-requirement name)
+      (signal 'orgspec-fold-error
+              (list (format "modified target %S not found" name))))
+    (let* ((current (orgspec-fold--scenario-names-at-point))
+           (incoming (mapcar #'orgspec-scenario-name
+                             (orgspec-requirement-scenarios req)))
+           (missing (seq-remove (lambda (s) (member s incoming)) current)))
+      (when missing
+        (signal 'orgspec-fold-error
+                (list (format "modified %S drops scenario(s): %s"
+                              name (string-join missing ", "))))))
+    (org-cut-subtree)
+    (orgspec-fold--paste-requirement req)))
+
+(defun orgspec-fold--apply-added (req)
+  "Append the ADDED requirement REQ to the end of the current spec buffer.
+Signals if a requirement of the same name already exists."
+  (let ((name (orgspec-requirement-name req)))
+    (when (orgspec-fold--find-requirement name)
+      (signal 'orgspec-fold-error
+              (list (format "added %S already exists in spec" name))))
+    (goto-char (point-max))
+    (orgspec-fold--paste-requirement req)))
+
+(defun orgspec-fold--apply-one (req)
+  "Apply a single delta requirement REQ to the current spec buffer."
+  (pcase (orgspec-requirement-op req)
+    ('renamed (orgspec-fold--apply-renamed req))
+    ('removed (orgspec-fold--apply-removed req))
+    ('modified (orgspec-fold--apply-modified req))
+    ('added (orgspec-fold--apply-added req))
+    (op (signal 'orgspec-fold-error (list (format "unknown op %S" op))))))
+
+(defun orgspec-fold-area (spec-text requirements)
+  "Return the new spec text for one area.
+SPEC-TEXT is the current on-disk spec (empty string for a new area).
+REQUIREMENTS is the area's delta requirements.  Applies the four ops in
+`orgspec-fold-order'.  Pure: builds the result in a temp buffer and
+returns the string; writes nothing."
+  (with-temp-buffer
+    (let ((org-inhibit-startup t)) (org-mode))
+    (insert (or spec-text ""))
+    (dolist (op orgspec-fold-order)
+      (dolist (req requirements)
+        (when (eq (orgspec-requirement-op req) op)
+          (goto-char (point-min))
+          (orgspec-fold--apply-one req))))
+    (buffer-string)))
+
+(provide 'orgspec-fold)
+;;; orgspec-fold.el ends here

--- a/elisp/orgspec-model.el
+++ b/elisp/orgspec-model.el
@@ -1,0 +1,61 @@
+;;; orgspec-model.el --- Data model for orgspec  -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; The three structures the orgspec parser produces and the fold/validator
+;; consume: a scenario, a requirement, and a change.  See issue #5.
+;;
+;; Identity rules (issue #5, "Grammar gotchas"):
+;; - Requirement identity is its exact headline text; renames are handled via
+;;   the `:FROM:' property (captured in `orgspec-requirement-from').
+;; - Scenario identity is its headline text (used by the MODIFIED drop guard).
+
+;;; Code:
+
+(require 'cl-lib)
+
+(cl-defstruct (orgspec-scenario (:constructor orgspec-scenario-create))
+  "One scenario under a requirement.
+NAME is the scenario headline text (its identity).  BODY is the raw
+GIVEN/WHEN/THEN text, kept verbatim -- orgspec counts scenario headlines,
+not their body lines."
+  name
+  body)
+
+(cl-defstruct (orgspec-requirement (:constructor orgspec-requirement-create))
+  "One requirement, in a change delta or in a spec.
+NAME is the headline text (identity).  OP is the delta operation keyword
+\(`added' / `modified' / `removed' / `renamed', from the org op tag) or nil
+for a plain spec requirement.  AREA is the target spec name (from the
+`:AREA:' property).  FROM is the previous name for a rename (from `:FROM:').
+BODY is the requirement prose (must carry SHALL/MUST for ADDED/MODIFIED).
+SCENARIOS is a list of `orgspec-scenario'.  IMPL is the list of raw
+traceability entries from the `:IMPL:' drawer, kept through the fold.
+SOURCE is the requirement's raw org subtree text, used verbatim by the
+fold's `org-paste-subtree' (so the pasted content matches the change file
+exactly, drawers and all)."
+  name
+  op
+  area
+  from
+  body
+  (scenarios nil)
+  (impl nil)
+  source)
+
+(cl-defstruct (orgspec-change (:constructor orgspec-change-create))
+  "A parsed change: its id and the delta requirements it carries.
+ID is the change directory name.  REQUIREMENTS is a list of
+`orgspec-requirement', each with a non-nil OP."
+  id
+  (requirements nil))
+
+(provide 'orgspec-model)
+;;; orgspec-model.el ends here

--- a/elisp/orgspec-parse.el
+++ b/elisp/orgspec-parse.el
@@ -1,0 +1,129 @@
+;;; orgspec-parse.el --- Parse orgspec change/spec buffers into the model  -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Extract the orgspec model from org buffers using `org-element'.  Going
+;; org-native removes the two hardest OpenSpec ports: `org-element' already
+;; sees code blocks/drawers and headline levels correctly, so there is no
+;; code-fence mask and no hand-rolled section-tree parser (issue #5).
+;;
+;; Two entry points:
+;; - `orgspec-parse-change'  : a change buffer's `* Delta' subtree ->
+;;                             `orgspec-change' (L2 requirements, L3 scenarios).
+;; - `orgspec-parse-spec'    : a spec buffer -> list of `orgspec-requirement'
+;;                             (L1 requirements, L2 scenarios, no op).
+
+;;; Code:
+
+(require 'org)
+(require 'org-element)
+(require 'orgspec)
+(require 'orgspec-model)
+
+(defun orgspec-parse--section-elements (headline)
+  "Return the elements in HEADLINE's own section (its direct prose/drawers).
+`org-element' nests a headline's non-headline content under a `section'
+element; descend into it so paragraphs and drawers are visible."
+  (let ((section (seq-find (lambda (el) (eq (org-element-type el) 'section))
+                           (org-element-contents headline))))
+    (and section (org-element-contents section))))
+
+(defun orgspec-parse--body (headline)
+  "Return the plain paragraph text directly under HEADLINE, trimmed.
+Excludes child headlines, drawers, and property drawers -- just the
+requirement/scenario prose."
+  (let ((parts '()))
+    (dolist (el (orgspec-parse--section-elements headline))
+      (when (memq (org-element-type el) '(paragraph plain-list))
+        (push (string-trim
+               (buffer-substring-no-properties
+                (org-element-property :contents-begin el)
+                (org-element-property :contents-end el)))
+              parts)))
+    (string-trim (string-join (nreverse parts) "\n"))))
+
+(defun orgspec-parse--impl (headline)
+  "Return the list of non-empty lines in HEADLINE's IMPL drawer, or nil."
+  (let (lines)
+    (dolist (el (orgspec-parse--section-elements headline))
+      (when (and (eq (org-element-type el) 'drawer)
+                 (equal (org-element-property :drawer-name el)
+                        orgspec-impl-drawer))
+        (setq lines
+              (seq-remove
+               #'string-empty-p
+               (mapcar #'string-trim
+                       (split-string
+                        (buffer-substring-no-properties
+                         (org-element-property :contents-begin el)
+                         (org-element-property :contents-end el))
+                        "\n" t))))))
+    lines))
+
+(defun orgspec-parse--scenarios (headline)
+  "Return the list of `orgspec-scenario' for the child headlines of HEADLINE."
+  (let (scenarios)
+    (dolist (child (org-element-contents headline))
+      (when (eq (org-element-type child) 'headline)
+        (push (orgspec-scenario-create
+               :name (org-element-property :raw-value child)
+               :body (orgspec-parse--body child))
+              scenarios)))
+    (nreverse scenarios)))
+
+(defun orgspec-parse--requirement (headline)
+  "Build an `orgspec-requirement' from a requirement HEADLINE element.
+Reads the op from the headline tags, AREA/FROM from properties, the IMPL
+drawer, the body prose, and the child scenarios."
+  (orgspec-requirement-create
+   :name (org-element-property :raw-value headline)
+   :op (orgspec-op-from-tags (org-element-property :tags headline))
+   :area (org-element-property
+          (intern (concat ":" orgspec-area-property)) headline)
+   :from (org-element-property
+          (intern (concat ":" orgspec-from-property)) headline)
+   :body (orgspec-parse--body headline)
+   :scenarios (orgspec-parse--scenarios headline)
+   :impl (orgspec-parse--impl headline)
+   :source (buffer-substring-no-properties
+            (org-element-property :begin headline)
+            (org-element-property :end headline))))
+
+(defun orgspec-parse-change (&optional id)
+  "Parse the current buffer's `* Delta' subtree into an `orgspec-change'.
+ID names the change (its directory).  Delta requirements are the level-2
+headlines under the top-level `Delta' headline; their scenarios are the
+level-3 children."
+  (let ((tree (org-element-parse-buffer))
+        requirements)
+    (org-element-map tree 'headline
+      (lambda (hl)
+        (when (and (= (org-element-property :level hl) 1)
+                   (equal (org-element-property :raw-value hl) "Delta"))
+          (dolist (child (org-element-contents hl))
+            (when (eq (org-element-type child) 'headline)
+              (push (orgspec-parse--requirement child) requirements))))))
+    (orgspec-change-create :id id
+                           :requirements (nreverse requirements))))
+
+(defun orgspec-parse-spec ()
+  "Parse the current buffer as a spec into a list of `orgspec-requirement'.
+Requirements are the level-1 headlines; scenarios their level-2 children.
+Spec requirements carry no op."
+  (let ((tree (org-element-parse-buffer))
+        requirements)
+    (org-element-map tree 'headline
+      (lambda (hl)
+        (when (= (org-element-property :level hl) 1)
+          (push (orgspec-parse--requirement hl) requirements))))
+    (nreverse requirements)))
+
+(provide 'orgspec-parse)
+;;; orgspec-parse.el ends here

--- a/elisp/orgspec.el
+++ b/elisp/orgspec.el
@@ -1,0 +1,95 @@
+;;; orgspec.el --- Org-native spec workflow (OpenSpec-inspired)  -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; orgspec is a thin, org-native, dependency-free port of the load-bearing
+;; core of OpenSpec: a structure parser, a delta-fold, and (later) a
+;; validator, living in Emacs and exposed to agents through mcp-emacs.  See
+;; issue #5 for the full design.
+;;
+;; This file holds the marker table -- the single place that names the delta
+;; op tags, the routing/traceability properties, the clarification and RFC-2119
+;; regexes, and the TODO-role mapping -- so nothing downstream hardcodes a
+;; marker or a headline depth.
+
+;;; Code:
+
+(defgroup orgspec nil
+  "Org-native spec workflow."
+  :group 'tools)
+
+;;;; Delta op tags
+
+(defconst orgspec-op-tags
+  '(("ADDED" . added)
+    ("MODIFIED" . modified)
+    ("REMOVED" . removed)
+    ("RENAMED" . renamed))
+  "Alist mapping the org op tag (as written on a delta headline) to a symbol.
+Each delta requirement headline in a change file is tagged with exactly
+one of these.")
+
+(defun orgspec-op-from-tags (tags)
+  "Return the orgspec op symbol found among TAGS, or nil.
+TAGS is a list of org tag strings (as from `org-get-tags')."
+  (seq-some (lambda (cell) (and (member (car cell) tags) (cdr cell)))
+            orgspec-op-tags))
+
+(defun orgspec-op-tag-name (op)
+  "Return the org tag string for op symbol OP, or nil."
+  (car (rassq op orgspec-op-tags)))
+
+;;;; Properties and drawers
+
+(defconst orgspec-area-property "AREA"
+  "Org property naming the target spec file for a delta requirement.
+Stripped from the requirement when it is folded into a spec -- it is
+routing metadata, not durable spec content.")
+
+(defconst orgspec-from-property "FROM"
+  "Org property giving a renamed requirement's previous name.")
+
+(defconst orgspec-impl-drawer "IMPL"
+  "Org drawer holding requirement->code traceability links.
+Kept when a requirement is folded into a spec -- durable provenance.")
+
+;;;; Regexes
+
+(defconst orgspec-clarification-regexp
+  "\\[NEEDS CLARIFICATION:[^]]*\\]"
+  "Regexp for an unresolved clarification marker.
+Its presence blocks `apply'/`archive' until resolved.")
+
+(defconst orgspec-normative-regexp
+  "\\<\\(SHALL\\|MUST\\)\\>"
+  "Regexp for an RFC-2119 normative keyword.
+An ADDED/MODIFIED requirement body must contain one (validator rule).")
+
+;;;; TODO-role mapping (issue #5 agenda lifecycle; used by MVP+)
+
+(defcustom orgspec-todo-blocked "WAIT"
+  "TODO keyword meaning a requirement is blocked on a clarification."
+  :type 'string :group 'orgspec)
+
+(defcustom orgspec-todo-active "STRT"
+  "TODO keyword meaning `apply' is currently working a requirement."
+  :type 'string :group 'orgspec)
+
+(defcustom orgspec-todo-removed "KILL"
+  "TODO keyword corresponding to a `:REMOVED:' requirement."
+  :type 'string :group 'orgspec)
+
+;;;; Fold apply order (OpenSpec parity)
+
+(defconst orgspec-fold-order '(renamed removed modified added)
+  "Fixed order in which delta ops are applied during a fold.")
+
+(provide 'orgspec)
+;;; orgspec.el ends here

--- a/test/orgspec-fold-test.el
+++ b/test/orgspec-fold-test.el
@@ -1,0 +1,167 @@
+(add-to-list 'load-path (expand-file-name "elisp"))
+(require 'orgspec-parse)
+(require 'orgspec-fold)
+
+(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+
+;; Parse a `* Delta' change string into its requirements (in order).
+(defun fold-test--reqs (change)
+  (with-temp-buffer
+    (let ((org-inhibit-startup t)) (org-mode))
+    (insert change)
+    (orgspec-change-requirements (orgspec-parse-change "t"))))
+
+;; --- ADDED: new requirement appended, cleaned -------------------------------
+
+(let* ((delta "* Delta
+** TODO New thing                                    :ADDED:
+:PROPERTIES:
+:AREA: auth
+:END:
+The system SHALL do the new thing.
+*** New scenario
+- GIVEN a
+- WHEN b
+- THEN c
+")
+       (out (orgspec-fold-area "" (fold-test--reqs delta))))
+  (check "added-requirement-L1" (and (string-match-p "^\\* New thing" out) t) t)
+  (check "added-scenario-L2" (and (string-match-p "^\\*\\* New scenario" out) t) t)
+  (check "added-todo-stripped" (string-match-p "\\* TODO " out) nil)
+  (check "added-op-tag-dropped" (string-match-p ":ADDED:" out) nil)
+  (check "added-area-stripped" (string-match-p ":AREA:" out) nil)
+  (check "added-shall-kept" (and (string-match-p "SHALL" out) t) t))
+
+;; --- ADDED with IMPL drawer kept --------------------------------------------
+
+(let* ((delta "* Delta
+** New thing                                         :ADDED:
+:PROPERTIES:
+:AREA: auth
+:END:
+:IMPL:
+[[file:auth.el::x][x]]
+:END:
+The system SHALL do it.
+*** S
+- GIVEN a
+- WHEN b
+- THEN c
+")
+       (out (orgspec-fold-area "" (fold-test--reqs delta))))
+  (check "added-impl-kept" (and (string-match-p ":IMPL:" out) t) t))
+
+;; --- REMOVED: existing requirement deleted ----------------------------------
+
+(let* ((spec "* Keep me
+The system SHALL stay.
+** S1
+- GIVEN a
+* Drop me
+The system SHALL go.
+** S2
+- GIVEN a
+")
+       (delta "* Delta
+** Drop me                                           :REMOVED:
+:PROPERTIES:
+:AREA: auth
+:END:
+Removed.
+")
+       (out (orgspec-fold-area spec (fold-test--reqs delta))))
+  (check "removed-gone" (string-match-p "Drop me" out) nil)
+  (check "removed-keeps-others" (and (string-match-p "^\\* Keep me" out) t) t))
+
+;; --- RENAMED: headline renamed via :FROM: -----------------------------------
+
+(let* ((spec "* Old name
+The system SHALL exist.
+** S1
+- GIVEN a
+")
+       (delta "* Delta
+** New name                                          :RENAMED:
+:PROPERTIES:
+:AREA: auth
+:FROM: Old name
+:END:
+Renamed.
+")
+       (out (orgspec-fold-area spec (fold-test--reqs delta))))
+  (check "renamed-to-new" (and (string-match-p "^\\* New name" out) t) t)
+  (check "renamed-old-gone" (string-match-p "^\\* Old name" out) nil))
+
+;; --- MODIFIED: replace, keeping all current scenarios -----------------------
+
+(let* ((spec "* Feature
+The system SHALL do old.
+** Keep scenario
+- GIVEN a
+")
+       (delta "* Delta
+** Feature                                           :MODIFIED:
+:PROPERTIES:
+:AREA: auth
+:END:
+The system SHALL do new and improved.
+*** Keep scenario
+- GIVEN a
+*** Extra scenario
+- GIVEN b
+")
+       (out (orgspec-fold-area spec (fold-test--reqs delta))))
+  (check "modified-body-updated" (and (string-match-p "new and improved" out) t) t)
+  (check "modified-old-body-gone" (string-match-p "SHALL do old" out) nil)
+  (check "modified-keeps-scenario" (and (string-match-p "Keep scenario" out) t) t)
+  (check "modified-adds-scenario" (and (string-match-p "Extra scenario" out) t) t))
+
+;; --- MODIFIED drop-guard: dropping a current scenario is an error -----------
+
+(let* ((spec "* Feature
+The system SHALL do it.
+** Important scenario
+- GIVEN a
+")
+       (delta "* Delta
+** Feature                                           :MODIFIED:
+:PROPERTIES:
+:AREA: auth
+:END:
+The system SHALL do it differently.
+*** Different scenario
+- GIVEN b
+"))
+  (check "modified-drop-guard-signals"
+         (condition-case _
+             (progn (orgspec-fold-area spec (fold-test--reqs delta)) nil)
+           (orgspec-fold-error t))
+         t))
+
+;; --- Fixed apply order: REMOVED before ADDED (same name reused) -------------
+
+(let* ((spec "* Thing
+The system SHALL do v1.
+** S
+- GIVEN a
+")
+       ;; Remove old Thing, then add a new Thing with the same name. Order
+       ;; renamed->removed->modified->added means removed runs first, so the
+       ;; add does not collide.
+       (delta "* Delta
+** Thing                                             :ADDED:
+:PROPERTIES:
+:AREA: auth
+:END:
+The system SHALL do v2.
+*** S
+- GIVEN a
+** Thing                                             :REMOVED:
+:PROPERTIES:
+:AREA: auth
+:END:
+Removed.
+")
+       (out (orgspec-fold-area spec (fold-test--reqs delta))))
+  (check "order-removed-then-added" (and (string-match-p "SHALL do v2" out)
+                                         (not (string-match-p "SHALL do v1" out)) t) t))

--- a/test/orgspec-parse-test.el
+++ b/test/orgspec-parse-test.el
@@ -1,0 +1,63 @@
+(add-to-list 'load-path (expand-file-name "elisp"))
+(require 'orgspec-parse)
+
+(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+
+(defun parse-test--change (s)
+  (with-temp-buffer
+    (let ((org-inhibit-startup t)) (org-mode))
+    (insert s)
+    (orgspec-parse-change "t")))
+
+;; A delta requirement: op, area, from, body, scenarios, impl all extracted.
+(let* ((chg (parse-test--change "* Delta
+** TODO Notify on lockout                            :ADDED:
+:PROPERTIES:
+:AREA: auth
+:END:
+:IMPL:
+[[file:auth.el::x][x]]
+:END:
+The system SHALL notify.
+*** Lockout triggered
+- GIVEN a
+- WHEN b
+- THEN c
+"))
+       (req (car (orgspec-change-requirements chg))))
+  (check "parse-op" (orgspec-requirement-op req) 'added)
+  (check "parse-name" (orgspec-requirement-name req) "Notify on lockout")
+  (check "parse-area" (orgspec-requirement-area req) "auth")
+  (check "parse-scenarios" (length (orgspec-requirement-scenarios req)) 1)
+  (check "parse-scenario-name"
+         (orgspec-scenario-name (car (orgspec-requirement-scenarios req)))
+         "Lockout triggered")
+  (check "parse-impl" (length (orgspec-requirement-impl req)) 1)
+  (check "parse-normative"
+         (and (string-match-p orgspec-normative-regexp
+                              (orgspec-requirement-body req)) t) t)
+  (check "parse-source-has-subtree"
+         (and (string-match-p "Notify on lockout"
+                              (orgspec-requirement-source req)) t) t))
+
+;; RENAMED carries :FROM:.
+(let* ((chg (parse-test--change "* Delta
+** New name                                          :RENAMED:
+:PROPERTIES:
+:AREA: auth
+:FROM: Old name
+:END:
+Renamed.
+"))
+       (req (car (orgspec-change-requirements chg))))
+  (check "parse-renamed-op" (orgspec-requirement-op req) 'renamed)
+  (check "parse-from" (orgspec-requirement-from req) "Old name"))
+
+;; A spec buffer parses to plain (op nil) requirements at L1.
+(let* ((reqs (with-temp-buffer
+               (let ((org-inhibit-startup t)) (org-mode))
+               (insert "* Req one\nThe system SHALL a.\n** S1\n- GIVEN x\n* Req two\nThe system SHALL b.\n")
+               (orgspec-parse-spec))))
+  (check "parse-spec-count" (length reqs) 2)
+  (check "parse-spec-no-op" (orgspec-requirement-op (car reqs)) nil)
+  (check "parse-spec-name" (orgspec-requirement-name (car reqs)) "Req one"))


### PR DESCRIPTION
Org-native, dependency-free port of OpenSpec's load-bearing core (#5), the MVP scope.

## What's here

- **`orgspec-model.el`** — scenario / requirement / change cl-defstructs.
- **`orgspec.el`** — marker table: op tags, `:AREA:`/`:FROM:` props, `:IMPL:` drawer, clarification + RFC-2119 regexes, TODO-role defcustoms, fold order.
- **`orgspec-parse.el`** — `org-element` extraction of change deltas (`* Delta`, L2 reqs / L3 scenarios) and specs (L1 / L2) into the model.
- **`orgspec-fold.el`** — the fold: `RENAMED → REMOVED → MODIFIED → ADDED` via subtree surgery (built on the proven spike primitives), strip TODO/op-tag/`:AREA:`, keep `:IMPL:`, MODIFIED scenario-drop guard. Pure per-area (validate-all-then-write-all).
- **`orgspec-commands.el`** — `new` / `status` / `archive`; archive folds every area in memory, writes only on full success, then `git mv`'s the change to archive.

## Verification

- parse tests: 13/13 · fold tests: 17/17 (all four ops, cleaning, drop-guard, fixed order) · fold spike still green.
- Full `new → status → archive` lifecycle verified end-to-end in a temp git repo; the resulting `specs/auth.org` is clean, human-verifiable org.
- CI byte-compiles the five modules and runs the suites.

## Scope

MVP per #5 — defers org-leverage (agenda lifecycle, `:IMPL:` code↔spec links, ediff fold review), the hard-gate validator, and typed MCP tools (driven via the existing `eval` tool for now). Flat `elisp/orgspec-*.el` layout.

Part of #5.