### PR TITLE
orgspec: hard-gate validator

### DIFF
--- a/.claude/commands/orgspec/validate.md
+++ b/.claude/commands/orgspec/validate.md
@@ -1,0 +1,39 @@
+---
+name: "orgspec: Validate"
+description: Run the hard-gate validator over a change and report problems
+allowed-tools: mcp__emacs__eval
+category: Workflow
+tags: [orgspec, workflow]
+---
+
+Run the hard-gate validator over a change's delta and report every structural problem, or "valid". Wraps `orgspec-validate-change` via the mcp-emacs `eval` tool. This is the same gate `/orgspec:archive` enforces — run it early to catch problems before you try to archive.
+
+**Input**: The argument after `/orgspec:validate` is the change id. Required.
+
+**Steps**
+
+1. If no id was given, ask which change to validate (offer `/orgspec:status` output to pick from).
+
+2. Validate by evaluating in Emacs:
+   ```elisp
+   (progn (require 'orgspec-validate)
+          (let ((errors (orgspec-validate-change
+                         (orgspec-commands--read-change "<id>"))))
+            (if errors (mapconcat #'identity errors "\n") "valid")))
+   ```
+   The ERROR rules checked:
+   - an ADDED/MODIFIED requirement body must contain `SHALL` or `MUST`;
+   - an ADDED/MODIFIED requirement must have at least one scenario;
+   - no duplicate requirement names within an op, and no duplicate `:FROM:`/`:TO:` across renames;
+   - no cross-op conflicts (a name in both MODIFIED and REMOVED, MODIFIED and ADDED, or ADDED and REMOVED; a renamed-to that collides with an ADDED name);
+   - at least one delta requirement in the change.
+
+**Output**
+
+- "valid", or the list of problems (one per line).
+- For each problem, point at the offending requirement in `change.org` and suggest the fix (add `SHALL`, add a scenario, rename, drop the duplicate op, …).
+
+**Guardrails**
+
+- Read-only. Do NOT modify `change.org` or any spec — just report.
+- Report the messages verbatim; they match what `/orgspec:archive` will refuse on.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
             -L elisp \
             -f batch-byte-compile \
             elisp/mcp-emacs.el elisp/mcp-emacs-report.el elisp/mcp-emacs-server.el elisp/mcp-emacs-ide.el elisp/mcp-emacs-remote.el \
-            elisp/orgspec-model.el elisp/orgspec.el elisp/orgspec-parse.el elisp/orgspec-fold.el elisp/orgspec-commands.el \
+            elisp/orgspec-model.el elisp/orgspec.el elisp/orgspec-parse.el elisp/orgspec-fold.el elisp/orgspec-validate.el elisp/orgspec-commands.el \
             elisp/orgspec-lifecycle.el elisp/orgspec-agenda.el elisp/orgspec-review.el elisp/orgspec-mcp.el \
             elisp/mcp-emacs-run-resume.el
 
       - name: Run tests
         run: |
-          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el test/mcp-emacs-report-test.el test/mcp-emacs-remote-test.el test/orgspec-fold-spike-test.el test/orgspec-parse-test.el test/orgspec-fold-test.el test/orgspec-lifecycle-test.el test/orgspec-agenda-test.el test/orgspec-review-test.el test/orgspec-mcp-test.el test/mcp-emacs-run-resume-test.el; do
+          for t in test/mcp-emacs-apply-diff-test.el test/mcp-emacs-ide-test.el test/mcp-emacs-report-test.el test/mcp-emacs-remote-test.el test/orgspec-fold-spike-test.el test/orgspec-parse-test.el test/orgspec-fold-test.el test/orgspec-lifecycle-test.el test/orgspec-agenda-test.el test/orgspec-review-test.el test/orgspec-validate-test.el test/orgspec-mcp-test.el test/mcp-emacs-run-resume-test.el; do
             echo "== $t =="
             emacs --batch \
               --eval "(require 'package)" \

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ work the same live artifacts together — see [`docs/VISION.md`](docs/VISION.md)
 | `orgspec_parse`                   | Read a change's delta as structured data (per-requirement op / area / scenarios)           |
 | `orgspec_archive`                 | Fold a change's delta into `specs/` and move the change to archive                         |
 | `orgspec_review`                  | Ediff a change's fold against the current specs before writing (writes nothing)            |
+| `orgspec_validate`                | Run the hard-gate validator over a change; report problems or valid                        |
 | `orgspec_advance`                 | Set a delta requirement's lifecycle TODO keyword (active / blocked / removed / done)       |
 | `orgspec_agenda`                  | Register the in-flight-requirements agenda custom command                                  |
 
@@ -93,6 +94,7 @@ tools above:
 | `/orgspec:status`  | report `[x]`/`[ ]` task completion |
 | `/orgspec:parse`   | read a change's delta as structured data |
 | `/orgspec:review`  | ediff the fold against the current specs before writing — see it, don't trust it |
+| `/orgspec:validate`| run the hard-gate validator (the same gate `archive` enforces) |
 | `/orgspec:archive` | fold the delta into `specs/` and `git mv` the change to archive |
 
 **The fold** is the load-bearing piece. It applies a change's delta in the fixed

--- a/elisp/orgspec-commands.el
+++ b/elisp/orgspec-commands.el
@@ -29,6 +29,7 @@
 (require 'orgspec-model)
 (require 'orgspec-parse)
 (require 'orgspec-fold)
+(require 'orgspec-validate)
 
 (defcustom orgspec-root "orgspec"
   "Directory (relative to the project root) holding specs and changes."
@@ -147,8 +148,9 @@ requirements.  Order matches the change's area grouping."
          (reqs (orgspec-change-requirements change))
          (groups (orgspec-fold--group-by-area reqs))
          built)
-    (unless reqs
-      (user-error "Change %s has no delta requirements" id))
+    ;; Hard gate: run the full validator before folding anything, so all
+    ;; structural problems are reported up front (covers the no-delta case).
+    (orgspec-validate-change-or-signal change)
     (dolist (group groups)
       (let* ((area (car group))
              (file (orgspec-commands--spec-file area))

--- a/elisp/orgspec-mcp.el
+++ b/elisp/orgspec-mcp.el
@@ -34,6 +34,7 @@
 (require 'orgspec-lifecycle)
 (require 'orgspec-agenda)
 (require 'orgspec-review)
+(require 'orgspec-validate)
 (require 'mcp-emacs-server)
 
 ;;;; Result formatting
@@ -83,6 +84,13 @@
     (format "reviewing (ediff, nothing written):\n%s"
             (mapconcat #'identity reviewed "\n"))))
 
+(defun orgspec-mcp--validate (args)
+  (let ((errors (orgspec-validate-change
+                 (orgspec-commands--read-change (alist-get 'id args)))))
+    (if errors
+        (format "invalid:\n- %s" (mapconcat #'identity errors "\n- "))
+      "valid")))
+
 (defun orgspec-mcp--advance (args)
   (let* ((id (alist-get 'id args))
          (name (alist-get 'requirement args))
@@ -129,6 +137,10 @@
          :description "Ediff a change's fold against the current specs before writing (writes nothing)"
          :schema (orgspec-mcp--id-schema "Change id to review")
          :handler #'orgspec-mcp--review)
+   (list :name "orgspec_validate"
+         :description "Run the hard-gate validator over a change; report problems or \"valid\""
+         :schema (orgspec-mcp--id-schema "Change id to validate")
+         :handler #'orgspec-mcp--validate)
    (list :name "orgspec_advance"
          :description "Set a delta requirement's lifecycle TODO keyword (active/blocked/removed/done)"
          :schema (mcp-emacs-server--obj

--- a/elisp/orgspec-validate.el
+++ b/elisp/orgspec-validate.el
@@ -1,0 +1,112 @@
+;;; orgspec-validate.el --- Hard-gate validator for orgspec changes  -*- lexical-binding: t; -*-
+
+;; Author: Gunnar Bastkowski
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools
+;; URL: https://github.com/gbastkowski/mcp-emacs
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; The hard-gate validator (issue #33, the "Full" rules from #5).  It runs the
+;; ERROR rules over a parsed `orgspec-change' and returns the list of problems;
+;; `orgspec-validate-change-or-signal' turns a non-empty result into a
+;; `user-error', so `archive' can gate on it.
+;;
+;; Rules (ported from OpenSpec's validator; messages adapted to org since the
+;; original wording is Markdown-parser specific):
+;;   - An ADDED/MODIFIED requirement body must contain SHALL or MUST.
+;;   - An ADDED/MODIFIED requirement must have at least one scenario.
+;;   - No duplicate requirement names within a single op (ADDED / MODIFIED /
+;;     REMOVED), and no duplicate FROM or TO across RENAMED.
+;;   - No cross-op conflicts: a name in both MODIFIED and REMOVED, both MODIFIED
+;;     and ADDED, or both ADDED and REMOVED; a RENAMED TO that collides with an
+;;     ADDED name.
+;;   - At least one delta requirement across the whole change.
+;; The fold already enforces some of this implicitly (its scenario drop-guard,
+;; the no-delta check in `orgspec-archive'); this makes the rules explicit and
+;; reports them all up front, before any fold runs.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'orgspec)
+(require 'orgspec-model)
+
+(defun orgspec-validate--op-name (op)
+  "Return the uppercase op-tag string for op symbol OP."
+  (or (orgspec-op-tag-name op) (upcase (symbol-name op))))
+
+(defun orgspec-validate--dups (names)
+  "Return the list of NAMES that occur more than once, each once."
+  (let (seen dups)
+    (dolist (n names)
+      (if (member n seen)
+          (unless (member n dups) (push n dups))
+        (push n seen)))
+    (nreverse dups)))
+
+(defun orgspec-validate-change (change)
+  "Return the list of validation ERROR messages for CHANGE (empty if valid)."
+  (let* ((reqs (orgspec-change-requirements change))
+         (by-op (lambda (op) (seq-filter
+                              (lambda (r) (eq (orgspec-requirement-op r) op)) reqs)))
+         (names-of (lambda (rs) (mapcar #'orgspec-requirement-name rs)))
+         (added (funcall by-op 'added))
+         (modified (funcall by-op 'modified))
+         (removed (funcall by-op 'removed))
+         (renamed (funcall by-op 'renamed))
+         (added-names (funcall names-of added))
+         (modified-names (funcall names-of modified))
+         (removed-names (funcall names-of removed))
+         errors)
+    (cl-flet ((err (fmt &rest args) (push (apply #'format fmt args) errors)))
+      ;; At least one delta requirement overall.
+      (unless reqs
+        (err "Change must have at least one delta"))
+      ;; SHALL/MUST + scenarios for ADDED and MODIFIED.
+      (dolist (r (append added modified))
+        (let ((op (orgspec-validate--op-name (orgspec-requirement-op r)))
+              (name (orgspec-requirement-name r)))
+          (unless (string-match-p orgspec-normative-regexp
+                                  (or (orgspec-requirement-body r) ""))
+            (err "%s \"%s\" must contain SHALL or MUST" op name))
+          (unless (orgspec-requirement-scenarios r)
+            (err "%s \"%s\" must include at least one scenario" op name))))
+      ;; Duplicate names within an op.
+      (dolist (cell (list (cons 'added added-names)
+                          (cons 'modified modified-names)
+                          (cons 'removed removed-names)))
+        (dolist (dup (orgspec-validate--dups (cdr cell)))
+          (err "Duplicate requirement in %s: \"%s\""
+               (orgspec-validate--op-name (car cell)) dup)))
+      ;; Duplicate FROM / TO across RENAMED.
+      (dolist (dup (orgspec-validate--dups
+                    (delq nil (mapcar #'orgspec-requirement-from renamed))))
+        (err "Duplicate FROM in RENAMED: \"%s\"" dup))
+      (dolist (dup (orgspec-validate--dups (funcall names-of renamed)))
+        (err "Duplicate TO in RENAMED: \"%s\"" dup))
+      ;; Cross-op conflicts.
+      (dolist (n (seq-intersection modified-names removed-names))
+        (err "Requirement present in both MODIFIED and REMOVED: \"%s\"" n))
+      (dolist (n (seq-intersection modified-names added-names))
+        (err "Requirement present in both MODIFIED and ADDED: \"%s\"" n))
+      (dolist (n (seq-intersection added-names removed-names))
+        (err "Requirement present in both ADDED and REMOVED: \"%s\"" n))
+      (dolist (r renamed)
+        (let ((to (orgspec-requirement-name r)))
+          (when (member to added-names)
+            (err "RENAMED TO collides with ADDED for \"%s\"" to)))))
+    (nreverse errors)))
+
+(defun orgspec-validate-change-or-signal (change)
+  "Validate CHANGE; signal a `user-error' listing every problem, else return t."
+  (let ((errors (orgspec-validate-change change)))
+    (when errors
+      (user-error "orgspec validation failed:\n- %s"
+                  (string-join errors "\n- ")))
+    t))
+
+(provide 'orgspec-validate)
+;;; orgspec-validate.el ends here

--- a/orgspec/changes/archive/add-validator/change.org
+++ b/orgspec/changes/archive/add-validator/change.org
@@ -1,0 +1,52 @@
+#+TITLE: add-validator
+
+* Intent
+The fold enforced only a couple of rules implicitly (its scenario drop-guard,
+the no-delta check in `archive').
+Structural problems in a change's delta — a requirement with no normative
+keyword, no scenario, a duplicate name, or a cross-op conflict — were only
+caught late or not at all.
+A hard-gate validator reports them all up front, before any fold runs, and
+`archive' refuses on them.
+
+* Scope
+In scope: `orgspec-validate.el' with the ERROR rules from OpenSpec (messages
+adapted to org), gating `archive' via the shared build, and exposed as the
+`orgspec_validate' MCP tool and `/orgspec:validate'.
+
+Out of scope: warnings/lint beyond the ERROR rules, and validating spec files
+themselves (only change deltas).
+
+* Approach
+- `orgspec-validate-change' returns the list of ERROR messages for a parsed
+  change; `orgspec-validate-change-or-signal' turns a non-empty result into a
+  `user-error'.
+- Gate the shared `orgspec-commands-fold-build' on it, so both `archive' and
+  `review' refuse an invalid change.
+- Add the `orgspec_validate' MCP tool and `/orgspec:validate' command.
+
+* Tasks
+- [ ] Add `orgspec-validate.el' with the ERROR rules
+- [ ] Gate the shared fold build on the validator
+- [ ] Add the `orgspec_validate' MCP tool and `/orgspec:validate' command
+- [ ] Tests: valid change passes; each rule fires with its message
+
+* Delta
+** Changes are validated before they are folded                  :ADDED:
+:PROPERTIES:
+:AREA: orgspec
+:END:
+orgspec SHALL validate a change's delta before folding it, reporting every
+ERROR — a missing SHALL/MUST keyword, a missing scenario, a duplicate name
+within an op, or a cross-op conflict — and `archive` MUST refuse to fold a
+change that has any such error.
+*** Invalid change is refused
+- GIVEN a change whose ADDED requirement has no scenario
+- WHEN the change is archived
+- THEN the fold is refused and the scenario error is reported, and no spec
+  file is written
+*** Valid change passes the gate
+- GIVEN a change whose requirements all carry SHALL/MUST and a scenario with
+  no duplicate or cross-op conflict
+- WHEN the change is validated
+- THEN it reports as valid and archive proceeds

--- a/orgspec/specs/orgspec.org
+++ b/orgspec/specs/orgspec.org
@@ -14,3 +14,18 @@ before ~archive~ commits it.
   writes
 - THEN both use the same in-memory build, so the reviewed result is exactly
   what archive would write
+* Changes are validated before they are folded
+orgspec SHALL validate a change's delta before folding it, reporting every
+ERROR — a missing SHALL/MUST keyword, a missing scenario, a duplicate name
+within an op, or a cross-op conflict — and `archive` MUST refuse to fold a
+change that has any such error.
+** Invalid change is refused
+- GIVEN a change whose ADDED requirement has no scenario
+- WHEN the change is archived
+- THEN the fold is refused and the scenario error is reported, and no spec
+  file is written
+** Valid change passes the gate
+- GIVEN a change whose requirements all carry SHALL/MUST and a scenario with
+  no duplicate or cross-op conflict
+- WHEN the change is validated
+- THEN it reports as valid and archive proceeds

--- a/test/orgspec-mcp-test.el
+++ b/test/orgspec-mcp-test.el
@@ -5,15 +5,16 @@
 (defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
 
 ;; Registration: the six orgspec tools land on the server extra-tools var.
-(check "reg-count" (length mcp-emacs-server-extra-tools) 7)
+(check "reg-count" (length mcp-emacs-server-extra-tools) 8)
 (check "reg-names"
        (sort (mapcar (lambda (tl) (plist-get tl :name)) mcp-emacs-server-extra-tools)
              #'string<)
        '("orgspec_advance" "orgspec_agenda" "orgspec_archive"
-         "orgspec_new" "orgspec_parse" "orgspec_review" "orgspec_status"))
-;; Idempotent re-register keeps the count at seven.
+         "orgspec_new" "orgspec_parse" "orgspec_review"
+         "orgspec_status" "orgspec_validate"))
+;; Idempotent re-register keeps the count at eight.
 (orgspec-mcp-register)
-(check "reg-idempotent" (length mcp-emacs-server-extra-tools) 7)
+(check "reg-idempotent" (length mcp-emacs-server-extra-tools) 8)
 ;; Every descriptor has the required plist keys.
 (check "reg-well-formed"
        (seq-every-p (lambda (tl) (and (plist-get tl :name)

--- a/test/orgspec-validate-test.el
+++ b/test/orgspec-validate-test.el
@@ -1,0 +1,148 @@
+(add-to-list 'load-path (expand-file-name "elisp"))
+(require 'orgspec-parse)
+(require 'orgspec-validate)
+
+(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+
+(defun val-test--change (s)
+  (with-temp-buffer
+    (let ((org-inhibit-startup t)) (org-mode))
+    (insert s)
+    (orgspec-parse-change "t")))
+
+(defun val-test--errors (s) (orgspec-validate-change (val-test--change s)))
+(defun val-test--has (s substr)
+  (and (seq-some (lambda (e) (string-match-p (regexp-quote substr) e))
+                 (val-test--errors s))
+       t))
+
+;; A canonical valid change: ADDED with SHALL + a scenario.
+(check "valid-clean"
+       (val-test--errors "* Delta
+** Notify on lockout :ADDED:
+:PROPERTIES:
+:AREA: auth
+:END:
+The system SHALL notify.
+*** ok
+- GIVEN a
+")
+       nil)
+
+;; No delta requirements at all.
+(check "no-delta"
+       (val-test--has "* Delta\n" "at least one delta") t)
+
+;; ADDED without SHALL/MUST.
+(check "added-no-shall"
+       (val-test--has "* Delta
+** Weak req :ADDED:
+:PROPERTIES:
+:AREA: a
+:END:
+This just describes something.
+*** ok
+- GIVEN a
+" "must contain SHALL or MUST") t)
+
+;; MODIFIED without a scenario.
+(check "modified-no-scenario"
+       (val-test--has "* Delta
+** Change it :MODIFIED:
+:PROPERTIES:
+:AREA: a
+:END:
+The system SHALL change.
+" "must include at least one scenario") t)
+
+;; Duplicate name within ADDED.
+(check "dup-added"
+       (val-test--has "* Delta
+** Dup :ADDED:
+:PROPERTIES:
+:AREA: a
+:END:
+SHALL a.
+*** s
+- GIVEN a
+** Dup :ADDED:
+:PROPERTIES:
+:AREA: a
+:END:
+SHALL b.
+*** s
+- GIVEN b
+" "Duplicate requirement in ADDED: \"Dup\"") t)
+
+;; Cross-op: same name in MODIFIED and REMOVED.
+(check "modified-and-removed"
+       (val-test--has "* Delta
+** X :MODIFIED:
+:PROPERTIES:
+:AREA: a
+:END:
+SHALL x.
+*** s
+- GIVEN a
+** X :REMOVED:
+:PROPERTIES:
+:AREA: a
+:END:
+gone.
+" "both MODIFIED and REMOVED: \"X\"") t)
+
+;; Cross-op: ADDED and REMOVED.
+(check "added-and-removed"
+       (val-test--has "* Delta
+** Y :ADDED:
+:PROPERTIES:
+:AREA: a
+:END:
+SHALL y.
+*** s
+- GIVEN a
+** Y :REMOVED:
+:PROPERTIES:
+:AREA: a
+:END:
+gone.
+" "both ADDED and REMOVED: \"Y\"") t)
+
+;; RENAMED TO collides with ADDED.
+(check "renamed-collides-added"
+       (val-test--has "* Delta
+** NewName :ADDED:
+:PROPERTIES:
+:AREA: a
+:END:
+SHALL n.
+*** s
+- GIVEN a
+** NewName :RENAMED:
+:PROPERTIES:
+:AREA: a
+:FROM: OldName
+:END:
+SHALL n.
+*** s
+- GIVEN a
+" "RENAMED TO collides with ADDED for \"NewName\"") t)
+
+;; or-signal raises on invalid, returns t on valid.
+(check "signal-raises"
+       (condition-case _ (progn (orgspec-validate-change-or-signal
+                                 (val-test--change "* Delta\n")) 'no-error)
+         (user-error 'raised))
+       'raised)
+(check "signal-ok"
+       (orgspec-validate-change-or-signal
+        (val-test--change "* Delta
+** Good :ADDED:
+:PROPERTIES:
+:AREA: a
+:END:
+The system SHALL work.
+*** s
+- GIVEN a
+"))
+       t)


### PR DESCRIPTION
Adds `orgspec-validate.el` (#33), the last "Full" piece from #5. `orgspec-validate-change` runs the ERROR rules over a parsed change and returns every problem; `orgspec-validate-change-or-signal` raises a `user-error` listing them.

Rules (ported from OpenSpec's validator, messages adapted to org):
- an ADDED/MODIFIED requirement body must contain `SHALL` or `MUST`;
- an ADDED/MODIFIED requirement must have at least one scenario;
- no duplicate names within an op, and no duplicate `:FROM:`/`:TO:` across renames;
- no cross-op conflicts (MODIFIED+REMOVED, MODIFIED+ADDED, ADDED+REMOVED, renamed-to vs ADDED);
- at least one delta requirement.

The shared `orgspec-commands-fold-build` is gated on it, so both `archive` and `review` refuse an invalid change (this subsumes the old ad-hoc no-delta check). Exposed as the `orgspec_validate` MCP tool and `/orgspec:validate`.

Dogfooded through the running Emacs (validate → archive); the folded spec lives in `orgspec/specs/orgspec.org`. Tests translate the OpenSpec validation cases to org (valid change passes; each rule fires with its message). 112 assertions green locally; `orgspec-mcp-test` (8 tools now) in CI.

Closes #33.