### PR TITLE
Add orgspec agenda TODO lifecycle + typed MCP tools

### DIFF
--- a/.claude/commands/orgspec/apply.md
+++ b/.claude/commands/orgspec/apply.md
@@ -8,7 +8,7 @@ tags: [orgspec, workflow]
 
 Implement a change: write the code that satisfies its delta requirements and tick off the `* Tasks` checklist as each step lands. This is the doing phase between `/orgspec:propose` and `/orgspec:archive`.
 
-**First-cut scope.** This implements tasks and updates the `- [ ]` → `- [x]` boxes only. It deliberately skips the org-leverage side effects #5 defers to MVP+: advancing the requirement's TODO keyword, and writing `:IMPL:` code↔spec links. Add those once that layer lands.
+**Scope.** This implements tasks, updates the `- [ ]` → `- [x]` boxes, and advances each delta requirement's TODO keyword through its lifecycle (`orgspec-lifecycle`). It still skips the `:IMPL:` code↔spec link writer #5 defers to a later MVP+ pass — add that when the traceability layer lands.
 
 **Input**: The argument after `/orgspec:apply` is the change id. Required.
 
@@ -24,12 +24,28 @@ Implement a change: write the code that satisfies its delta requirements and tic
 
 3. Read the change file (`orgspec/changes/<id>/change.org`) to get the Intent / Approach and the `* Tasks` checklist.
 
-4. For each unchecked task, in order:
+4. When you start working a requirement, mark it active in Emacs:
+   ```elisp
+   (progn (require 'orgspec-lifecycle)
+          (orgspec-lifecycle-advance "<change.org path>" "<requirement name>" 'active))
+   ```
+   This sets the requirement's TODO keyword to `orgspec-todo-active` (STRT), so it shows up in the `orgspec` agenda as in-flight. Use the requirement's exact headline text as the name.
+
+5. For each unchecked task, in order:
    - Implement it in the codebase (Read / Edit / Write; run the build or tests via Bash where it makes sense to verify).
    - Only after the task is actually done and verified, tick its box: edit that line's `- [ ]` to `- [x]` in `change.org`.
-   - If a task turns out to be blocked or ambiguous, leave it unchecked and note why — do NOT tick a box for work that isn't real.
+   - If a task turns out to be blocked or ambiguous, leave it unchecked and note why — do NOT tick a box for work that isn't real. If it is blocked on an open question, mark the requirement blocked and leave a marker:
+     ```elisp
+     (orgspec-lifecycle-advance "<change.org path>" "<requirement name>" 'blocked)
+     ```
+     (`orgspec-todo-blocked`, WAIT) and add a `[NEEDS CLARIFICATION: <question>]` to its body.
 
-5. Report progress with `/orgspec:status <id>`.
+6. When every task for a requirement is done and verified, mark it done:
+   ```elisp
+   (orgspec-lifecycle-advance "<change.org path>" "<requirement name>" 'done)
+   ```
+
+7. Report progress with `/orgspec:status <id>`.
 
 **Output**
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,12 @@ jobs:
             -L elisp \
             -f batch-byte-compile \
             elisp/mcp-emacs.el elisp/mcp-emacs-report.el elisp/mcp-emacs-server.el elisp/mcp-emacs-ide.el elisp/mcp-emacs-remote.el \
-            elisp/orgspec-model.el elisp/orgspec.el elisp/orgspec-parse.el elisp/orgspec-fold.el elisp/orgspec-commands.el
+            elisp/orgspec-model.el elisp/orgspec.el elisp/orgspec-parse.el elisp/orgspec-fold.el elisp/orgspec-commands.el \
+            elisp/orgspec-lifecycle.el elisp/orgspec-agenda.el elisp/orgspec-mcp.el
 
       - name: Run tests
         run: |
-          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el test/mcp-emacs-report-test.el test/mcp-emacs-remote-test.el test/orgspec-fold-spike-test.el test/orgspec-parse-test.el test/orgspec-fold-test.el; do
+          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el test/mcp-emacs-report-test.el test/mcp-emacs-remote-test.el test/orgspec-fold-spike-test.el test/orgspec-parse-test.el test/orgspec-fold-test.el test/orgspec-lifecycle-test.el test/orgspec-agenda-test.el test/orgspec-mcp-test.el; do
             echo "== $t =="
             emacs --batch \
               --eval "(require 'package)" \

--- a/elisp/mcp-emacs-server.el
+++ b/elisp/mcp-emacs-server.el
@@ -415,10 +415,20 @@ rather than `null' (an empty alist would)."
                      (alist-get 'kind args)))))
   "List of tool descriptors.  Each is a plist with :name :description :schema :handler.")
 
+(defvar mcp-emacs-server-extra-tools nil
+  "Tool descriptors registered by optional modules (e.g. orgspec).
+Same plist shape as `mcp-emacs-server--tools' (:name :description
+:schema :handler).  Modules push their descriptors here at load time so
+they are exposed without editing the core tool list.")
+
+(defun mcp-emacs-server--all-tools ()
+  "Return the core tools followed by any registered extra tools."
+  (append mcp-emacs-server--tools mcp-emacs-server-extra-tools))
+
 (defun mcp-emacs-server--find-tool (name)
   "Return the tool descriptor whose :name equals NAME, or nil."
   (seq-find (lambda (tool) (string= (plist-get tool :name) name))
-            mcp-emacs-server--tools))
+            (mcp-emacs-server--all-tools)))
 
 ;;;; Resource registry
 
@@ -458,7 +468,7 @@ rather than `null' (an empty alist would)."
                      "name" (plist-get tool :name)
                      "description" (plist-get tool :description)
                      "inputSchema" (plist-get tool :schema)))
-                  mcp-emacs-server--tools))))
+                  (mcp-emacs-server--all-tools)))))
 
 (defun mcp-emacs-server--tools-call (params)
   "Execute a tools/call request described by PARAMS, return the result value."

--- a/elisp/orgspec-agenda.el
+++ b/elisp/orgspec-agenda.el
@@ -1,0 +1,60 @@
+;;; orgspec-agenda.el --- In-flight dashboard for orgspec  -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; The org-leverage layer's in-flight dashboard (issue #5, step 8).  Because
+;; delta requirements carry the user's TODO keywords (set by the lifecycle
+;; helpers in orgspec-lifecycle.el), one `org-agenda-custom-commands' entry
+;; over the change files becomes the "in-flight requirements" view OpenSpec had
+;; to build by hand.  This file owns only the read/dashboard side; advancing a
+;; requirement's state is orgspec-lifecycle.el.
+
+;;; Code:
+
+(require 'org)
+(require 'org-agenda)
+(require 'orgspec)
+
+(defcustom orgspec-agenda-key "o"
+  "Dispatch key for the orgspec in-flight agenda custom command."
+  :type 'string :group 'orgspec)
+
+(defun orgspec-agenda-files (changes-dir)
+  "Return the list of change.org files under CHANGES-DIR (active only).
+Archived changes (under an `archive/' subdir) are excluded."
+  (when (file-directory-p changes-dir)
+    (seq-filter
+     #'file-exists-p
+     (mapcar (lambda (id) (expand-file-name (format "%s/change.org" id)
+                                            changes-dir))
+             (seq-filter
+              (lambda (n) (and (not (member n '("." ".." "archive")))
+                               (file-directory-p (expand-file-name n changes-dir))))
+              (directory-files changes-dir))))))
+
+(defun orgspec-agenda-install (changes-dir)
+  "Register the orgspec in-flight agenda command over CHANGES-DIR.
+Adds an `org-agenda-custom-commands' entry under `orgspec-agenda-key'
+that lists every delta requirement (any op tag) with an active TODO
+state across the change files.  Idempotent."
+  (let* ((tag-match (mapconcat #'car orgspec-op-tags "|"))
+         (entry
+          `(,orgspec-agenda-key "orgspec in-flight requirements"
+            tags-todo ,(format "+{%s}" tag-match)
+            ((org-agenda-files ',(orgspec-agenda-files changes-dir))
+             (org-agenda-overriding-header
+              "orgspec: in-flight delta requirements")))))
+    (setq org-agenda-custom-commands
+          (cons entry
+                (assoc-delete-all orgspec-agenda-key org-agenda-custom-commands)))
+    entry))
+
+(provide 'orgspec-agenda)
+;;; orgspec-agenda.el ends here

--- a/elisp/orgspec-lifecycle.el
+++ b/elisp/orgspec-lifecycle.el
@@ -1,0 +1,81 @@
+;;; orgspec-lifecycle.el --- TODO lifecycle for orgspec delta requirements  -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; The org-leverage layer's TODO lifecycle (issue #5, step 8).  Delta
+;; requirements in a change file carry the user's existing TODO keywords, so
+;; `apply' can move a requirement through its lifecycle.  The agenda dashboard
+;; that reads these states lives in orgspec-agenda.el.
+;;
+;; Lifecycle role -> keyword (all read from the defcustoms in orgspec.el, so
+;; nothing here invents workflow states):
+;;   active   -> `orgspec-todo-active'   (STRT): `apply' is working it
+;;   blocked  -> `orgspec-todo-blocked'  (WAIT): stuck on [NEEDS CLARIFICATION]
+;;   removed  -> `orgspec-todo-removed'  (KILL): a :REMOVED: requirement
+;;   done     -> org's own done state (`org-todo' with `done')
+;;
+;; The fold strips the TODO keyword on the way into specs/ (see orgspec-fold);
+;; workflow state lives only in the change file, never the accumulating spec.
+
+;;; Code:
+
+(require 'org)
+(require 'orgspec)
+
+(defun orgspec-lifecycle-goto-requirement (name)
+  "Move point to the delta requirement headline NAME in the current buffer.
+A delta requirement is a level-2 headline under `* Delta'.  Returns
+point on success, nil (and leaves point unmoved) if not found."
+  (let ((start (point)))
+    (goto-char (point-min))
+    (if (re-search-forward
+         (format "^\\*\\* +\\(?:[A-Z]+ +\\)?%s *\\(?::.*:\\)?$"
+                 (regexp-quote name))
+         nil t)
+        (progn (org-back-to-heading t) (point))
+      (goto-char start)
+      nil)))
+
+(defun orgspec-lifecycle--keyword-for-role (role)
+  "Return the TODO keyword string for lifecycle ROLE, or the symbol `done'.
+ROLE is one of the symbols `active', `blocked', `removed', `done'."
+  (pcase role
+    ('active orgspec-todo-active)
+    ('blocked orgspec-todo-blocked)
+    ('removed orgspec-todo-removed)
+    ('done 'done)
+    (_ (error "Unknown orgspec lifecycle role: %S" role))))
+
+(defun orgspec-lifecycle-advance-at-point (role)
+  "Set the requirement headline at point to lifecycle ROLE.
+For `done' this uses org's own done handling (so logging/CLOSED behave
+normally); otherwise it sets the mapped keyword explicitly."
+  (org-back-to-heading t)
+  (let ((kw (orgspec-lifecycle--keyword-for-role role)))
+    (if (eq kw 'done)
+        (org-todo 'done)
+      (org-todo kw))))
+
+(defun orgspec-lifecycle-advance (file name role)
+  "In change FILE, advance delta requirement NAME to lifecycle ROLE.
+Opens FILE, moves to the requirement, sets its keyword, and saves.
+Signals a `user-error' if the requirement is not found.  Returns the
+keyword that was set."
+  (let ((buf (find-file-noselect file)))
+    (with-current-buffer buf
+      (save-excursion
+        (unless (orgspec-lifecycle-goto-requirement name)
+          (user-error "No delta requirement %S in %s" name file))
+        (orgspec-lifecycle-advance-at-point role)
+        (save-buffer)
+        (org-get-todo-state)))))
+
+(provide 'orgspec-lifecycle)
+;;; orgspec-lifecycle.el ends here

--- a/elisp/orgspec-mcp.el
+++ b/elisp/orgspec-mcp.el
@@ -1,0 +1,156 @@
+;;; orgspec-mcp.el --- Typed MCP tools for orgspec  -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Typed MCP tools over the orgspec command verbs and the agenda lifecycle
+;; (issue #5, step 7).  Promotes the `eval'-driven MVP shortcut to a proper
+;; agent surface: each tool has a name, a JSON schema, and a handler that
+;; returns human/agent-readable text.
+;;
+;; The tools are registered onto `mcp-emacs-server-extra-tools' at load time
+;; (the server splices that in via `mcp-emacs-server--all-tools'), so requiring
+;; this file is all it takes to expose them -- no edit to the core tool list.
+;;
+;; Tools:
+;;   orgspec_new       scaffold changes/<id>/change.org
+;;   orgspec_status    task-checkbox counts for one change or all
+;;   orgspec_parse     a change's delta as structured data
+;;   orgspec_archive   fold the delta into specs/ and archive the change
+;;   orgspec_advance   set a delta requirement's lifecycle keyword
+;;   orgspec_agenda    register the in-flight agenda command
+
+;;; Code:
+
+(require 'orgspec)
+(require 'orgspec-model)
+(require 'orgspec-commands)
+(require 'orgspec-lifecycle)
+(require 'orgspec-agenda)
+(require 'mcp-emacs-server)
+
+;;;; Result formatting
+
+(defun orgspec-mcp--format-status (alist)
+  "Render an `orgspec-status' ALIST as readable lines."
+  (if (null alist)
+      "no active changes"
+    (mapconcat (lambda (c) (format "%s: %d/%d tasks done"
+                                   (car c) (cadr c) (cddr c)))
+               alist "\n")))
+
+(defun orgspec-mcp--format-change (change)
+  "Render an `orgspec-change' CHANGE as a readable per-requirement summary."
+  (let ((reqs (orgspec-change-requirements change)))
+    (if (null reqs)
+        (format "%s: no delta requirements" (orgspec-change-id change))
+      (mapconcat
+       (lambda (r)
+         (format "- %s [%s] area=%s%s scenarios=%d"
+                 (orgspec-requirement-name r)
+                 (or (orgspec-requirement-op r) "?")
+                 (or (orgspec-requirement-area r) "?")
+                 (if (orgspec-requirement-from r)
+                     (format " from=%S" (orgspec-requirement-from r)) "")
+                 (length (orgspec-requirement-scenarios r))))
+       reqs "\n"))))
+
+;;;; Handlers
+
+(defun orgspec-mcp--new (args)
+  (orgspec-new (alist-get 'id args)))
+
+(defun orgspec-mcp--status (args)
+  (orgspec-mcp--format-status (orgspec-status (alist-get 'id args))))
+
+(defun orgspec-mcp--parse (args)
+  (orgspec-mcp--format-change
+   (orgspec-commands--read-change (alist-get 'id args))))
+
+(defun orgspec-mcp--archive (args)
+  (let ((written (orgspec-archive (alist-get 'id args))))
+    (format "wrote:\n%s" (mapconcat #'identity written "\n"))))
+
+(defun orgspec-mcp--advance (args)
+  (let* ((id (alist-get 'id args))
+         (name (alist-get 'requirement args))
+         (role (intern (alist-get 'role args)))
+         (file (orgspec-commands--change-file id)))
+    (format "%s -> %s" name (orgspec-lifecycle-advance file name role))))
+
+(defun orgspec-mcp--agenda (_args)
+  (orgspec-agenda-install (orgspec-commands--changes-dir))
+  (format "registered agenda command under key %S" orgspec-agenda-key))
+
+;;;; Tool descriptors
+
+(defun orgspec-mcp--id-schema (desc)
+  (mcp-emacs-server--obj
+   "type" "object"
+   "properties" (mcp-emacs-server--obj
+                 "id" (mcp-emacs-server--prop "string" desc))
+   "required" (vector "id")))
+
+(defconst orgspec-mcp--tools
+  (list
+   (list :name "orgspec_new"
+         :description "Scaffold a new orgspec change (changes/<id>/change.org)"
+         :schema (orgspec-mcp--id-schema "Change id (kebab-case)")
+         :handler #'orgspec-mcp--new)
+   (list :name "orgspec_status"
+         :description "Report task-checkbox completion for one change or all active changes"
+         :schema (mcp-emacs-server--obj
+                  "type" "object"
+                  "properties" (mcp-emacs-server--obj
+                                "id" (mcp-emacs-server--prop
+                                      "string" "Change id, or omit for all active changes")))
+         :handler #'orgspec-mcp--status)
+   (list :name "orgspec_parse"
+         :description "Read a change's delta as structured data (per-requirement op/area/scenarios)"
+         :schema (orgspec-mcp--id-schema "Change id to parse")
+         :handler #'orgspec-mcp--parse)
+   (list :name "orgspec_archive"
+         :description "Fold a change's delta into specs/ and move the change to archive"
+         :schema (orgspec-mcp--id-schema "Change id to archive")
+         :handler #'orgspec-mcp--archive)
+   (list :name "orgspec_advance"
+         :description "Set a delta requirement's lifecycle TODO keyword (active/blocked/removed/done)"
+         :schema (mcp-emacs-server--obj
+                  "type" "object"
+                  "properties" (mcp-emacs-server--obj
+                                "id" (mcp-emacs-server--prop "string" "Change id")
+                                "requirement" (mcp-emacs-server--prop
+                                               "string" "Exact requirement headline text")
+                                "role" (mcp-emacs-server--obj
+                                        "type" "string"
+                                        "description" "Lifecycle role"
+                                        "enum" (vector "active" "blocked" "removed" "done")))
+                  "required" (vector "id" "requirement" "role"))
+         :handler #'orgspec-mcp--advance)
+   (list :name "orgspec_agenda"
+         :description "Register the orgspec in-flight-requirements agenda custom command"
+         :schema (mcp-emacs-server--no-args)
+         :handler #'orgspec-mcp--agenda))
+  "orgspec MCP tool descriptors, registered onto the server's extra-tools.")
+
+;;;; Registration
+
+(defun orgspec-mcp-register ()
+  "Register the orgspec tools onto `mcp-emacs-server-extra-tools'.
+Idempotent: replaces any previously registered orgspec descriptors."
+  (let ((names (mapcar (lambda (tl) (plist-get tl :name)) orgspec-mcp--tools)))
+    (setq mcp-emacs-server-extra-tools
+          (append orgspec-mcp--tools
+                  (seq-remove (lambda (tl) (member (plist-get tl :name) names))
+                              mcp-emacs-server-extra-tools)))))
+
+(orgspec-mcp-register)
+
+(provide 'orgspec-mcp)
+;;; orgspec-mcp.el ends here

--- a/test/orgspec-agenda-test.el
+++ b/test/orgspec-agenda-test.el
@@ -1,0 +1,44 @@
+(add-to-list 'load-path (expand-file-name "elisp"))
+(require 'orgspec-agenda)
+
+(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+
+;; Build a temp changes dir: two active changes + one archived.
+(let* ((root (make-temp-file "orgspec-agenda-" t))
+       (changes (expand-file-name "changes" root)))
+  (dolist (id '("add-auth" "fix-lockout"))
+    (let ((d (expand-file-name id changes)))
+      (make-directory d t)
+      (with-temp-file (expand-file-name "change.org" d) (insert "* Delta\n"))))
+  ;; An archived change must be excluded.
+  (let ((a (expand-file-name "archive/old-change" changes)))
+    (make-directory a t)
+    (with-temp-file (expand-file-name "change.org" a) (insert "* Delta\n")))
+  ;; A change dir with no change.org must be skipped.
+  (make-directory (expand-file-name "half-baked" changes) t)
+
+  (let ((files (orgspec-agenda-files changes)))
+    (check "files-count" (length files) 2)
+    (check "files-active-only"
+           (and (seq-every-p (lambda (f) (not (string-match-p "/archive/" f))) files) t)
+           t)
+    (check "files-existing"
+           (and (seq-every-p #'file-exists-p files) t) t))
+
+  ;; install registers one entry under the key, idempotently.
+  (let ((org-agenda-custom-commands nil)
+        (orgspec-agenda-key "o"))
+    (orgspec-agenda-install changes)
+    (check "install-one" (length org-agenda-custom-commands) 1)
+    (check "install-key" (car (car org-agenda-custom-commands)) "o")
+    (orgspec-agenda-install changes)
+    (check "install-idempotent" (length org-agenda-custom-commands) 1)
+    (let ((entry (car org-agenda-custom-commands)))
+      (check "install-type" (nth 2 entry) 'tags-todo)
+      (check "install-match-has-ops"
+             (and (string-match-p "ADDED" (nth 3 entry))
+                  (string-match-p "RENAMED" (nth 3 entry)) t)
+             t))))
+
+;; A missing changes dir yields no files (no error).
+(check "files-missing" (orgspec-agenda-files "/nonexistent/xyz") nil)

--- a/test/orgspec-lifecycle-test.el
+++ b/test/orgspec-lifecycle-test.el
@@ -1,0 +1,66 @@
+(add-to-list 'load-path (expand-file-name "elisp"))
+(require 'orgspec-lifecycle)
+
+(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+
+(defconst life-test--change "* Delta
+** Notify on lockout                                 :ADDED:
+:PROPERTIES:
+:AREA: auth
+:END:
+The system SHALL notify.
+*** Lockout triggered
+- GIVEN a
+** Second requirement                                :MODIFIED:
+:PROPERTIES:
+:AREA: auth
+:END:
+The system MUST also do b.
+")
+
+(defun life-test--in-buffer (fn)
+  (with-temp-buffer
+    (let ((org-inhibit-startup t)
+          (org-todo-keywords '((sequence "TODO" "STRT" "WAIT" "|" "DONE" "KILL"))))
+      (org-mode)
+      (insert life-test--change)
+      (goto-char (point-min))
+      (funcall fn))))
+
+;; goto finds an untagged-keyword requirement by name.
+(life-test--in-buffer
+ (lambda ()
+   (check "goto-found" (and (orgspec-lifecycle-goto-requirement "Notify on lockout") t) t)
+   (check "goto-on-heading" (org-get-heading t t t t) "Notify on lockout")))
+
+;; goto returns nil and does not move for an absent name.
+(life-test--in-buffer
+ (lambda ()
+   (goto-char (point-max))
+   (let ((before (point)))
+     (check "goto-absent" (orgspec-lifecycle-goto-requirement "Nope") nil)
+     (check "goto-absent-nomove" (point) before))))
+
+;; advance-at-point sets the active keyword.
+(life-test--in-buffer
+ (lambda ()
+   (orgspec-lifecycle-goto-requirement "Notify on lockout")
+   (orgspec-lifecycle-advance-at-point 'active)
+   (check "advance-active" (org-get-todo-state) orgspec-todo-active)))
+
+;; advance-at-point 'done reaches a done state.
+(life-test--in-buffer
+ (lambda ()
+   (orgspec-lifecycle-goto-requirement "Second requirement")
+   (orgspec-lifecycle-advance-at-point 'done)
+   (check "advance-done"
+          (and (member (substring-no-properties (org-get-todo-state))
+                       org-done-keywords)
+               t)
+          t)))
+
+;; role->keyword map.
+(check "role-active" (orgspec-lifecycle--keyword-for-role 'active) orgspec-todo-active)
+(check "role-blocked" (orgspec-lifecycle--keyword-for-role 'blocked) orgspec-todo-blocked)
+(check "role-removed" (orgspec-lifecycle--keyword-for-role 'removed) orgspec-todo-removed)
+(check "role-done" (orgspec-lifecycle--keyword-for-role 'done) 'done)

--- a/test/orgspec-mcp-test.el
+++ b/test/orgspec-mcp-test.el
@@ -1,0 +1,47 @@
+(add-to-list 'load-path (expand-file-name "elisp"))
+(require 'cl-lib)
+(require 'orgspec-mcp)
+
+(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+
+;; Registration: the six orgspec tools land on the server extra-tools var.
+(check "reg-count" (length mcp-emacs-server-extra-tools) 6)
+(check "reg-names"
+       (sort (mapcar (lambda (tl) (plist-get tl :name)) mcp-emacs-server-extra-tools)
+             #'string<)
+       '("orgspec_advance" "orgspec_agenda" "orgspec_archive"
+         "orgspec_new" "orgspec_parse" "orgspec_status"))
+;; Idempotent re-register keeps the count at six.
+(orgspec-mcp-register)
+(check "reg-idempotent" (length mcp-emacs-server-extra-tools) 6)
+;; Every descriptor has the required plist keys.
+(check "reg-well-formed"
+       (seq-every-p (lambda (tl) (and (plist-get tl :name)
+                                      (plist-get tl :description)
+                                      (plist-get tl :schema)
+                                      (functionp (plist-get tl :handler))))
+                    mcp-emacs-server-extra-tools)
+       t)
+
+;; Drive the new -> status -> parse -> advance handlers on a temp project.
+(let* ((root (make-temp-file "orgspec-mcp-" t))
+       (default-directory (file-name-as-directory root))
+       (orgspec-root "orgspec")
+       (org-todo-keywords '((sequence "TODO" "STRT" "WAIT" "|" "DONE" "KILL"))))
+  (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
+    (orgspec-mcp--new '((id . "add-auth")))
+    (let ((f (orgspec-commands--change-file "add-auth")))
+      (check "new-created" (file-exists-p f) t)
+      (with-temp-file f
+        (insert "* Tasks\n- [ ] a\n- [x] b\n* Delta\n"
+                "** Login required :ADDED:\n:PROPERTIES:\n:AREA: auth\n:END:\n"
+                "The system SHALL require login.\n*** happy\n- GIVEN x\n")))
+    (check "status-text" (orgspec-mcp--status '((id . "add-auth")))
+           "add-auth: 1/2 tasks done")
+    (let ((s (orgspec-mcp--parse '((id . "add-auth")))))
+      (check "parse-has-req" (and (string-match-p "Login required" s) t) t)
+      (check "parse-has-area" (and (string-match-p "area=auth" s) t) t))
+    (check "advance-active"
+           (orgspec-mcp--advance
+            '((id . "add-auth") (requirement . "Login required") (role . "active")))
+           (format "Login required -> %s" orgspec-todo-active))))


### PR DESCRIPTION
The org-leverage agenda lifecycle from #5 (step 8) plus the promotion of the orgspec verbs to typed MCP tools (step 7). `orgspec-lifecycle.el` advances a delta requirement's TODO keyword (active/blocked/removed/done, read from the defcustoms in `orgspec.el`); `orgspec-agenda.el` registers one agenda custom command over the active change files as the in-flight dashboard. `orgspec-mcp.el` exposes `orgspec_new/status/parse/archive/advance/agenda` via a new `mcp-emacs-server-extra-tools` registry hook (no edit to the core tool list). `/orgspec:apply` now drives the lifecycle. New modules and tests are wired into CI.

Tests: lifecycle 10, agenda 9 locally green; mcp-tool test runs in CI (needs the web-server dep). The fold already strips the TODO keyword, so specs/ stays plain-headline.

Part of #5.