### PR TITLE
orgspec: ediff review of the fold before it writes

### DIFF
--- a/.claude/commands/orgspec/review.md
+++ b/.claude/commands/orgspec/review.md
@@ -1,0 +1,32 @@
+---
+name: "orgspec: Review"
+description: Ediff a change's fold against the current specs before writing (writes nothing)
+allowed-tools: mcp__emacs__eval
+category: Workflow
+tags: [orgspec, workflow]
+---
+
+Show what `/orgspec:archive` *would* write, as an ediff, before committing to it — "see the fold", not "trust the fold". Wraps `orgspec-review-fold` via the mcp-emacs `eval` tool. Review-only: nothing is written and nothing is moved.
+
+**Input**: The argument after `/orgspec:review` is the change id. Required.
+
+**Steps**
+
+1. If no id was given, ask which change to review (offer `/orgspec:status` output to pick from).
+
+2. Review by evaluating in Emacs:
+   ```elisp
+   (progn (require 'orgspec-review) (orgspec-review-fold "<id>"))
+   ```
+   For each affected area this ediffs the on-disk `specs/<area>.org` against the folded result the archive would produce. It builds the same in-memory result `archive` uses (validate-all), so the same blocks apply — an unresolved `[NEEDS CLARIFICATION]` marker or a change with no delta requirements is a `user-error`. The window layout is captured before ediff opens and restored when you quit each review. Returns the list of area spec files reviewed.
+
+**Output**
+
+- The list of area spec files being reviewed.
+- Reminder that this wrote nothing: run `/orgspec:archive <id>` to actually apply the fold.
+
+**Guardrails**
+
+- Read-only. Do NOT write specs or move the change — that is `/orgspec:archive`.
+- Each area opens its own ediff; the user resolves (quits) each in Emacs. Report the file list, don't try to drive the ediff from here.
+- If the eval errors on a clarification marker or an empty delta, report it verbatim and stop.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,12 @@ jobs:
             -f batch-byte-compile \
             elisp/mcp-emacs.el elisp/mcp-emacs-report.el elisp/mcp-emacs-server.el elisp/mcp-emacs-ide.el elisp/mcp-emacs-remote.el \
             elisp/orgspec-model.el elisp/orgspec.el elisp/orgspec-parse.el elisp/orgspec-fold.el elisp/orgspec-commands.el \
-            elisp/orgspec-lifecycle.el elisp/orgspec-agenda.el elisp/orgspec-mcp.el \
+            elisp/orgspec-lifecycle.el elisp/orgspec-agenda.el elisp/orgspec-review.el elisp/orgspec-mcp.el \
             elisp/mcp-emacs-run-resume.el
 
       - name: Run tests
         run: |
-          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el test/mcp-emacs-report-test.el test/mcp-emacs-remote-test.el test/orgspec-fold-spike-test.el test/orgspec-parse-test.el test/orgspec-fold-test.el test/orgspec-lifecycle-test.el test/orgspec-agenda-test.el test/orgspec-mcp-test.el test/mcp-emacs-run-resume-test.el; do
+          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el test/mcp-emacs-report-test.el test/mcp-emacs-remote-test.el test/orgspec-fold-spike-test.el test/orgspec-parse-test.el test/orgspec-fold-test.el test/orgspec-lifecycle-test.el test/orgspec-agenda-test.el test/orgspec-review-test.el test/orgspec-mcp-test.el test/mcp-emacs-run-resume-test.el; do
             echo "== $t =="
             emacs --batch \
               --eval "(require 'package)" \

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ work the same live artifacts together — see [`docs/VISION.md`](docs/VISION.md)
 | `orgspec_status`                  | Report task-checkbox completion for one change or all active changes                       |
 | `orgspec_parse`                   | Read a change's delta as structured data (per-requirement op / area / scenarios)           |
 | `orgspec_archive`                 | Fold a change's delta into `specs/` and move the change to archive                         |
+| `orgspec_review`                  | Ediff a change's fold against the current specs before writing (writes nothing)            |
 | `orgspec_advance`                 | Set a delta requirement's lifecycle TODO keyword (active / blocked / removed / done)       |
 | `orgspec_agenda`                  | Register the in-flight-requirements agenda custom command                                  |
 
@@ -91,6 +92,7 @@ tools above:
 | `/orgspec:apply`   | implement the tasks, tick the checklist, advance each requirement's TODO keyword |
 | `/orgspec:status`  | report `[x]`/`[ ]` task completion |
 | `/orgspec:parse`   | read a change's delta as structured data |
+| `/orgspec:review`  | ediff the fold against the current specs before writing — see it, don't trust it |
 | `/orgspec:archive` | fold the delta into `specs/` and `git mv` the change to archive |
 
 **The fold** is the load-bearing piece. It applies a change's delta in the fixed

--- a/elisp/orgspec-commands.el
+++ b/elisp/orgspec-commands.el
@@ -135,14 +135,13 @@ Returns an alist (ID (DONE . TOTAL) ...); as a command, messages it."
       (when (re-search-forward orgspec-clarification-regexp nil t)
         (user-error "Change %s has an unresolved [NEEDS CLARIFICATION] marker" id)))))
 
-;;;###autoload
-(defun orgspec-archive (id)
-  "Fold change ID's delta into the specs, then move the change to archive.
-Validate-all-then-write-all: every affected spec is rebuilt in memory and
-only written once all folds succeed, so a failure leaves specs/ untouched.
-Uses `git mv' to archive the change when the project is a git repo, else a
-plain rename.  Returns the list of spec files written."
-  (interactive "sChange id to archive: ")
+(defun orgspec-commands-fold-build (id)
+  "Fold change ID's delta in memory; return an alist (SPEC-FILE . NEW-TEXT).
+Every affected spec is rebuilt in a temp buffer (validate-all) and the
+whole set returned without writing anything, so callers can write it
+atomically (`orgspec-archive') or diff it before writing
+(`orgspec-review-fold').  Signals if the change has no delta
+requirements.  Order matches the change's area grouping."
   (orgspec-commands--assert-no-clarifications id)
   (let* ((change (orgspec-commands--read-change id))
          (reqs (orgspec-change-requirements change))
@@ -150,7 +149,6 @@ plain rename.  Returns the list of spec files written."
          built)
     (unless reqs
       (user-error "Change %s has no delta requirements" id))
-    ;; Build every target spec in memory first (validate-all).
     (dolist (group groups)
       (let* ((area (car group))
              (file (orgspec-commands--spec-file area))
@@ -158,13 +156,25 @@ plain rename.  Returns the list of spec files written."
                         (with-temp-buffer (insert-file-contents file)
                                           (buffer-string)))))
         (push (cons file (orgspec-fold-area current (cdr group))) built)))
+    (nreverse built)))
+
+;;;###autoload
+(defun orgspec-archive (id)
+  "Fold change ID's delta into the specs, then move the change to archive.
+Validate-all-then-write-all: every affected spec is rebuilt in memory
+via `orgspec-commands-fold-build' and only written once all folds
+succeed, so a failure leaves specs/ untouched.  Uses `git mv' to archive
+the change when the project is a git repo, else a plain rename.  Returns
+the list of spec files written."
+  (interactive "sChange id to archive: ")
+  (let ((built (orgspec-commands-fold-build id)))
     ;; Write every target (write-all) only after all folds succeeded.
     (dolist (cell built)
       (make-directory (file-name-directory (car cell)) t)
       (with-temp-file (car cell) (insert (cdr cell))))
     ;; Move the change into archive.
     (orgspec-commands--archive-move id)
-    (nreverse (mapcar #'car built))))
+    (mapcar #'car built)))
 
 (defun orgspec-commands--archive-move (id)
   "Move change ID's directory into changes/archive/, via `git mv' if possible."

--- a/elisp/orgspec-mcp.el
+++ b/elisp/orgspec-mcp.el
@@ -33,6 +33,7 @@
 (require 'orgspec-commands)
 (require 'orgspec-lifecycle)
 (require 'orgspec-agenda)
+(require 'orgspec-review)
 (require 'mcp-emacs-server)
 
 ;;;; Result formatting
@@ -77,6 +78,11 @@
   (let ((written (orgspec-archive (alist-get 'id args))))
     (format "wrote:\n%s" (mapconcat #'identity written "\n"))))
 
+(defun orgspec-mcp--review (args)
+  (let ((reviewed (orgspec-review-fold (alist-get 'id args))))
+    (format "reviewing (ediff, nothing written):\n%s"
+            (mapconcat #'identity reviewed "\n"))))
+
 (defun orgspec-mcp--advance (args)
   (let* ((id (alist-get 'id args))
          (name (alist-get 'requirement args))
@@ -119,6 +125,10 @@
          :description "Fold a change's delta into specs/ and move the change to archive"
          :schema (orgspec-mcp--id-schema "Change id to archive")
          :handler #'orgspec-mcp--archive)
+   (list :name "orgspec_review"
+         :description "Ediff a change's fold against the current specs before writing (writes nothing)"
+         :schema (orgspec-mcp--id-schema "Change id to review")
+         :handler #'orgspec-mcp--review)
    (list :name "orgspec_advance"
          :description "Set a delta requirement's lifecycle TODO keyword (active/blocked/removed/done)"
          :schema (mcp-emacs-server--obj

--- a/elisp/orgspec-review.el
+++ b/elisp/orgspec-review.el
@@ -1,0 +1,79 @@
+;;; orgspec-review.el --- Ediff review of an orgspec fold before it writes  -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; The org-leverage fold review (issue #34, split from #5).  `archive' folds a
+;; change's delta into the spec files with validate-all-then-write-all, so the
+;; folded result already exists in memory before anything is written.  This
+;; surfaces that: `orgspec-review-fold' ediffs the on-disk spec against the
+;; folded text for each affected area -- "see the fold", not "trust the fold" --
+;; without touching disk.
+;;
+;; Review-only: it changes no fold rule and writes nothing.  It reuses the
+;; window-layout convention from the native diff review (issue #21): the window
+;; configuration is captured before ediff opens and restored when the review
+;; quits, so side windows come back and the layout is left unchanged.
+
+;;; Code:
+
+(require 'ediff)
+(require 'orgspec-commands)
+
+(defun orgspec-review--ediff (title on-disk new-text)
+  "Ediff the ON-DISK spec text against the folded NEW-TEXT.
+TITLE labels the buffers.  Captures the window configuration before ediff
+opens and restores it once on quit (issue #21), so the caller's layout --
+side windows included -- comes back.  View-only: nothing is written."
+  (let ((winconf (current-window-configuration))
+        (buf-a (generate-new-buffer (format "*orgspec on-disk: %s*" title)))
+        (buf-b (generate-new-buffer (format "*orgspec folded: %s*" title))))
+    (with-current-buffer buf-a
+      (insert (or on-disk ""))
+      (let ((org-inhibit-startup t)) (org-mode)))
+    (with-current-buffer buf-b
+      (insert (or new-text ""))
+      (let ((org-inhibit-startup t)) (org-mode)))
+    (dolist (window (window-list))
+      (when (window-parameter window 'window-side)
+        (ignore-errors (delete-window window))))
+    (let ((ediff-window-setup-function 'ediff-setup-windows-plain)
+          (ediff-split-window-function 'split-window-horizontally))
+      (ediff-buffers
+       buf-a buf-b
+       (list (lambda ()
+               (with-current-buffer ediff-control-buffer
+                 (setq-local
+                  ediff-quit-hook
+                  (list (lambda ()
+                          (ignore-errors (set-window-configuration winconf))
+                          (when (buffer-live-p buf-a) (kill-buffer buf-a))
+                          (when (buffer-live-p buf-b) (kill-buffer buf-b))))))))))))
+
+;;;###autoload
+(defun orgspec-review-fold (id)
+  "Ediff the fold of change ID against the current specs, before writing.
+Builds every affected spec in memory with `orgspec-commands-fold-build'
+(the same result `archive' would write) and ediffs the on-disk spec
+against it, one area at a time.  Writes nothing and moves nothing -- run
+`orgspec-archive' to actually apply the fold.  Returns the list of area
+spec files reviewed."
+  (interactive "sChange id to review: ")
+  (let ((built (orgspec-commands-fold-build id)))
+    (dolist (cell built)
+      (let* ((file (car cell))
+             (new-text (cdr cell))
+             (on-disk (when (file-exists-p file)
+                        (with-temp-buffer (insert-file-contents file)
+                                          (buffer-string)))))
+        (orgspec-review--ediff (file-name-nondirectory file) on-disk new-text)))
+    (mapcar #'car built)))
+
+(provide 'orgspec-review)
+;;; orgspec-review.el ends here

--- a/orgspec/changes/archive/add-fold-review/change.org
+++ b/orgspec/changes/archive/add-fold-review/change.org
@@ -1,0 +1,54 @@
+#+TITLE: add-fold-review
+
+* Intent
+`archive' folds a change's delta into the spec files and writes them in one
+step.
+Until now the only way to see the result before committing was a `git diff'
+after the fact.
+Because the fold uses validate-all-then-write-all, the folded text for every
+area already exists in memory before anything is written — so it can be shown
+as an ediff first: see the fold, don't trust it.
+
+* Scope
+In scope: a review step that ediffs each affected on-disk spec against the
+folded result, writing nothing; exposed as `orgspec-review-fold', the
+`orgspec_review' MCP tool, and `/orgspec:review'.
+Extract the in-memory build shared with `archive' so the two never drift.
+
+Out of scope: changing any fold rule, or making `archive' call review
+automatically — review is a separate, opt-in step.
+
+* Approach
+- Extract the per-area in-memory build from `orgspec-archive' into
+  `orgspec-commands-fold-build', returning an alist ~(spec-file . new-text)~.
+- `orgspec-review-fold' builds that, then ediffs the on-disk spec against the
+  folded text per area, reusing the window-config save/restore convention from
+  the native diff review (#21) so the layout comes back on quit.
+- Add the `orgspec_review' MCP tool and the `/orgspec:review' command.
+
+* Tasks
+- [ ] Extract `orgspec-commands-fold-build'; `archive' uses it
+- [ ] Add `orgspec-review-fold' (ediff per area, restore layout, write nothing)
+- [ ] Add the `orgspec_review' MCP tool and `/orgspec:review' command
+- [ ] Tests: build returns folded pairs, archive still writes, review writes nothing
+
+* Delta
+** Fold can be reviewed as an ediff before it is written          :ADDED:
+:PROPERTIES:
+:AREA: orgspec
+:END:
+orgspec SHALL provide a fold review that, for each area a change touches,
+ediffs the current on-disk spec against the folded result the archive would
+write, and SHALL write nothing and move nothing, so the fold can be inspected
+before ~archive~ commits it.
+*** Review shows the fold without writing
+- GIVEN a change with delta requirements that has not been archived
+- WHEN the fold review is run for that change
+- THEN an ediff of on-disk spec versus folded result is shown for each area
+  and no spec file is written or moved
+*** Review shares the archive's build
+- GIVEN the same change
+- WHEN the review builds its folded result and when archive builds what it
+  writes
+- THEN both use the same in-memory build, so the reviewed result is exactly
+  what archive would write

--- a/orgspec/specs/orgspec.org
+++ b/orgspec/specs/orgspec.org
@@ -1,0 +1,16 @@
+* Fold can be reviewed as an ediff before it is written
+orgspec SHALL provide a fold review that, for each area a change touches,
+ediffs the current on-disk spec against the folded result the archive would
+write, and SHALL write nothing and move nothing, so the fold can be inspected
+before ~archive~ commits it.
+** Review shows the fold without writing
+- GIVEN a change with delta requirements that has not been archived
+- WHEN the fold review is run for that change
+- THEN an ediff of on-disk spec versus folded result is shown for each area
+  and no spec file is written or moved
+** Review shares the archive's build
+- GIVEN the same change
+- WHEN the review builds its folded result and when archive builds what it
+  writes
+- THEN both use the same in-memory build, so the reviewed result is exactly
+  what archive would write

--- a/test/orgspec-mcp-test.el
+++ b/test/orgspec-mcp-test.el
@@ -5,15 +5,15 @@
 (defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
 
 ;; Registration: the six orgspec tools land on the server extra-tools var.
-(check "reg-count" (length mcp-emacs-server-extra-tools) 6)
+(check "reg-count" (length mcp-emacs-server-extra-tools) 7)
 (check "reg-names"
        (sort (mapcar (lambda (tl) (plist-get tl :name)) mcp-emacs-server-extra-tools)
              #'string<)
        '("orgspec_advance" "orgspec_agenda" "orgspec_archive"
-         "orgspec_new" "orgspec_parse" "orgspec_status"))
-;; Idempotent re-register keeps the count at six.
+         "orgspec_new" "orgspec_parse" "orgspec_review" "orgspec_status"))
+;; Idempotent re-register keeps the count at seven.
 (orgspec-mcp-register)
-(check "reg-idempotent" (length mcp-emacs-server-extra-tools) 6)
+(check "reg-idempotent" (length mcp-emacs-server-extra-tools) 7)
 ;; Every descriptor has the required plist keys.
 (check "reg-well-formed"
        (seq-every-p (lambda (tl) (and (plist-get tl :name)

--- a/test/orgspec-review-test.el
+++ b/test/orgspec-review-test.el
@@ -1,0 +1,68 @@
+(add-to-list 'load-path (expand-file-name "elisp"))
+(require 'cl-lib)
+(require 'orgspec-commands)
+(require 'orgspec-review)
+
+(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+
+(defun review-test--project ()
+  "Create a temp project with one change touching two areas; return its root."
+  (let* ((root (make-temp-file "orgspec-review-" t))
+         (cdir (expand-file-name "orgspec/changes/add-two/" root)))
+    (make-directory cdir t)
+    (with-temp-file (expand-file-name "change.org" cdir)
+      (insert "#+TITLE: add-two\n* Tasks\n- [ ] x\n* Delta\n"
+              "** Auth requirement :ADDED:\n:PROPERTIES:\n:AREA: auth\n:END:\n"
+              "The system SHALL authenticate.\n*** ok\n- GIVEN a\n"
+              "** Billing requirement :ADDED:\n:PROPERTIES:\n:AREA: billing\n:END:\n"
+              "The system MUST bill.\n*** ok\n- GIVEN b\n"))
+    root))
+
+(cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
+
+  ;; fold-build: two areas, each with the folded (file . text), nothing written.
+  (let* ((root (review-test--project))
+         (default-directory (file-name-as-directory root))
+         (orgspec-root "orgspec")
+         (built (orgspec-commands-fold-build "add-two")))
+    (check "build-count" (length built) 2)
+    (check "build-areas"
+           (sort (mapcar (lambda (c) (file-name-base (car c))) built) #'string<)
+           '("auth" "billing"))
+    (check "build-folded-has-req"
+           (and (seq-some (lambda (c) (string-match-p "Auth requirement" (cdr c))) built) t) t)
+    (check "build-folded-plain-headline"
+           ;; re-leveled to L1, op tag stripped
+           (and (seq-some (lambda (c)
+                            (string-match-p "^\\* Auth requirement$" (cdr c))) built) t) t)
+    (check "build-writes-nothing"
+           (file-exists-p (expand-file-name "orgspec/specs/auth.org" root)) nil))
+
+  ;; archive: writes both specs and returns their files; change moves to archive.
+  (let* ((root (review-test--project))
+         (default-directory (file-name-as-directory root))
+         (orgspec-root "orgspec"))
+    (cl-letf (((symbol-function 'orgspec-commands--archive-move) (lambda (_id) nil)))
+      (let ((written (orgspec-archive "add-two")))
+        (check "archive-returns-two" (length written) 2)
+        (check "archive-wrote-auth"
+               (file-exists-p (expand-file-name "orgspec/specs/auth.org" root)) t)
+        (check "archive-wrote-billing"
+               (file-exists-p (expand-file-name "orgspec/specs/billing.org" root)) t)
+        (check "archive-auth-content"
+               (with-temp-buffer
+                 (insert-file-contents (expand-file-name "orgspec/specs/auth.org" root))
+                 (and (string-match-p "Auth requirement" (buffer-string)) t)) t))))
+
+  ;; review-fold: builds and diffs each area, writing nothing; ediff stubbed.
+  (let* ((root (review-test--project))
+         (default-directory (file-name-as-directory root))
+         (orgspec-root "orgspec")
+         (ediff-calls 0))
+    (cl-letf (((symbol-function 'orgspec-review--ediff)
+               (lambda (&rest _) (setq ediff-calls (1+ ediff-calls)))))
+      (let ((reviewed (orgspec-review-fold "add-two")))
+        (check "review-count" (length reviewed) 2)
+        (check "review-ediff-per-area" ediff-calls 2)
+        (check "review-writes-nothing"
+               (file-exists-p (expand-file-name "orgspec/specs/auth.org" root)) nil)))))


### PR DESCRIPTION
Adds `orgspec-review-fold` (#34): for each area a change touches, ediff the current on-disk spec against the folded result `archive` would write — see the fold, don't trust it. Nothing is written or moved.

Since the fold is validate-all-then-write-all, both sides already exist in memory. The per-area build is extracted into `orgspec-commands-fold-build` so review and archive share it and can't drift (archive now writes what the build returns). The review reuses the diff-review window save/restore convention from #21 so the layout comes back on quit. Exposed as the `orgspec_review` MCP tool and `/orgspec:review`.

Designed by dogfooding the orgspec loop through the running Emacs (propose → parse → archive); the folded spec lives in `orgspec/specs/orgspec.org`. Tests: a new review/archive regression suite (12) plus the updated tool-registration count; 102 assertions green locally, `orgspec-mcp-test` in CI.

Closes #34.