### PR TITLE
Add orgspec slash commands

### DIFF
--- a/.claude/commands/orgspec/apply.md
+++ b/.claude/commands/orgspec/apply.md
@@ -1,0 +1,45 @@
+---
+name: "orgspec: Apply"
+description: Implement a change's tasks in the codebase and tick off the checklist
+allowed-tools: mcp__emacs__eval, Read, Edit, Write, Bash
+category: Workflow
+tags: [orgspec, workflow]
+---
+
+Implement a change: write the code that satisfies its delta requirements and tick off the `* Tasks` checklist as each step lands. This is the doing phase between `/orgspec:propose` and `/orgspec:archive`.
+
+**First-cut scope.** This implements tasks and updates the `- [ ]` → `- [x]` boxes only. It deliberately skips the org-leverage side effects #5 defers to MVP+: advancing the requirement's TODO keyword, and writing `:IMPL:` code↔spec links. Add those once that layer lands.
+
+**Input**: The argument after `/orgspec:apply` is the change id. Required.
+
+**Steps**
+
+1. If no id was given, ask which change to apply (offer `/orgspec:status` output to pick from).
+
+2. Read the change and check readiness:
+   ```elisp
+   (progn (require 'orgspec-commands) (orgspec-commands--read-change "<id>"))
+   ```
+   And confirm there is no open clarification marker — if `/orgspec:parse` or a scan shows a `[NEEDS CLARIFICATION]`, STOP and ask the user to resolve it first (same gate `/orgspec:archive` enforces). Do not implement around an unresolved question.
+
+3. Read the change file (`orgspec/changes/<id>/change.org`) to get the Intent / Approach and the `* Tasks` checklist.
+
+4. For each unchecked task, in order:
+   - Implement it in the codebase (Read / Edit / Write; run the build or tests via Bash where it makes sense to verify).
+   - Only after the task is actually done and verified, tick its box: edit that line's `- [ ]` to `- [x]` in `change.org`.
+   - If a task turns out to be blocked or ambiguous, leave it unchecked and note why — do NOT tick a box for work that isn't real.
+
+5. Report progress with `/orgspec:status <id>`.
+
+**Output**
+
+- Which tasks were completed (now `[x]`) and which remain `[ ]` and why.
+- A short note on what changed in the codebase (files touched, build/test result).
+- If all tasks are done: prompt "All tasks complete — `/orgspec:archive <id>` to fold the delta into `specs/`."
+
+**Guardrails**
+
+- Tick a box ONLY when its task is genuinely implemented and verified. A ticked box is a claim the work is done — never tick ahead of the code.
+- Do NOT fold into `specs/` — that's `/orgspec:archive`.
+- Do NOT modify the `* Delta` requirements; apply implements them, it doesn't redefine them. If the delta is wrong, that's a `/orgspec:propose` edit, not apply.
+- Blocked on a `[NEEDS CLARIFICATION]` marker → stop and ask, don't guess.

--- a/.claude/commands/orgspec/archive.md
+++ b/.claude/commands/orgspec/archive.md
@@ -1,0 +1,44 @@
+---
+name: "orgspec: Archive"
+description: Fold a completed change's delta into the specs and move it to archive
+allowed-tools: mcp__emacs__eval
+category: Workflow
+tags: [orgspec, workflow]
+---
+
+Fold a completed change's delta into `specs/` and move the change to archive, via the running Emacs (mcp-emacs `eval` tool). Wraps `orgspec-archive`. This is the destructive, load-bearing verb — it rewrites spec files and moves the change directory.
+
+**Input**: The argument after `/orgspec:archive` is the change id to archive. Required.
+
+**Steps**
+
+1. If no id was given, ask which change to archive (offer `/orgspec:status` output to pick from).
+
+2. Confirm the change is complete: run `/orgspec:status <id>` first. If tasks are unfinished (`DONE < TOTAL`), surface that and ask the user to confirm they still want to archive.
+
+3. Archive by evaluating in Emacs:
+   ```elisp
+   (progn (require 'orgspec-commands) (orgspec-archive "<id>"))
+   ```
+   Behaviour:
+   - Blocks (signals `user-error`) if the change still has a `[NEEDS CLARIFICATION]` marker.
+   - Blocks if the change has no delta requirements.
+   - Folds every affected area in fixed order `RENAMED → REMOVED → MODIFIED → ADDED`.
+   - Validate-all-then-write-all: rebuilds every target spec in memory and writes only if all folds succeed, so a failure leaves `specs/` untouched.
+   - Strips TODO keyword / op-tag / `:AREA:` on re-level; keeps the `:IMPL:` drawer.
+   - Moves `changes/<id>/` to `changes/archive/<id>/` via `git mv` when in a git repo.
+   - Returns the list of spec files written.
+
+4. Show `git diff` of the written `specs/*.org` so the fold is human-verifiable.
+
+**Output**
+
+- The list of spec files written.
+- A short summary of the `specs/` diff (added/modified/removed requirements).
+- Confirmation the change now lives under `changes/archive/<id>/`.
+
+**Guardrails**
+
+- If the eval errors on a clarification marker, report the message verbatim and stop — the user must resolve the marker in `change.org` first.
+- Do NOT retry a failed archive without understanding why it failed; a partial write should not be possible (validate-all-then-write-all), but always show the diff to confirm.
+- Do NOT `git commit` — leave the working tree staged/modified for the user to review and commit.

--- a/.claude/commands/orgspec/new.md
+++ b/.claude/commands/orgspec/new.md
@@ -1,0 +1,33 @@
+---
+name: "orgspec: New"
+description: Scaffold a new orgspec change (changes/<id>/change.org) in the running Emacs
+allowed-tools: mcp__emacs__eval
+category: Workflow
+tags: [orgspec, workflow]
+---
+
+Scaffold a new orgspec change via the running Emacs (mcp-emacs `eval` tool). Wraps `orgspec-new`.
+
+**Input**: The argument after `/orgspec:new` is the change id (kebab-case). If none given, ask what the user wants to build and derive a kebab-case id (e.g. "notify on account lockout" → `notify-account-lockout`).
+
+**Steps**
+
+1. If no id was provided, ask what the change is about and derive a kebab-case id. Do NOT proceed without one.
+
+2. Create the change by evaluating in Emacs:
+   ```elisp
+   (progn (require 'orgspec-commands) (orgspec-new "<id>"))
+   ```
+   This creates `orgspec/changes/<id>/change.org` from the template (Intent / Scope / Approach / Tasks / `* Delta`) and returns the file path.
+
+**Output**
+
+- The change id and the returned `change.org` path.
+- Reminder that the file has an empty `* Delta` subtree ready for requirements (level-2 headlines tagged `:ADDED:`/`:MODIFIED:`/`:REMOVED:`/`:RENAMED:` with an `:AREA:` property; scenarios level-3).
+- Prompt: "Describe the change and I'll fill in `change.org`, or run `/orgspec:status` to check progress."
+
+**Guardrails**
+
+- If the id is not kebab-case, ask for a valid one.
+- If `orgspec-new` signals that the change already exists, stop and suggest editing the existing `change.org` instead.
+- Do NOT write any delta requirements yet — just scaffold.

--- a/.claude/commands/orgspec/parse.md
+++ b/.claude/commands/orgspec/parse.md
@@ -1,0 +1,47 @@
+---
+name: "orgspec: Parse"
+description: Read a change's delta as structured data (the orgspec model) via the running Emacs
+allowed-tools: mcp__emacs__eval
+category: Workflow
+tags: [orgspec, workflow]
+---
+
+Read a change's `* Delta` as structured data — the orgspec model, not prose — so you can inspect a change programmatically. Wraps `orgspec-parse-change` via the mcp-emacs `eval` tool (the planned `orgspec_parse_change` tool, driven through `eval` until typed MCP tools land).
+
+**Input**: The argument after `/orgspec:parse` is the change id. Required.
+
+**Steps**
+
+1. If no id was given, ask which change to parse (offer `/orgspec:status` output to pick from).
+
+2. Parse by evaluating in Emacs. This maps the structs to a readable alist so the output is inspectable rather than opaque `#s(...)`:
+   ```elisp
+   (progn
+     (require 'orgspec-commands)
+     (let ((c (orgspec-commands--read-change "<id>")))
+       (list
+        :id (orgspec-change-id c)
+        :requirements
+        (mapcar
+         (lambda (r)
+           (list :name (orgspec-requirement-name r)
+                 :op (orgspec-requirement-op r)
+                 :area (orgspec-requirement-area r)
+                 :from (orgspec-requirement-from r)
+                 :impl (orgspec-requirement-impl r)
+                 :scenarios (mapcar #'orgspec-scenario-name
+                                    (orgspec-requirement-scenarios r))))
+         (orgspec-change-requirements c)))))
+   ```
+   Each requirement reports its name (identity), op tag (`added`/`modified`/`removed`/`renamed`), `:AREA:` target spec, `:FROM:` rename source, `:IMPL:` traceability entries, and its scenario headline names.
+
+**Output**
+
+- The change id and a per-requirement breakdown: op, area, scenario count + names, and rename source where present.
+- Flag anything the archive fold would reject: a requirement with no scenarios, or a `renamed` op missing `:FROM:`.
+
+**Guardrails**
+
+- Read-only. Do NOT modify any files.
+- Requirement/scenario identity is the exact headline text — report names verbatim, do not normalize them.
+- Errors (e.g. no change file) surface as `user-error`; report the message verbatim and stop.

--- a/.claude/commands/orgspec/propose.md
+++ b/.claude/commands/orgspec/propose.md
@@ -1,0 +1,60 @@
+---
+name: "orgspec: Propose"
+description: Scaffold a change and draft its full change.org from a description
+allowed-tools: mcp__emacs__eval, Read, Edit, Write
+category: Workflow
+tags: [orgspec, workflow]
+---
+
+Start a change end-to-end: scaffold it (`orgspec-new`), then draft the whole `change.org` from the user's description. This is the orgspec equivalent of OpenSpec's `propose` — its four artifacts (propose / tasks / design / spec-delta) collapse into one `change.org`.
+
+**Input**: The argument after `/orgspec:propose` is either a change id (kebab-case) followed by a description, or just a description. If only a description is given, derive a kebab-case id from it (e.g. "notify on account lockout" → `notify-account-lockout`).
+
+**Steps**
+
+1. If no description was given, ask what the change is about. Do NOT proceed without understanding the intent.
+
+2. Scaffold the change in Emacs:
+   ```elisp
+   (progn (require 'orgspec-commands) (orgspec-new "<id>"))
+   ```
+   Returns the `change.org` path. If it errors that the change already exists, stop and offer to edit the existing file instead.
+
+3. Draft `change.org` at the returned path (use Read to see the scaffold, then Edit/Write). Fill every section:
+   - `* Intent` — why this change exists (the problem / motivation).
+   - `* Scope` — what's in and, where useful, an explicit out-of-scope note.
+   - `* Approach` — how it will be built, at a high level.
+   - `* Tasks` — a `- [ ]` checklist of concrete implementation steps (these drive `/orgspec:status`).
+   - `* Delta` — the requirements this change adds/changes. Each requirement is a **level-2** headline tagged with its op and carrying an `:AREA:` property; scenarios are **level-3**:
+     ```org
+     ** Notify on account lockout                            :ADDED:
+     :PROPERTIES:
+     :AREA: auth
+     :END:
+     The system SHALL send a notification email when an account is locked out.
+     *** Lockout triggered
+     - GIVEN an account just crossed the failed-attempt threshold
+     - WHEN the lockout is applied
+     - THEN a notification email is sent to the account address
+     ```
+   Rules:
+   - Op tag is one of `:ADDED:` `:MODIFIED:` `:REMOVED:` `:RENAMED:`. For `:RENAMED:` add a `:FROM:` property with the old name.
+   - Every `:ADDED:` / `:MODIFIED:` requirement body MUST contain `SHALL` or `MUST`, and MUST have ≥ 1 scenario (else the archive fold / future validator rejects it).
+   - Requirement identity is its exact headline text; scenario identity is its headline text. GIVEN/WHEN/THEN is free text.
+   - Where a decision is genuinely open, leave a `[NEEDS CLARIFICATION: <question>]` marker — it blocks `/orgspec:archive` until resolved, which is the intended gate.
+
+4. Show the drafted `change.org` and run `/orgspec:parse <id>` to confirm the delta parses into the model cleanly (flags no-scenario reqs and renames missing `:FROM:`).
+
+**Output**
+
+- The change id and `change.org` path.
+- A short summary of the drafted delta: per requirement, its op / area / scenario count.
+- Any `[NEEDS CLARIFICATION]` markers left open.
+- Prompt: "Refine `change.org`, then `/orgspec:apply` the tasks; `/orgspec:archive` when done."
+
+**Guardrails**
+
+- If the id is not kebab-case, ask for a valid one.
+- Do NOT fold into `specs/` — that's `/orgspec:archive`. Propose only writes `change.org`.
+- Do NOT invent requirements the user didn't ask for; leave a `[NEEDS CLARIFICATION]` marker instead of guessing.
+- Keep the RFC-2119 keyword (`SHALL` / `MUST`) in the requirement body, not the headline.

--- a/.claude/commands/orgspec/status.md
+++ b/.claude/commands/orgspec/status.md
@@ -1,0 +1,34 @@
+---
+name: "orgspec: Status"
+description: Report task completion for orgspec changes via the running Emacs
+allowed-tools: mcp__emacs__eval
+category: Workflow
+tags: [orgspec, workflow]
+---
+
+Report task-checkbox completion for orgspec changes via the running Emacs (mcp-emacs `eval` tool). Wraps `orgspec-status`.
+
+**Input**: The optional argument after `/orgspec:status` is a change id. With no id, all active changes are reported.
+
+**Steps**
+
+1. Evaluate in Emacs. With an id:
+   ```elisp
+   (progn (require 'orgspec-commands) (orgspec-status "<id>"))
+   ```
+   Without an id (all active changes):
+   ```elisp
+   (progn (require 'orgspec-commands) (orgspec-status))
+   ```
+   Returns an alist `((ID (DONE . TOTAL)) ...)` counting `[x]`/`[ ]` checkboxes per change.
+
+**Output**
+
+- One line per change: `<id>: <done>/<total> tasks done`.
+- Flag any change at `N/N` as ready to `/orgspec:archive`.
+- Flag any change with `0` total tasks (empty Tasks section).
+
+**Guardrails**
+
+- Read-only. Do NOT modify any files.
+- Archived changes (under `changes/archive/`) are excluded by the verb — don't try to include them.


### PR DESCRIPTION
Expose the orgspec MVP verbs as Claude Code slash commands under `.claude/commands/orgspec/`, driven through the mcp-emacs `eval` tool (the MVP shortcut from #5, before typed MCP tools exist): `/orgspec:new`, `/orgspec:status`, `/orgspec:archive`, `/orgspec:parse` (maps the model to a readable alist and flags fold-rejects), and `/orgspec:propose` (scaffold + draft the full change.org from a description). Guardrails mirror each verb — duplicate/invalid id, read-only status/parse, clarification-marker and no-delta blocks on archive with a specs/ diff for review.

Part of #5.