### PR TITLE
Resolve apply_diff reviews asynchronously

### DIFF
--- a/elisp/mcp-emacs-server.el
+++ b/elisp/mcp-emacs-server.el
@@ -316,6 +316,16 @@ rather than `null' (an empty alist would)."
                                 "new_content" (mcp-emacs-server--prop "string" "Proposed new content for the file")
                                 "timeout" (mcp-emacs-server--prop "integer" "Timeout in seconds (default 120, capped at 600)"))
                   "required" (vector "path" "new_content"))
+         ;; Async: the human has to answer this one, so the request is
+         ;; deferred rather than blocking the process filter (which would
+         ;; leave no command loop for the ediff panel).  `:handler' stays as
+         ;; the synchronous fallback for callers that dispatch directly.
+         :async-handler (lambda (args done)
+                          (mcp-emacs-apply-diff-async
+                           (alist-get 'path args)
+                           (alist-get 'new_content args)
+                           (alist-get 'timeout args)
+                           done))
          :handler (lambda (args)
                     (mcp-emacs-apply-diff
                      (alist-get 'path args)
@@ -470,6 +480,13 @@ they are exposed without editing the core tool list.")
                      "inputSchema" (plist-get tool :schema)))
                   (mcp-emacs-server--all-tools)))))
 
+(defun mcp-emacs-server--text-result (text)
+  "Wrap TEXT as a tools/call result value."
+  (mcp-emacs-server--obj
+   "content" (vector (mcp-emacs-server--obj
+                      "type" "text"
+                      "text" (format "%s" (or text ""))))))
+
 (defun mcp-emacs-server--tools-call (params)
   "Execute a tools/call request described by PARAMS, return the result value."
   (let* ((name (alist-get 'name params))
@@ -477,11 +494,29 @@ they are exposed without editing the core tool list.")
          (tool (mcp-emacs-server--find-tool name)))
     (unless tool
       (error "Unknown tool: %s" name))
-    (let ((text (funcall (plist-get tool :handler) args)))
-      (mcp-emacs-server--obj
-       "content" (vector (mcp-emacs-server--obj
-                          "type" "text"
-                          "text" (format "%s" (or text ""))))))))
+    (mcp-emacs-server--text-result
+     (funcall (plist-get tool :handler) args))))
+
+(defun mcp-emacs-server--tools-call-async (params id send)
+  "Start the async tools/call described by PARAMS for request ID.
+Call SEND with the finished JSON-RPC response object once the tool
+resolves.  Return non-nil when PARAMS named an async tool and the call was
+started, nil when the tool is synchronous and should be dispatched
+normally.
+
+Async tools are for reviews a human has to answer: blocking the process
+filter would leave Emacs without a command loop to answer them in."
+  (let* ((name (alist-get 'name params))
+         (args (alist-get 'arguments params))
+         (tool (mcp-emacs-server--find-tool name))
+         (async (and tool (plist-get tool :async-handler))))
+    (when async
+      (funcall
+       async args
+       (lambda (text)
+         (funcall send (mcp-emacs-server--result
+                        id (mcp-emacs-server--text-result text)))))
+      t)))
 
 (defun mcp-emacs-server--resources-list ()
   "Return the JSON value for a resources/list result."
@@ -571,14 +606,31 @@ Returns nil for notifications, which require no response."
       (cond
        ;; POST with a JSON-RPC body: the normal MCP request path.
        ((and is-post rpc)
-        (let* ((response (mcp-emacs-server--dispatch rpc)))
-          (if response
-              (let ((json (json-encode response)))
-                (ws-response-header process 200
-                                    '("Content-Type" . "application/json"))
-                (process-send-string process json))
-            ;; Notification: 202 Accepted, empty body.
-            (ws-response-header process 202 '("Content-Type" . "application/json")))))
+        ;; Async tools (human-answered reviews) must not block the filter:
+        ;; hold the connection open, return to the event loop, and write the
+        ;; response from the tool's callback.  `:keep-alive' tells
+        ;; `ws-filter' to leave this process undeleted.
+        (if (and (equal (alist-get 'method rpc) "tools/call")
+                 (alist-get 'id rpc)
+                 (mcp-emacs-server--tools-call-async
+                  (alist-get 'params rpc)
+                  (alist-get 'id rpc)
+                  (lambda (response)
+                    (when (process-live-p process)
+                      (let ((json (json-encode response)))
+                        (ws-response-header
+                         process 200 '("Content-Type" . "application/json"))
+                        (process-send-string process json))
+                      (delete-process process)))))
+            (throw 'close-connection :keep-alive)
+          (let* ((response (mcp-emacs-server--dispatch rpc)))
+            (if response
+                (let ((json (json-encode response)))
+                  (ws-response-header process 200
+                                      '("Content-Type" . "application/json"))
+                  (process-send-string process json))
+              ;; Notification: 202 Accepted, empty body.
+              (ws-response-header process 202 '("Content-Type" . "application/json"))))))
        ;; Anything else: minimal health response.
        (t
         (ws-response-header process 200 '("Content-Type" . "text/plain"))

--- a/elisp/mcp-emacs.el
+++ b/elisp/mcp-emacs.el
@@ -1092,6 +1092,79 @@ timeout."
              (signal (car err) (cdr err))))
     control))
 
+(defun mcp-emacs-apply-diff-async (path new-content timeout on-done)
+  "Review NEW-CONTENT against the file at PATH via ediff, without blocking.
+Open the ediff session and return immediately; ON-DONE is called with one
+argument -- the outcome string, in the same format
+`mcp-emacs-apply-diff' returns -- once the human accepts or rejects, or
+when TIMEOUT elapses.
+
+This exists because the synchronous variant cannot be resolved by a human
+when it is served from a process filter: Emacs runs filters with
+`inhibit-quit' bound to t and no command loop for the ediff control
+panel, so the review is displayed but its keys are dead.  Returning to
+the event loop instead -- and answering the request from the ediff quit
+hook -- keeps the panel interactive.  See `mcp-emacs-server--handler' for
+the HTTP side of the deferral.
+
+TIMEOUT is capped at `mcp-emacs-apply-diff-max-timeout' and defaults to
+`mcp-emacs-apply-diff-default-timeout'."
+  (condition-case err
+      (let* ((file (expand-file-name path))
+             (buffer-a (find-file-noselect file))
+             (entry-content (with-current-buffer buffer-a
+                              (buffer-substring-no-properties
+                               (point-min) (point-max))))
+             (buffer-b (generate-new-buffer
+                        (format "*mcp-apply-diff: %s*"
+                                (file-name-nondirectory file))))
+             (result (list nil))
+             (secs (min mcp-emacs-apply-diff-max-timeout
+                        (if (and (numberp timeout) (> timeout 0))
+                            timeout
+                          mcp-emacs-apply-diff-default-timeout)))
+             ;; Guards single delivery: the quit hook and the timeout timer
+             ;; race, and whichever arrives first must be the only answer.
+             (done (list nil))
+             control timer)
+        (with-current-buffer buffer-b
+          (insert new-content)
+          (let ((mode (assoc-default file auto-mode-alist 'string-match)))
+            (when (functionp mode) (ignore-errors (funcall mode)))))
+        (let ((finish
+               (lambda (outcome)
+                 (unless (car done)
+                   (setcar done t)
+                   (when timer (cancel-timer timer))
+                   (when (buffer-live-p buffer-b) (kill-buffer buffer-b))
+                   (funcall on-done outcome)))))
+          (setq control
+                (mcp-emacs--ediff-review
+                 buffer-a buffer-b entry-content result
+                 (lambda ()
+                   (funcall
+                    finish
+                    (if (eq (car result) 'applied)
+                        (format "Status: applied\n%s"
+                                (with-current-buffer buffer-a
+                                  (buffer-substring-no-properties
+                                   (point-min) (point-max))))
+                      "Status: rejected")))))
+          ;; Timeout arms only after setup succeeded, so a failed ediff
+          ;; cannot leave a timer pointing at a dead session.
+          (setq timer
+                (run-at-time
+                 secs nil
+                 (lambda ()
+                   (when (and control (buffer-live-p control))
+                     (with-current-buffer control
+                       (if (fboundp 'ediff-really-quit)
+                           (ignore-errors (ediff-really-quit nil))
+                         (kill-buffer control))))
+                   (funcall finish "Status: timeout")))))
+        nil)
+    (error (funcall on-done (error-message-string err)) nil)))
+
 (defun mcp-emacs-apply-diff (path new-content timeout)
   "Present NEW-CONTENT as a proposed change to the file at PATH via ediff.
 Open an `ediff-buffers' session comparing the file's current content

--- a/test/mcp-emacs-apply-diff-test.el
+++ b/test/mcp-emacs-apply-diff-test.el
@@ -121,3 +121,171 @@
         (check "accept-preserved-through-restore" (car result) 'applied)
         (check "restore-called-once-per-quit" restored-count 1))
     (when (buffer-live-p control) (kill-buffer control))))
+
+;;;; Async apply-diff (deferred resolution)
+;;
+;; `mcp-emacs-apply-diff-async' must return immediately and answer later via
+;; its callback: blocking here is exactly the bug it exists to avoid (a
+;; process filter has `inhibit-quit' set and no command loop, so the ediff
+;; panel renders but cannot be answered).  These tests stub `ediff-buffers'
+;; the same way the layout tests above do, capture the ON-RESOLVE callback
+;; that `mcp-emacs--ediff-review' installs, and fire it by hand.
+
+(defmacro mcp--with-async-review (bindings &rest body)
+  "Run BODY with `ediff-buffers' stubbed for an async apply-diff test.
+BINDINGS is a list of (VAR . INIT) forms evaluated before the stub is
+installed.  Inside BODY, `resolve' calls the captured ON-RESOLVE callback
+and `control' is the fake control buffer."
+  (declare (indent 1))
+  `(let* ((control (generate-new-buffer " *fake-async-control*"))
+          (captured nil)
+          ,@bindings)
+     (unwind-protect
+         (cl-letf (((symbol-function 'ediff-buffers)
+                    (lambda (_a _b setup-hooks &rest _)
+                      (let ((ediff-control-buffer control))
+                        (dolist (fn setup-hooks) (funcall fn)))
+                      control))
+                   ;; Never touch the real window layout from batch.
+                   ((symbol-function 'set-window-configuration)
+                    (lambda (&rest _) nil))
+                   ;; Capture ON-RESOLVE instead of driving a real ediff.
+                   ((symbol-function 'mcp-emacs--ediff-review)
+                    (lambda (_a _b _entry _result &optional on-resolve _tab)
+                      (setq captured on-resolve)
+                      control)))
+           (cl-flet ((resolve () (when captured (funcall captured))))
+             ,@body))
+       (when (buffer-live-p control) (kill-buffer control)))))
+
+;; A temp file to review against; `mcp-emacs-apply-diff-async' opens PATH
+;; with `find-file-noselect', so it must exist on disk.
+(defun mcp--async-fixture ()
+  "Return a fresh temp file path containing \"old\\n\"."
+  (let ((f (make-temp-file "mcp-async-" nil ".txt" "old\n")))
+    f))
+
+;; Returns immediately (nil) rather than blocking until a decision, and does
+;; not invoke the callback before the human resolves.
+(let ((file (mcp--async-fixture)))
+  (unwind-protect
+      (mcp--with-async-review ((calls nil))
+        (let ((ret (mcp-emacs-apply-diff-async
+                    file "new\n" 60 (lambda (out) (push out calls)))))
+          (check "async-returns-immediately" ret nil)
+          (check "async-no-callback-before-resolve" calls nil)))
+    (delete-file file)))
+
+;; Accept -> the callback gets "Status: applied" plus buffer A's content.
+;; The stub must expose the RESULT cell so the test can record an accept the
+;; way the real accept key binding does; otherwise only the reject branch is
+;; ever reachable and the applied path goes untested.
+(let ((file (mcp--async-fixture)))
+  (unwind-protect
+      (let* ((control (generate-new-buffer " *fake-async-control*"))
+             (captured nil)
+             (cell nil)
+             (calls nil))
+        (unwind-protect
+            (cl-letf (((symbol-function 'mcp-emacs--ediff-review)
+                       (lambda (_a _b _entry result &optional on-resolve _tab)
+                         (setq captured on-resolve
+                               cell result)
+                         control)))
+              (mcp-emacs-apply-diff-async
+               file "new\n" 60 (lambda (out) (push out calls)))
+              ;; Mirror the accept command: record the decision, and put the
+              ;; proposal into buffer A (which is what gets reported back).
+              (setcar cell 'applied)
+              (let ((buf (find-buffer-visiting file)))
+                (with-current-buffer buf (erase-buffer) (insert "new\n")))
+              (funcall captured)
+              (check "async-accept-count" (length calls) 1)
+              (check "async-accept-status"
+                     (car calls) "Status: applied\nnew\n"))
+          (when (buffer-live-p control) (kill-buffer control))))
+    (let ((buf (find-buffer-visiting file)))
+      (when buf (with-current-buffer buf (set-buffer-modified-p nil))
+            (kill-buffer buf)))
+    (delete-file file)))
+
+;; Resolving twice must deliver exactly one answer: the quit hook can fire
+;; again (e.g. a second `q') after the decision is already recorded.
+(let ((file (mcp--async-fixture)))
+  (unwind-protect
+      (mcp--with-async-review ((calls nil))
+        (mcp-emacs-apply-diff-async
+         file "new\n" 60 (lambda (out) (push out calls)))
+        (resolve)
+        (resolve)
+        (check "async-single-delivery" (length calls) 1))
+    (let ((buf (find-buffer-visiting file)))
+      (when buf (with-current-buffer buf (set-buffer-modified-p nil))
+            (kill-buffer buf)))
+    (delete-file file)))
+
+;; Rejection surfaces as "Status: rejected" (result cell left unset).
+(let ((file (mcp--async-fixture)))
+  (unwind-protect
+      (mcp--with-async-review ((calls nil))
+        (mcp-emacs-apply-diff-async
+         file "new\n" 60 (lambda (out) (push out calls)))
+        (resolve)
+        (check "async-reject-status" (car calls) "Status: rejected"))
+    (let ((buf (find-buffer-visiting file)))
+      (when buf (with-current-buffer buf (set-buffer-modified-p nil))
+            (kill-buffer buf)))
+    (delete-file file)))
+
+;; Timeout fires the callback with "Status: timeout" when nobody resolves.
+;; A 1-second timeout keeps the batch run short.
+(let ((file (mcp--async-fixture)))
+  (unwind-protect
+      (mcp--with-async-review ((calls nil))
+        (mcp-emacs-apply-diff-async
+         file "new\n" 1 (lambda (out) (push out calls)))
+        (check "async-timeout-not-yet" calls nil)
+        (sleep-for 2)
+        (check "async-timeout-status" (car calls) "Status: timeout")
+        (check "async-timeout-single" (length calls) 1)
+        ;; A late human resolve after a timeout must not answer twice.
+        (resolve)
+        (check "async-timeout-then-resolve-single" (length calls) 1))
+    (let ((buf (find-buffer-visiting file)))
+      (when buf (with-current-buffer buf (set-buffer-modified-p nil))
+            (kill-buffer buf)))
+    (delete-file file)))
+
+;; The timeout timer is cancelled once the review resolves, so a finished
+;; review leaves nothing pending behind it.
+(let ((file (mcp--async-fixture)))
+  (unwind-protect
+      (mcp--with-async-review ((calls nil))
+        ;; Assert on `timer-list' directly.  The single-delivery guard would
+        ;; suppress a second callback even if the timer were never cancelled,
+        ;; so counting calls cannot tell the two mechanisms apart -- only an
+        ;; uncancelled timer shows up here.
+        (let ((before (length timer-list)))
+          (mcp-emacs-apply-diff-async
+           file "new\n" 30 (lambda (out) (push out calls)))
+          (check "async-timer-armed" (> (length timer-list) before) t)
+          (resolve)
+          (check "async-resolve-before-timeout" (length calls) 1)
+          (check "async-timer-cancelled" (length timer-list) before)))
+    (let ((buf (find-buffer-visiting file)))
+      (when buf (with-current-buffer buf (set-buffer-modified-p nil))
+            (kill-buffer buf)))
+    (delete-file file)))
+
+;; A path that does not exist is NOT an error: `find-file-noselect' happily
+;; makes a buffer for a new file, so the review opens as usual.  What matters
+;; for the deferred HTTP reply is that the callback still fires on its own —
+;; the request must never hang waiting for a session nobody will answer.
+;; (Uses a real ediff rather than the stub, hence the 1-second timeout.)
+(let ((calls nil))
+  (mcp-emacs-apply-diff-async
+   "/nonexistent-dir-mcp-test/nope.txt" "new\n" 1
+   (lambda (out) (push out calls)))
+  (check "async-missing-path-defers" calls nil)
+  (sleep-for 2)
+  (check "async-missing-path-answers" (length calls) 1))

--- a/test/mcp-emacs-server-async-test.el
+++ b/test/mcp-emacs-server-async-test.el
@@ -1,0 +1,123 @@
+;;; mcp-emacs-server-async-test.el --- Tests for deferred tools/call -*- lexical-binding: t; -*-
+
+;; Batch tests for the async (deferred) tools/call path.  A tool marked with
+;; `:async-handler' must not answer from the process filter: the HTTP handler
+;; holds the connection open and the response is written later, from the
+;; tool's callback.  These tests drive the dispatch layer directly -- no live
+;; web-server, no live ediff.
+
+(add-to-list 'load-path (expand-file-name "elisp"))
+(require 'json)
+(require 'cl-lib)
+(require 'mcp-emacs)
+;; `mcp-emacs-server' hard-requires web-server, which is usually absent in
+;; batch.  Satisfy the require with a stub feature before loading it; these
+;; tests drive dispatch directly and never open a socket.
+(unless (require 'web-server nil t)
+  (defun ws-response-header (&rest _) nil)
+  (defun ws-start (&rest _) nil)
+  (defun ws-stop (&rest _) nil)
+  (provide 'web-server))
+(require 'mcp-emacs-server)
+
+(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+
+(defun mcp-srv--text (response)
+  "Return the text payload of a JSON-RPC RESPONSE object built by the server."
+  (let* ((result (cdr (assoc "result" response)))
+         (content (cdr (assoc "content" result)))
+         (first (aref content 0)))
+    (cdr (assoc "text" first))))
+
+(defun mcp-srv--id (response)
+  "Return the id of a JSON-RPC RESPONSE object built by the server."
+  (cdr (assoc "id" response)))
+
+;;;; Registry
+
+;; apply_diff is the human-answered review, so it must carry an async handler
+;; while keeping its synchronous one as a direct-dispatch fallback.
+(let ((tool (mcp-emacs-server--find-tool "apply_diff")))
+  (check "apply-diff-has-async" (functionp (plist-get tool :async-handler)) t)
+  (check "apply-diff-keeps-sync" (functionp (plist-get tool :handler)) t))
+
+;; Ordinary tools must stay synchronous: deferring them would hold a
+;; connection open for a reply that is already available.
+(let ((tool (mcp-emacs-server--find-tool "project_info")))
+  (check "sync-tool-has-no-async" (plist-get tool :async-handler) nil))
+
+;;;; Deferral
+
+;; An async tool returns non-nil (the call was started) and does NOT answer
+;; synchronously -- that is the whole point of the path.
+(let* ((sent nil)
+       (tool (list :name "fake_async"
+                   :async-handler (lambda (_args done)
+                                    (setq mcp-srv-test--done done))))
+       (mcp-emacs-server-extra-tools (list tool)))
+  (defvar mcp-srv-test--done nil)
+  (setq mcp-srv-test--done nil)
+  (let ((started (mcp-emacs-server--tools-call-async
+                  (list (cons 'name "fake_async") (cons 'arguments nil))
+                  42
+                  (lambda (response) (push response sent)))))
+    (check "async-call-started" started t)
+    (check "async-no-immediate-response" sent nil)
+    ;; Resolving the tool writes the response, carrying the original id.
+    (funcall mcp-srv-test--done "Status: applied\nnew\n")
+    (check "async-response-sent" (length sent) 1)
+    (check "async-response-id" (mcp-srv--id (car sent)) 42)
+    (check "async-response-text"
+           (mcp-srv--text (car sent)) "Status: applied\nnew\n")))
+
+;; A synchronous tool must report "not handled" so the caller falls through
+;; to the normal dispatch path instead of hanging.
+(let ((sent nil))
+  (let ((started (mcp-emacs-server--tools-call-async
+                  (list (cons 'name "project_info") (cons 'arguments nil))
+                  7
+                  (lambda (response) (push response sent)))))
+    (check "sync-tool-not-deferred" started nil)
+    (check "sync-tool-no-response" sent nil)))
+
+;; An unknown tool is likewise not deferred: it must reach normal dispatch,
+;; which turns it into a JSON-RPC error rather than an open connection.
+(let ((sent nil))
+  (let ((started (mcp-emacs-server--tools-call-async
+                  (list (cons 'name "no_such_tool") (cons 'arguments nil))
+                  8
+                  (lambda (response) (push response sent)))))
+    (check "unknown-tool-not-deferred" started nil)
+    (check "unknown-tool-no-response" sent nil)))
+
+;; The deferred response is a well-formed JSON-RPC success object, since it
+;; is written straight to the socket without going through `--dispatch'.
+(let* ((sent nil)
+       (tool (list :name "fake_async2"
+                   :async-handler (lambda (_args done)
+                                    (funcall done "Status: rejected"))))
+       (mcp-emacs-server-extra-tools (list tool)))
+  (mcp-emacs-server--tools-call-async
+   (list (cons 'name "fake_async2") (cons 'arguments nil))
+   99
+   (lambda (response) (push response sent)))
+  (let* ((response (car sent))
+         (encoded (json-encode response)))
+    (check "deferred-has-jsonrpc" (cdr (assoc "jsonrpc" response)) "2.0")
+    (check "deferred-text" (mcp-srv--text response) "Status: rejected")
+    ;; Round-trips through json-encode without error.
+    (check "deferred-encodes" (stringp encoded) t)))
+
+;; Arguments reach the async handler unchanged.
+(let* ((seen nil)
+       (tool (list :name "fake_async3"
+                   :async-handler (lambda (args done)
+                                    (setq seen args)
+                                    (funcall done "ok"))))
+       (mcp-emacs-server-extra-tools (list tool)))
+  (mcp-emacs-server--tools-call-async
+   (list (cons 'name "fake_async3")
+         (cons 'arguments (list (cons 'path "/tmp/x") (cons 'timeout 30))))
+   1 (lambda (_r) nil))
+  (check "async-args-passed-path" (alist-get 'path seen) "/tmp/x")
+  (check "async-args-passed-timeout" (alist-get 'timeout seen) 30))


### PR DESCRIPTION
The ediff review opened by `apply_diff` was unanswerable whenever the tool was served over HTTP: the handler blocked in a cooperative wait inside the web-server process filter, and Emacs runs filters with `inhibit-quit` bound to `t` and no command loop for the control panel. The panel was displayed and its keymap was correct (`a`/`q` bound as usual), but keys did nothing and `C-g` was the only way out — so the only reachable outcome was a timeout, each one leaking an orphaned ediff session.

This returns to the event loop instead of blocking. `mcp-emacs-apply-diff-async` opens the review and answers through a callback from the ediff quit hook, and the HTTP handler throws `:keep-alive` to hold the connection open and writes the JSON-RPC response once the human resolves. Tools opt in with an `:async-handler` entry; everything else dispatches exactly as before, and `apply_diff` keeps its synchronous `:handler` for direct callers. A `done` cell guards single delivery, since the quit hook and the timeout timer race and whichever lands first must be the only answer.

Verified end to end against a headless `claude --print` child with the built-in write tools disabled, routing edits through `mcp__emacs__apply_diff`: the review is now interactive and an accept returns `Status: applied`. 30 new tests cover the async path (deferred delivery, accept/reject, timeout, the single-delivery race, timer cancellation) plus the deferral layer in a new `mcp-emacs-server-async-test.el`; 285 pass across all suites. The single-delivery and deferral tests were mutation-checked — breaking either mechanism fails them.

Not covered: concurrent async reviews on one connection, and the `:keep-alive` HTTP path itself, which needs a real socket and is verified only by the live run.
