### PR TITLE
Native picker to resume a past Claude session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,12 @@ jobs:
             -f batch-byte-compile \
             elisp/mcp-emacs.el elisp/mcp-emacs-report.el elisp/mcp-emacs-server.el elisp/mcp-emacs-ide.el elisp/mcp-emacs-remote.el \
             elisp/orgspec-model.el elisp/orgspec.el elisp/orgspec-parse.el elisp/orgspec-fold.el elisp/orgspec-commands.el \
-            elisp/orgspec-lifecycle.el elisp/orgspec-agenda.el elisp/orgspec-mcp.el
+            elisp/orgspec-lifecycle.el elisp/orgspec-agenda.el elisp/orgspec-mcp.el \
+            elisp/mcp-emacs-run-resume.el
 
       - name: Run tests
         run: |
-          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el test/mcp-emacs-report-test.el test/mcp-emacs-remote-test.el test/orgspec-fold-spike-test.el test/orgspec-parse-test.el test/orgspec-fold-test.el test/orgspec-lifecycle-test.el test/orgspec-agenda-test.el test/orgspec-mcp-test.el; do
+          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el test/mcp-emacs-report-test.el test/mcp-emacs-remote-test.el test/orgspec-fold-spike-test.el test/orgspec-parse-test.el test/orgspec-fold-test.el test/orgspec-lifecycle-test.el test/orgspec-agenda-test.el test/orgspec-mcp-test.el test/mcp-emacs-run-resume-test.el; do
             echo "== $t =="
             emacs --batch \
               --eval "(require 'package)" \

--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ Configure `mcp-emacs-run-executable` and `-flags`, then:
 
 - `M-x mcp-emacs-run` — start (or switch to) the runner for the current project.
 - `M-x mcp-emacs-run-start` — start the runner hidden (no window, no focus); reveal it later with `-toggle` or `-switch`.
-- `M-x mcp-emacs-run-continue` / `-resume` — pick up a prior conversation.
+- `M-x mcp-emacs-run-continue` / `-resume` — pick up a prior conversation (`-resume` uses the CLI's own in-terminal picker).
+- `M-x mcp-emacs-run-resume-select` — pick a past session from a native Emacs `completing-read` (most recent first, labelled with a relative time and the first real prompt) and resume it with `--resume <id>`. Reads the store under `mcp-emacs-run-resume-projects-root` (default `~/.claude/projects`).
 - `M-x mcp-emacs-run-toggle` — show/hide the runner window.
 - `M-x mcp-emacs-run-list` / `-switch` / `-kill` — manage sessions.
 - `M-x mcp-emacs-run-quit` — gracefully quit a session: sends the CLI quit (Ctrl-C twice), then force-kills the process and removes the buffer if it has not exited within `mcp-emacs-run-quit-timeout` seconds (default 10). Unlike `-kill`, it lets the CLI shut down cleanly first.

--- a/elisp/mcp-emacs-run-resume.el
+++ b/elisp/mcp-emacs-run-resume.el
@@ -1,0 +1,172 @@
+;;; mcp-emacs-run-resume.el --- Native picker for resuming past Claude sessions  -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; `mcp-emacs-run-resume-select' (issue #19): a native Emacs `completing-read'
+;; over the current project's past Claude sessions, launching the chosen one
+;; with `--resume <session-id>'.  This replaces relying on the CLI's own
+;; in-terminal picker (what `mcp-emacs-run-resume' with a bare `--resume' does)
+;; -- pick from Emacs, with readable labels.
+;;
+;; The session store layout (verified):
+;;   ~/.claude/projects/<slug>/<session-id>.jsonl
+;; where <slug> is the project root path with `/' and `.' replaced by `-', and
+;; <session-id> is the file-name stem (a uuid).
+;;
+;; The preview label is `<relative-time>  <first real prompt>'.  Extracting the
+;; first *genuine* user prompt is the fiddly part: a transcript's literal first
+;; `type:user' line is often an injected `<command-message>' / `<local-command-
+;; caveat>' block or a tool result, not the human's prompt, so those are skipped
+;; and the first real text line wins.  Falls back to the session id.
+
+;;; Code:
+
+(require 'json)
+(require 'subr-x)
+
+(defcustom mcp-emacs-run-resume-projects-root
+  (expand-file-name "~/.claude/projects")
+  "Directory holding per-project Claude session stores."
+  :type 'directory :group 'mcp-emacs-run)
+
+(defcustom mcp-emacs-run-resume-head-lines 40
+  "How many leading transcript lines to scan for the first real prompt.
+Tuned to clear injected caveat/command blocks at the head without
+reading whole transcripts."
+  :type 'integer :group 'mcp-emacs-run)
+
+;;;; Store location
+
+(defun mcp-emacs-run-resume--slug (root)
+  "Return the Claude store slug for project ROOT.
+The slug is ROOT's absolute path with `/' and `.' each replaced by `-'."
+  (let ((path (directory-file-name (expand-file-name root))))
+    (replace-regexp-in-string "[/.]" "-" path)))
+
+(defun mcp-emacs-run-resume--store-dir (root)
+  "Return the session store directory for project ROOT."
+  (expand-file-name (mcp-emacs-run-resume--slug root)
+                    mcp-emacs-run-resume-projects-root))
+
+(defun mcp-emacs-run-resume--session-files (root)
+  "Return ROOT's session `.jsonl' files, most-recently-modified first."
+  (let ((dir (mcp-emacs-run-resume--store-dir root)))
+    (when (file-directory-p dir)
+      (sort (directory-files dir t "\\.jsonl\\'")
+            (lambda (a b)
+              (time-less-p (file-attribute-modification-time (file-attributes b))
+                           (file-attribute-modification-time (file-attributes a))))))))
+
+(defun mcp-emacs-run-resume--session-id (file)
+  "Return the session id (file-name stem) for transcript FILE."
+  (file-name-base file))
+
+;;;; Preview extraction
+
+(defun mcp-emacs-run-resume--content-text (content)
+  "Normalise a message CONTENT value to a single string, or nil.
+CONTENT is either a string or a vector/list of blocks; for the latter
+the first block carrying a `text' field is used."
+  (cond
+   ((stringp content) content)
+   ((and (or (vectorp content) (listp content)) (> (length content) 0))
+    (let ((blocks (append content nil)) text)
+      (while (and blocks (not text))
+        (let ((b (pop blocks)))
+          (when (and (listp b) (stringp (alist-get 'text b)))
+            (setq text (alist-get 'text b)))))
+      text))
+   (t nil)))
+
+(defun mcp-emacs-run-resume--noise-p (text)
+  "Return non-nil when TEXT is an injected block, not a human prompt.
+Skips `<command-*>' / `<local-command-*>' wrappers and caveat blocks."
+  (let ((s (string-trim (or text ""))))
+    (or (string-empty-p s)
+        (string-prefix-p "<command-" s)
+        (string-prefix-p "<local-command-" s)
+        (string-prefix-p "Caveat:" s))))
+
+(defun mcp-emacs-run-resume--first-prompt (file)
+  "Return the first genuine user prompt in transcript FILE, or nil.
+Reads only the head window (`mcp-emacs-run-resume-head-lines'): parses
+each line, keeps `type:user' entries whose normalised text is not noise,
+and returns the first such text trimmed to a single line."
+  (when (file-readable-p file)
+    (with-temp-buffer
+      (insert-file-contents file nil 0)
+      (goto-char (point-min))
+      (let ((json-object-type 'alist)
+            (json-array-type 'vector)
+            (n 0) prompt)
+        (while (and (not prompt)
+                    (< n mcp-emacs-run-resume-head-lines)
+                    (not (eobp)))
+          (setq n (1+ n))
+          (let ((line (buffer-substring-no-properties
+                       (line-beginning-position) (line-end-position))))
+            (unless (string-empty-p (string-trim line))
+              (let ((obj (ignore-errors (json-read-from-string line))))
+                (when (and obj (equal (alist-get 'type obj) "user"))
+                  (let* ((msg (alist-get 'message obj))
+                         (text (mcp-emacs-run-resume--content-text
+                                (and (listp msg) (alist-get 'content msg)))))
+                    (when (and text (not (mcp-emacs-run-resume--noise-p text)))
+                      (setq prompt (car (split-string (string-trim text) "\n")))))))))
+          (forward-line 1))
+        prompt))))
+
+(defun mcp-emacs-run-resume--relative-time (file)
+  "Return a short relative-time string for FILE's modification time."
+  (let* ((mtime (file-attribute-modification-time (file-attributes file)))
+         (secs (float-time (time-subtract (current-time) mtime))))
+    (cond
+     ((< secs 60) "just now")
+     ((< secs 3600) (format "%dm ago" (floor secs 60)))
+     ((< secs 86400) (format "%dh ago" (floor secs 3600)))
+     (t (format "%dd ago" (floor secs 86400))))))
+
+(defun mcp-emacs-run-resume--label (file)
+  "Return the `completing-read' label for session transcript FILE.
+`<relative-time>  <first real prompt>', falling back to the session id
+when no genuine prompt is found in the head window."
+  (let ((id (mcp-emacs-run-resume--session-id file)))
+    (format "%-8s  %s"
+            (mcp-emacs-run-resume--relative-time file)
+            (or (mcp-emacs-run-resume--first-prompt file) id))))
+
+;;;; Command
+
+;;;###autoload
+(defun mcp-emacs-run-resume-select ()
+  "Pick a past Claude session for the current project and resume it.
+`completing-read' over the project's stored sessions (most recent
+first), labelled with a relative time and the first real prompt, then
+launch the chosen one with `--resume <session-id>'.  Signals a
+`user-error' when the store is empty or missing -- it never silently
+falls back to the CLI's own picker (use `mcp-emacs-run-resume' for
+that)."
+  (interactive)
+  (require 'mcp-emacs-run)
+  (let* ((root (mcp-emacs-run--project-root))
+         (files (mcp-emacs-run-resume--session-files root)))
+    (unless files
+      (user-error "No past Claude sessions for %s"
+                  (mcp-emacs-run--project-name root)))
+    (let* ((alist (mapcar (lambda (f) (cons (mcp-emacs-run-resume--label f) f))
+                          files))
+           (pick (completing-read "Resume session: " alist nil t))
+           (file (cdr (assoc pick alist))))
+      (when file
+        (mcp-emacs-run--launch root nil "--resume"
+                               (mcp-emacs-run-resume--session-id file))))))
+
+(provide 'mcp-emacs-run-resume)
+;;; mcp-emacs-run-resume.el ends here

--- a/test/mcp-emacs-run-resume-test.el
+++ b/test/mcp-emacs-run-resume-test.el
@@ -1,0 +1,90 @@
+(add-to-list 'load-path (expand-file-name "elisp"))
+(require 'cl-lib)
+;; Avoid loading the full runner (needs eat) -- stub the two helpers the
+;; command uses; the unit tests below never call the command itself.
+(provide 'mcp-emacs-run)
+(defun mcp-emacs-run--project-root () default-directory)
+(defun mcp-emacs-run--project-name (root) (file-name-nondirectory (directory-file-name root)))
+(defvar mcp-emacs-run--launched nil)
+(defun mcp-emacs-run--launch (&rest args) (setq mcp-emacs-run--launched args))
+(require 'mcp-emacs-run-resume)
+
+(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+
+;;;; slug builder
+(check "slug-basic"
+       (mcp-emacs-run-resume--slug "/Users/x/git/mcp-emacs")
+       "-Users-x-git-mcp-emacs")
+(check "slug-dots"
+       (mcp-emacs-run-resume--slug "/Users/x/.emacs.d")
+       "-Users-x--emacs-d")
+(check "slug-trailing-slash"
+       (mcp-emacs-run-resume--slug "/Users/x/proj/")
+       "-Users-x-proj")
+
+;;;; content normalisation
+(check "content-string" (mcp-emacs-run-resume--content-text "hi") "hi")
+(check "content-array-text"
+       (mcp-emacs-run-resume--content-text (vector '((type . "text") (text . "hello"))))
+       "hello")
+(check "content-array-skip-nontext"
+       (mcp-emacs-run-resume--content-text
+        (vector '((type . "tool_result")) '((type . "text") (text . "real"))))
+       "real")
+(check "content-nil" (mcp-emacs-run-resume--content-text nil) nil)
+
+;;;; noise predicate
+(check "noise-command" (and (mcp-emacs-run-resume--noise-p "<command-message>x</command-message>") t) t)
+(check "noise-local-caveat" (and (mcp-emacs-run-resume--noise-p "<local-command-caveat>y") t) t)
+(check "noise-caveat" (and (mcp-emacs-run-resume--noise-p "Caveat: blah") t) t)
+(check "noise-empty" (and (mcp-emacs-run-resume--noise-p "   ") t) t)
+(check "noise-real" (mcp-emacs-run-resume--noise-p "show open issues") nil)
+
+;;;; first-prompt over a fixture store
+(let* ((store (make-temp-file "resume-store-" t)))
+  ;; clean string prompt
+  (let ((f (expand-file-name "aaa.jsonl" store)))
+    (with-temp-file f
+      (insert "{\"type\":\"mode\"}\n"
+              "{\"type\":\"user\",\"message\":{\"content\":\"show open issues\"}}\n"))
+    (check "prompt-clean" (mcp-emacs-run-resume--first-prompt f) "show open issues"))
+  ;; caveat/command block precedes the real prompt -> skip to real
+  (let ((f (expand-file-name "bbb.jsonl" store)))
+    (with-temp-file f
+      (insert "{\"type\":\"user\",\"message\":{\"content\":\"<local-command-caveat>Caveat: x\"}}\n"
+              "{\"type\":\"user\",\"message\":{\"content\":\"<command-message>opsx:new</command-message>\"}}\n"
+              "{\"type\":\"user\",\"message\":{\"content\":\"the actual prompt\"}}\n"))
+    (check "prompt-skip-noise" (mcp-emacs-run-resume--first-prompt f) "the actual prompt"))
+  ;; array content
+  (let ((f (expand-file-name "ccc.jsonl" store)))
+    (with-temp-file f
+      (insert "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"array prompt\"}]}}\n"))
+    (check "prompt-array" (mcp-emacs-run-resume--first-prompt f) "array prompt"))
+  ;; multi-line prompt -> first line only
+  (let ((f (expand-file-name "ddd.jsonl" store)))
+    (with-temp-file f
+      (insert "{\"type\":\"user\",\"message\":{\"content\":\"line one\\nline two\"}}\n"))
+    (check "prompt-first-line" (mcp-emacs-run-resume--first-prompt f) "line one"))
+  ;; no genuine prompt in head -> nil (label falls back to id)
+  (let ((f (expand-file-name "eee.jsonl" store)))
+    (with-temp-file f
+      (insert "{\"type\":\"user\",\"message\":{\"content\":\"<command-message>only noise</command-message>\"}}\n"))
+    (check "prompt-none" (mcp-emacs-run-resume--first-prompt f) nil)
+    (check "label-id-fallback"
+           (string-suffix-p "eee" (mcp-emacs-run-resume--label f)) t)))
+
+;;;; session-files: mtime ordering, newest first, .jsonl only
+(let* ((store (make-temp-file "resume-order-" t))
+       (slug-root "/tmp/fake-proj"))
+  (cl-letf (((symbol-function 'mcp-emacs-run-resume--store-dir) (lambda (_r) store)))
+    (let ((old (expand-file-name "old.jsonl" store))
+          (new (expand-file-name "new.jsonl" store)))
+      (with-temp-file old (insert "{}\n"))
+      (with-temp-file new (insert "{}\n"))
+      (set-file-times old '(20000 0))
+      (set-file-times new '(25000 0))
+      (with-temp-file (expand-file-name "notes.txt" store) (insert "ignore"))
+      (let ((files (mcp-emacs-run-resume--session-files slug-root)))
+        (check "files-count" (length files) 2)
+        (check "files-newest-first"
+               (mcp-emacs-run-resume--session-id (car files)) "new")))))


### PR DESCRIPTION
`mcp-emacs-run-resume-select` (#19): a native Emacs `completing-read` over the current project's past Claude sessions — most recent first, each labelled with a relative time and the first real prompt — that resumes the chosen one with `--resume <session-id>`, instead of dropping into the CLI's own in-terminal picker.

The store is located by slugifying the project root under `mcp-emacs-run-resume-projects-root` (default `~/.claude/projects`). The preview reads only the transcript head and skips injected `<command-*>` / `<local-command-*>` / caveat blocks and non-text content — the literal first user line is usually a caveat, not the human's prompt — falling back to the session id. An empty or missing store is a `user-error`, never a silent fallback to the CLI picker; `mcp-emacs-run-resume` stays as that fallback.

Verified end-to-end against the real store (20 sessions, clean labels, caveat blocks skipped). Unit tests (20) cover the slug builder, content normalisation, the noise predicate, first-prompt extraction, and mtime ordering.

Closes #19.