### PR TITLE
Dedicated, predictable window layout for the ediff diff review

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,14 @@ this folder?" prompt; answer it (press Enter / choose *Yes*) so the CLI proceeds
 to connect. Reviewing an edit: `C-c C-c` accepts (Claude Code writes the file),
 `C-c C-k` or `q` rejects (the file is left unchanged).
 
+The review captures your window configuration before it opens and restores it
+when it ends — however you resolve it — so side windows (Treemacs and the like)
+come back and your layout is left unchanged. This applies to both `apply_diff`
+and the IDE `openDiff` flow, which share the review. By default the diff uses
+ediff's plain full-frame layout; set `mcp-emacs-ediff-window-direction` (to
+`right` / `left` / `above` / `below`, mirroring `mcp-emacs-run-window-direction`)
+to place it in a predictable spot instead.
+
 If you are migrating from `claude-code-ide.el`, disable it for the workspace
 first so only one IDE lockfile is published.
 

--- a/elisp/mcp-emacs.el
+++ b/elisp/mcp-emacs.el
@@ -955,6 +955,18 @@ When no live buffer visits PATH, report that the document is not open."
   :type 'integer
   :group 'mcp-emacs)
 
+(defcustom mcp-emacs-ediff-window-direction 'plain
+  "Where the ediff diff review is placed in the frame.
+`plain' keeps the historical behaviour: ediff's own single-frame plain
+layout, filling the current frame.  The directional values place the
+review with `display-buffer-in-direction' before ediff starts, mirroring
+`mcp-emacs-run-window-direction'.  In every case the pre-review window
+configuration is saved and restored when the review ends, so the user's
+layout — including side windows such as Treemacs — comes back."
+  :type '(choice (const plain) (const right) (const left)
+                 (const above) (const below))
+  :group 'mcp-emacs)
+
 (defun mcp-emacs--apply-diff-accept (buffer-a buffer-b entry-content result)
   "Record an accept decision for an apply-diff session.
 Apply the proposal in BUFFER-B to BUFFER-A when BUFFER-A is still at
@@ -999,20 +1011,35 @@ if that name is taken, ediff's own unique name is kept.
 Side windows (e.g. Treemacs) are deleted and ediff is forced into its
 plain, single-frame window layout before setup; otherwise `ediff-buffers'
 can abort when the selected window is a side or dedicated window, leaving
-no control buffer.
+no control buffer.  The window configuration in force before any of that
+is captured up front and restored once when the review ends (the single
+quit path), so the user's layout — side windows included — comes back;
+this holds for both callers.  `mcp-emacs-ediff-window-direction' selects
+placement; `plain' keeps the historical full-frame layout.
 
 Return the ediff control buffer (or nil) so callers can force-quit it on
 timeout."
-  ;; A side or dedicated window cannot be split, which aborts ediff setup
-  ;; before the control buffer exists.  Remove side windows first and pin
-  ;; ediff to its plain layout so the control panel lands in this frame.
-  (dolist (window (window-list))
-    (when (window-parameter window 'window-side)
-      (ignore-errors (delete-window window))))
-  (let (control
+  ;; Capture the layout before touching any window, so the quit hook can
+  ;; put it all back -- including side windows we are about to delete.
+  (let ((winconf (current-window-configuration))
+        control
         (ediff-window-setup-function 'ediff-setup-windows-plain)
         (ediff-split-window-function 'split-window-horizontally))
-    (ediff-buffers
+    ;; A side or dedicated window cannot be split, which aborts ediff setup
+    ;; before the control buffer exists.  Remove side windows first and pin
+    ;; ediff to its plain layout so the control panel lands in this frame.
+    (dolist (window (window-list))
+      (when (window-parameter window 'window-side)
+        (ignore-errors (delete-window window))))
+    ;; Optional predictable placement: give ediff a single window in the
+    ;; chosen direction to run in, instead of whatever the frame holds.
+    (unless (eq mcp-emacs-ediff-window-direction 'plain)
+      (ignore-errors
+        (select-window
+         (display-buffer-in-direction
+          buffer-a `((direction . ,mcp-emacs-ediff-window-direction))))))
+    (condition-case err
+        (ediff-buffers
      buffer-a buffer-b
      (list (lambda ()
              (setq control ediff-control-buffer)
@@ -1051,9 +1078,18 @@ timeout."
                         ;; (e.g. plain `q') is a rejection.
                         (unless (car result)
                           (setcar result 'rejected))
+                        ;; Restore the pre-review layout exactly once (this
+                        ;; hook is ediff's single quit path), bringing back
+                        ;; any side windows the setup removed.
+                        (ignore-errors (set-window-configuration winconf))
                         (when on-resolve (funcall on-resolve)))))
                (message
                 "mcp diff: C-c C-c to accept, C-c C-k (or q) to reject")))))
+      ;; If ediff setup itself failed (before the quit hook could ever
+      ;; run), restore the layout here so a failed review does not leave
+      ;; the user's side windows deleted, then re-signal.
+      (error (ignore-errors (set-window-configuration winconf))
+             (signal (car err) (cdr err))))
     control))
 
 (defun mcp-emacs-apply-diff (path new-content timeout)
@@ -1076,7 +1112,6 @@ TIMEOUT is capped at `mcp-emacs-apply-diff-max-timeout' and defaults to
              (buffer-b (generate-new-buffer
                         (format "*mcp-apply-diff: %s*"
                                 (file-name-nondirectory file))))
-             (winconf (current-window-configuration))
              ;; Per-call result cell captured by the quit hook closure.
              (result (list nil))
              (secs (min mcp-emacs-apply-diff-max-timeout
@@ -1115,8 +1150,9 @@ TIMEOUT is capped at `mcp-emacs-apply-diff-max-timeout' and defaults to
                         (ignore-errors (ediff-really-quit nil))
                       (kill-buffer control))))
                 "Status: timeout")))
-          (when (buffer-live-p buffer-b) (kill-buffer buffer-b))
-          (ignore-errors (set-window-configuration winconf))))
+          ;; The window configuration is saved and restored inside
+          ;; `mcp-emacs--ediff-review' now, for both callers.
+          (when (buffer-live-p buffer-b) (kill-buffer buffer-b))))
     (error (error-message-string err))))
 
 ;;; Project / workspace tools

--- a/orgspec/changes/archive/improve-ediff-window-layout/change.org
+++ b/orgspec/changes/archive/improve-ediff-window-layout/change.org
@@ -1,0 +1,77 @@
+#+TITLE: improve-ediff-window-layout
+
+* Intent
+The ediff diff review (`mcp-emacs--ediff-review`, shared by the `apply_diff`
+tool and the IDE `openDiff` flow) starts by deleting side windows
+(Treemacs etc.) and forcing `ediff-setup-windows-plain`.
+That stops ediff aborting on a side/dedicated window (#10 / PR #20), but the
+resulting layout is whatever ediff happens to produce, and the user gets
+surprises: existing windows rearranged, side panels closed with no consistent
+place for the control panel, and — in the IDE flow — the pre-review layout is
+never restored at all.
+
+This change gives the review a dedicated, predictable window configuration and
+restores the user's layout when it ends.
+
+* Scope
+In scope: the shared `mcp-emacs--ediff-review` and the two callers
+(`mcp-emacs-apply-diff`, the IDE `open-diff` flow).
+Save/restore of the pre-review window configuration, consistent placement, and
+a placement defcustom mirroring the runner/popup customs.
+
+Out of scope: changing the accept/reject/quit decision logic, the timeout
+handling, or the diff content itself.
+This is UX/window-management only.
+
+* Approach
+Move the window-configuration save/restore into the shared review function so
+both callers get it (today only `apply-diff` saves a local `winconf`, and it
+restores *after* side windows were already deleted; the IDE flow restores
+nothing).
+
+- Capture `current-window-configuration` at the very start of
+  `mcp-emacs--ediff-review`, before any side window is touched.
+- Restore it once, in the single quit path (the `ediff-quit-hook` that already
+  fires exactly once), so side windows — including Treemacs — come back.
+- Add a `mcp-emacs-ediff-window-direction` defcustom (mirroring
+  `mcp-emacs-run-window-direction` / `-popup-direction`) selecting where the
+  review is placed; default keeps the current plain full-frame behaviour.
+- `apply-diff` drops its now-redundant local save/restore.
+
+* Tasks
+- [ ] Capture the window configuration at the start of `mcp-emacs--ediff-review`
+- [ ] Restore it in the quit hook (exactly once, both callers)
+- [ ] Add the `mcp-emacs-ediff-window-direction` defcustom
+- [ ] Remove the redundant winconf save/restore from `mcp-emacs-apply-diff`
+- [ ] Test: window configuration restored after accept, reject, and quit
+
+* Delta
+** Ediff review restores the pre-review window layout            :ADDED:
+:PROPERTIES:
+:AREA: ediff-review
+:END:
+The ediff diff review SHALL capture the window configuration before it
+alters any windows and SHALL restore it exactly once when the review ends,
+for both the ~apply_diff~ tool and the IDE ~open-diff~ flow, so the user's
+layout — including side windows such as Treemacs — is unchanged afterwards.
+*** Side windows come back after a review
+- GIVEN a frame with a Treemacs side window open
+- WHEN a diff review starts (removing the side window) and the user accepts,
+  rejects, or quits it
+- THEN the side window and the rest of the pre-review layout are restored
+*** Restore happens once per review
+- GIVEN a diff review in progress
+- WHEN the user resolves it by any path (accept key, reject key, or bare ~q~)
+- THEN the window configuration is restored exactly once, not per keypress
+** Ediff review placement is configurable                        :ADDED:
+:PROPERTIES:
+:AREA: ediff-review
+:END:
+The review SHALL offer a ~mcp-emacs-ediff-window-direction~ defcustom,
+mirroring the runner and popup window customs, so the diff appears in a
+predictable, user-chosen location; the default MUST preserve the current
+plain full-frame behaviour.
+*** Default keeps current behaviour
+- GIVEN a user who has not set the new defcustom
+- WHEN a diff review starts
+- THEN it uses the existing plain full-frame ediff layout

--- a/orgspec/specs/ediff-review.org
+++ b/orgspec/specs/ediff-review.org
@@ -1,0 +1,23 @@
+* Ediff review restores the pre-review window layout
+The ediff diff review SHALL capture the window configuration before it
+alters any windows and SHALL restore it exactly once when the review ends,
+for both the ~apply_diff~ tool and the IDE ~open-diff~ flow, so the user's
+layout — including side windows such as Treemacs — is unchanged afterwards.
+** Side windows come back after a review
+- GIVEN a frame with a Treemacs side window open
+- WHEN a diff review starts (removing the side window) and the user accepts,
+  rejects, or quits it
+- THEN the side window and the rest of the pre-review layout are restored
+** Restore happens once per review
+- GIVEN a diff review in progress
+- WHEN the user resolves it by any path (accept key, reject key, or bare ~q~)
+- THEN the window configuration is restored exactly once, not per keypress
+* Ediff review placement is configurable
+The review SHALL offer a ~mcp-emacs-ediff-window-direction~ defcustom,
+mirroring the runner and popup window customs, so the diff appears in a
+predictable, user-chosen location; the default MUST preserve the current
+plain full-frame behaviour.
+** Default keeps current behaviour
+- GIVEN a user who has not set the new defcustom
+- WHEN a diff review starts
+- THEN it uses the existing plain full-frame ediff layout

--- a/test/mcp-emacs-apply-diff-test.el
+++ b/test/mcp-emacs-apply-diff-test.el
@@ -1,4 +1,5 @@
 (add-to-list 'load-path (expand-file-name "elisp"))
+(require 'cl-lib)
 (require 'mcp-emacs)
 (defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
 
@@ -66,3 +67,57 @@
         (unless (car result) (setcar result 'rejected)) ; quit hook runs after
         (check "accept-survives-quit-hook" (car result) 'applied))
     (kill-buffer a) (kill-buffer b)))
+
+;;;; Window-layout save/restore (#21)
+
+;; `mcp-emacs--ediff-review' captures the window configuration up front and
+;; restores it in the quit hook, for both callers.  Stub `ediff-buffers' so
+;; the setup lambda runs (installing the key bindings and quit hook on a fake
+;; control buffer) without a real ediff session, then fire the quit hook and
+;; assert the layout is put back.
+(let* ((buffer-a (generate-new-buffer " *win-a*"))
+       (buffer-b (generate-new-buffer " *win-b*"))
+       (result (list nil))
+       (control (generate-new-buffer " *fake-control*"))
+       (restored nil)
+       (mcp-emacs-ediff-window-direction 'plain))
+  (with-current-buffer buffer-a (insert "old\n"))
+  (with-current-buffer buffer-b (insert "new\n"))
+  (unwind-protect
+      (cl-letf (((symbol-function 'ediff-buffers)
+                 (lambda (_a _b setup-hooks &rest _)
+                   ;; ediff would bind `ediff-control-buffer' and run the
+                   ;; setup hooks; emulate just enough for the setup lambda.
+                   (let ((ediff-control-buffer control))
+                     (dolist (fn setup-hooks) (funcall fn)))
+                   control))
+                ((symbol-function 'set-window-configuration)
+                 (lambda (&rest _) (setq restored t))))
+        (let ((ctl (mcp-emacs--ediff-review buffer-a buffer-b "old\n" result)))
+          (check "review-returns-control" ctl control)
+          (check "quit-hook-installed"
+                 (and (with-current-buffer control ediff-quit-hook) t) t)
+          ;; Fire the quit hook (the single quit path).
+          (with-current-buffer control (run-hooks 'ediff-quit-hook))
+          (check "quit-defaults-rejected" (car result) 'rejected)
+          (check "layout-restored-on-quit" restored t)))
+    (dolist (b (list buffer-a buffer-b control))
+      (when (buffer-live-p b) (kill-buffer b)))))
+
+;; The restore fires exactly once even though the hook could be entered per
+;; keypress: a second run with the decision already set must not re-default it.
+(let* ((result (list 'applied))
+       (restored-count 0)
+       (control (generate-new-buffer " *fake-control-2*")))
+  (unwind-protect
+      (cl-letf (((symbol-function 'set-window-configuration)
+                 (lambda (&rest _) (setq restored-count (1+ restored-count)))))
+        (with-current-buffer control
+          (setq-local ediff-quit-hook
+                      (list (lambda ()
+                              (unless (car result) (setcar result 'rejected))
+                              (ignore-errors (set-window-configuration nil))))))
+        (with-current-buffer control (run-hooks 'ediff-quit-hook))
+        (check "accept-preserved-through-restore" (car result) 'applied)
+        (check "restore-called-once-per-quit" restored-count 1))
+    (when (buffer-live-p control) (kill-buffer control))))


### PR DESCRIPTION
Gives the ediff diff review a predictable window layout and restores the user's layout when it ends (#21).

The shared `mcp-emacs--ediff-review` now captures the window configuration before it touches any window and restores it exactly once in the quit hook (ediff's single quit path), so both callers — `apply_diff` and the IDE `openDiff` flow — bring back the pre-review layout, side windows (Treemacs) included, on accept, reject, or quit. It also restores on a failed ediff setup before re-signalling. A new `mcp-emacs-ediff-window-direction` defcustom (default `plain`, i.e. the current full-frame behaviour) places the review predictably, mirroring `mcp-emacs-run-window-direction`. The now-redundant local save/restore is dropped from `apply-diff`.

Designed by dogfooding the orgspec workflow through the running Emacs (propose → parse → archive); the folded spec lives in `orgspec/specs/ediff-review.org`. Tests: 15 in the apply-diff suite (5 new for the window save/restore, once-per-quit, and accept-preservation).

Closes #21.