### PR TITLE
Add a terminal-free Claude runner

### DIFF
--- a/elisp/claude-client.el
+++ b/elisp/claude-client.el
@@ -1,0 +1,346 @@
+;;; claude-client.el --- Terminal-free Claude Code runner -*- lexical-binding: t; -*-
+
+;; Drive Claude Code without a terminal emulator: spawn the CLI headless,
+;; parse its stream-json output, and render the conversation into an
+;; ordinary Emacs buffer.  This is the non-`eat' runner from issue #40,
+;; modelled on `opencode-client.el' (stream parse -> event model -> render
+;; into a `special-mode' buffer).
+;;
+;; Two things differ from the opencode backend:
+;;
+;; - Transport is a subprocess, not HTTP+SSE.  Claude's `--output-format
+;;   stream-json' is NDJSON: one complete JSON object per line.  Frame on
+;;   newlines, not on SSE's blank-line separator.
+;; - Edits are gated at the MCP tool boundary.  Claude's own mutating tools
+;;   are disabled with `--disallowedTools' and the mcp-emacs server is
+;;   passed via `--mcp-config', so a write can only happen by calling
+;;   `mcp__emacs__apply_diff' -- which opens an ediff the human answers.
+;;   The CLI's `can_use_tool' stdio control request is NOT used: it is
+;;   never emitted in headless mode (verified against 2.1.220), and the
+;;   `permission_denials' in the result are a post-hoc audit record rather
+;;   than a gate.
+;;
+;; This first slice is deliberately one-shot: spawn, stream, render.
+;; Multi-turn stdin, `--resume', and window management are follow-ups.
+
+;;; Code:
+
+(require 'json)
+(require 'subr-x)
+
+;;;; Customization
+
+(defgroup claude-client nil
+  "Terminal-free Claude Code runner."
+  :group 'tools)
+
+(defcustom claude-client-executable "claude"
+  "Claude Code CLI executable."
+  :type 'string
+  :group 'claude-client)
+
+(defcustom claude-client-model nil
+  "Model to pass to the CLI, or nil to use its default."
+  :type '(choice (const :tag "CLI default" nil) string)
+  :group 'claude-client)
+
+(defcustom claude-client-mcp-config nil
+  "Path to an MCP config file exposing the mcp-emacs server to Claude.
+When nil, one is written to a temp file pointing at the running
+`mcp-emacs-server' -- see `claude-client--mcp-config-file'."
+  :type '(choice (const :tag "Generate" nil) file)
+  :group 'claude-client)
+
+(defcustom claude-client-disallowed-tools
+  '("Write" "Edit" "MultiEdit" "NotebookEdit")
+  "Claude built-in tools to disable so edits route through mcp-emacs.
+`MultiEdit' must be disabled alongside `Edit': otherwise Claude can
+batch file changes through it and bypass the ediff gate entirely."
+  :type '(repeat string)
+  :group 'claude-client)
+
+(defcustom claude-client-allowed-mcp-tools
+  '("mcp__emacs__apply_diff"
+    "mcp__emacs__open_file"
+    "mcp__emacs__get_buffer_content"
+    "mcp__emacs__list_open_editors"
+    "mcp__emacs__save_buffer")
+  "MCP tools Claude may call without an interactive permission prompt.
+Proxied MCP tools are denied by default, so the write path
+\(`apply_diff') has to be listed here or every edit is refused before
+the human ever sees the ediff."
+  :type '(repeat string)
+  :group 'claude-client)
+
+(defcustom claude-client-system-prompt
+  "You are running inside Emacs. You have no Write or Edit tools.
+To change a file you must call mcp__emacs__apply_diff with the absolute
+path and the complete new file content. The human reviews it in ediff and
+accepts or rejects; the tool result tells you which. Never claim a change
+was made unless apply_diff returned applied."
+  "Extra system prompt telling Claude how to reach the edit path.
+Without this the model tends to reach for its (disabled) built-in
+tools first and then report that it cannot edit."
+  :type 'string
+  :group 'claude-client)
+
+;;;; State
+
+(defvar-local claude-client--process nil
+  "The Claude CLI subprocess for this conversation buffer.")
+
+(defvar-local claude-client--stdout ""
+  "Unparsed tail of the CLI's stdout, awaiting a complete line.")
+
+(defvar-local claude-client--events nil
+  "Parsed conversation events, oldest first.
+Each is a plist: :kind, plus kind-specific keys.  This is the render
+model, and the append-only log issue #39 wants to subscribe to.")
+
+(defvar-local claude-client--session-id nil
+  "Claude session id, from the `system'/`init' event.")
+
+(defvar claude-client-event-functions nil
+  "Abnormal hook run with (BUFFER EVENT) for every parsed event.
+Each EVENT is a plist as stored in `claude-client--events'.  This is
+the subscriber seam: rendering is one consumer, and issue #39's Org
+transcript can be another without touching this file.")
+
+;;;; Spawning
+
+(defun claude-client--mcp-config-file ()
+  "Return a path to the MCP config exposing mcp-emacs to Claude.
+Uses `claude-client-mcp-config' when set, otherwise writes a temp file
+pointing at the running server's endpoint."
+  (or claude-client-mcp-config
+      (let ((file (make-temp-file "claude-client-mcp-" nil ".json"))
+            (url (format "http://localhost:%s/mcp"
+                         (if (boundp 'mcp-emacs-server-port)
+                             (symbol-value 'mcp-emacs-server-port)
+                           8765))))
+        (with-temp-file file
+          (insert (json-encode
+                   `((mcpServers . ((emacs . ((type . "http")
+                                              (url . ,url)))))))))
+        file)))
+
+(defun claude-client--settings-file ()
+  "Write and return a settings file allowlisting the mcp-emacs tools."
+  (let ((file (make-temp-file "claude-client-settings-" nil ".json")))
+    (with-temp-file file
+      (insert (json-encode
+               `((permissions
+                  . ((allow . ,(vconcat claude-client-allowed-mcp-tools))
+                     (deny . [])))))))
+    file))
+
+(defun claude-client--system-prompt-file ()
+  "Write and return a file holding `claude-client-system-prompt'."
+  (let ((file (make-temp-file "claude-client-prompt-" nil ".txt")))
+    (with-temp-file file (insert claude-client-system-prompt))
+    file))
+
+(defun claude-client--command ()
+  "Return the full argument list for the Claude CLI subprocess."
+  (append
+   (list claude-client-executable
+         "--print"
+         "--output-format" "stream-json"
+         "--input-format" "stream-json"
+         "--verbose"
+         "--mcp-config" (claude-client--mcp-config-file)
+         "--strict-mcp-config"
+         "--settings" (claude-client--settings-file)
+         "--append-system-prompt-file" (claude-client--system-prompt-file))
+   (when claude-client-model (list "--model" claude-client-model))
+   (when claude-client-disallowed-tools
+     (cons "--disallowedTools" claude-client-disallowed-tools))))
+
+;;;; Event model
+
+(defun claude-client--push-event (buffer event)
+  "Append EVENT to BUFFER's log, notify subscribers, and re-render."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (setq claude-client--events
+            (append claude-client--events (list event)))
+      (run-hook-with-args 'claude-client-event-functions buffer event)
+      (claude-client--render))))
+
+(defun claude-client--events-for-message (msg)
+  "Return render events for an assistant MSG's content blocks."
+  (delq nil
+        (mapcar
+         (lambda (block)
+           (let ((type (alist-get 'type block)))
+             (cond
+              ((equal type "text")
+               (let ((text (string-trim (or (alist-get 'text block) ""))))
+                 (unless (string-empty-p text)
+                   (list :kind 'text :text text))))
+              ((equal type "tool_use")
+               (list :kind 'tool-use
+                     :name (alist-get 'name block)
+                     :input (alist-get 'input block)))
+              (t nil))))
+         (alist-get 'content msg))))
+
+(defun claude-client--handle-message (buffer msg)
+  "Turn one parsed stream-json MSG into events and apply them to BUFFER."
+  (let ((type (alist-get 'type msg)))
+    (cond
+     ((and (equal type "system") (equal (alist-get 'subtype msg) "init"))
+      (when (buffer-live-p buffer)
+        (with-current-buffer buffer
+          (setq claude-client--session-id (alist-get 'session_id msg))))
+      (claude-client--push-event
+       buffer (list :kind 'started
+                    :session (alist-get 'session_id msg)
+                    :model (alist-get 'model msg))))
+     ((equal type "assistant")
+      (dolist (event (claude-client--events-for-message
+                      (alist-get 'message msg)))
+        (claude-client--push-event buffer event)))
+     ((equal type "user")
+      ;; Tool results come back as a synthetic user message.
+      (dolist (block (alist-get 'content (alist-get 'message msg)))
+        (when (equal (alist-get 'type block) "tool_result")
+          (let ((content (alist-get 'content block)))
+            (claude-client--push-event
+             buffer (list :kind 'tool-result
+                          :text (if (stringp content)
+                                    content
+                                  (mapconcat
+                                   (lambda (c) (or (alist-get 'text c) ""))
+                                   content "\n"))))))))
+     ((equal type "result")
+      (claude-client--push-event
+       buffer (list :kind 'finished
+                    :subtype (alist-get 'subtype msg)
+                    :denials (alist-get 'permission_denials msg))))
+     (t nil))))
+
+;;;; Streaming
+
+(defun claude-client--filter (buffer proc chunk)
+  "Frame CHUNK from PROC as NDJSON lines and dispatch them to BUFFER."
+  (ignore proc)
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (setq claude-client--stdout (concat claude-client--stdout chunk))
+      ;; stream-json is one complete object per line; a chunk can split a
+      ;; line, so only consume up to the last newline and keep the tail.
+      (let (pos)
+        (while (setq pos (string-search "\n" claude-client--stdout))
+          (let ((line (substring claude-client--stdout 0 pos)))
+            (setq claude-client--stdout
+                  (substring claude-client--stdout (1+ pos)))
+            (unless (string-empty-p (string-trim line))
+              (let ((msg (ignore-errors
+                           (json-parse-string line
+                                              :object-type 'alist
+                                              :array-type 'list
+                                              :null-object nil
+                                              :false-object nil))))
+                (when msg
+                  (claude-client--handle-message buffer msg))))))))))
+
+(defun claude-client--sentinel (buffer proc _change)
+  "Report PROC exiting into BUFFER."
+  (unless (process-live-p proc)
+    (when (buffer-live-p buffer)
+      (with-current-buffer buffer
+        (setq claude-client--process nil)))))
+
+;;;; Rendering
+
+(defun claude-client--render-event (event)
+  "Return a display string for EVENT, or nil to skip it."
+  (pcase (plist-get event :kind)
+    ('started (format "── claude %s ──" (or (plist-get event :model) "")))
+    ('text (plist-get event :text))
+    ('tool-use (format "  [tool: %s]" (plist-get event :name)))
+    ('tool-result
+     (let ((text (string-trim (or (plist-get event :text) ""))))
+       (unless (string-empty-p text)
+         (format "  → %s"
+                 (car (split-string text "\n"))))))
+    ('finished (format "── %s ──" (or (plist-get event :subtype) "done")))
+    (_ nil)))
+
+(defun claude-client--render ()
+  "Re-render this buffer's event log."
+  (let ((at-end (eobp))
+        (inhibit-read-only t))
+    (erase-buffer)
+    (dolist (event claude-client--events)
+      (when-let ((s (claude-client--render-event event)))
+        (insert s)
+        (unless (string-suffix-p "\n" s) (insert "\n"))))
+    (when at-end (goto-char (point-max)))))
+
+;;;; Entry point
+
+;;;###autoload
+(defun claude-client-start (prompt)
+  "Run PROMPT through a headless Claude and render it in a buffer.
+Edits are routed through the mcp-emacs server's `apply_diff', so any
+file change opens an ediff for the human to accept or reject."
+  (interactive "sPrompt: ")
+  (let ((buffer (get-buffer-create "*claude-client*")))
+    (with-current-buffer buffer
+      (unless (derived-mode-p 'claude-client-mode)
+        (claude-client-mode))
+      ;; One conversation buffer, one subprocess.  Silently restarting would
+      ;; orphan the running CLI -- and any ediff it is blocked on, which then
+      ;; waits for a human whose answer no longer goes anywhere.
+      (when (process-live-p claude-client--process)
+        (user-error "A Claude run is already active here; `k' to kill it first"))
+      (let ((inhibit-read-only t)) (erase-buffer))
+      (setq claude-client--events nil
+            claude-client--stdout ""
+            claude-client--session-id nil)
+      (let ((proc (make-process
+                   :name "claude-client"
+                   :buffer nil
+                   :command (claude-client--command)
+                   :connection-type 'pipe
+                   :noquery t
+                   :filter (lambda (p c) (claude-client--filter buffer p c))
+                   :sentinel (lambda (p c)
+                               (claude-client--sentinel buffer p c)))))
+        (setq claude-client--process proc)
+        (process-send-string
+         proc
+         (concat (json-encode
+                  `((type . "user")
+                    (message . ((role . "user")
+                                (content . [((type . "text")
+                                             (text . ,prompt))])))))
+                 "\n"))))
+    (pop-to-buffer buffer)
+    buffer))
+
+(defun claude-client-quit ()
+  "Kill the CLI subprocess for this buffer."
+  (interactive)
+  (when (process-live-p claude-client--process)
+    (delete-process claude-client--process))
+  (setq claude-client--process nil))
+
+;;;; Major mode
+
+(defvar claude-client-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "g") #'claude-client-start)
+    (define-key map (kbd "k") #'claude-client-quit)
+    map)
+  "Keymap for `claude-client-mode'.")
+
+(define-derived-mode claude-client-mode special-mode "claude"
+  "Major mode for the terminal-free Claude conversation buffer."
+  (setq-local truncate-lines nil))
+
+(provide 'claude-client)
+
+;;; claude-client.el ends here

--- a/test/claude-client-test.el
+++ b/test/claude-client-test.el
@@ -1,0 +1,279 @@
+;;; claude-client-test.el --- Tests for the terminal-free runner -*- lexical-binding: t; -*-
+
+;; Batch tests for `claude-client.el'.  No CLI is spawned: the stream filter
+;; is fed captured stream-json lines directly, which is also how the real
+;; subprocess reaches it.  The sample lines below are trimmed from actual
+;; `claude --print --output-format stream-json' output.
+
+(add-to-list 'load-path (expand-file-name "elisp"))
+(require 'cl-lib)
+(require 'json)
+(require 'claude-client)
+
+(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+
+(defun claude-test--buffer ()
+  "Return a fresh conversation buffer in `claude-client-mode'."
+  (let ((buf (generate-new-buffer " *claude-test*")))
+    (with-current-buffer buf (claude-client-mode))
+    buf))
+
+(defun claude-test--feed (buffer &rest lines)
+  "Feed LINES to BUFFER's stream filter as if the CLI had written them."
+  (dolist (line lines)
+    (claude-client--filter buffer nil line)))
+
+(defun claude-test--kinds (buffer)
+  "Return the ordered list of event kinds recorded in BUFFER."
+  (with-current-buffer buffer
+    (mapcar (lambda (e) (plist-get e :kind)) claude-client--events)))
+
+(defun claude-test--text (buffer)
+  (with-current-buffer buffer
+    (buffer-substring-no-properties (point-min) (point-max))))
+
+;; Captured stream-json lines (one complete JSON object per line).
+(defconst claude-test--init
+  "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"abc-123\",\"model\":\"claude-opus-5\"}")
+(defconst claude-test--text-msg
+  "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"I'll write the file.\"}]}}")
+(defconst claude-test--tool-use
+  "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_01\",\"name\":\"mcp__emacs__apply_diff\",\"input\":{\"path\":\"/tmp/x\"}}]}}")
+(defconst claude-test--tool-result
+  "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"content\":\"Status: applied\\nnew\\n\"}]}}")
+(defconst claude-test--result
+  "{\"type\":\"result\",\"subtype\":\"success\",\"permission_denials\":[]}")
+
+;;;; Command construction
+;;
+;; These flags are the permission model, not cosmetics: the built-in write
+;; tools must be off and the MCP config on, or Claude edits files directly
+;; and never reaches the ediff gate.
+
+(let ((cmd (claude-client--command)))
+  (check "cmd-print" (and (member "--print" cmd) t) t)
+  (check "cmd-stream-json-out"
+         (equal (cadr (member "--output-format" cmd)) "stream-json") t)
+  (check "cmd-stream-json-in"
+         (equal (cadr (member "--input-format" cmd)) "stream-json") t)
+  (check "cmd-strict-mcp" (and (member "--strict-mcp-config" cmd) t) t)
+  (check "cmd-has-mcp-config" (and (member "--mcp-config" cmd) t) t)
+  (check "cmd-has-settings" (and (member "--settings" cmd) t) t)
+  ;; Edit and MultiEdit both: MultiEdit alone can batch writes past the gate.
+  (check "cmd-disallows-write" (and (member "Write" cmd) t) t)
+  (check "cmd-disallows-edit" (and (member "Edit" cmd) t) t)
+  (check "cmd-disallows-multiedit" (and (member "MultiEdit" cmd) t) t))
+
+;; The generated MCP config points at the mcp-emacs HTTP endpoint.
+(let* ((file (claude-client--mcp-config-file))
+       (parsed (with-temp-buffer
+                 (insert-file-contents file)
+                 (json-parse-string (buffer-string)
+                                    :object-type 'alist :array-type 'list))))
+  (let* ((servers (alist-get 'mcpServers parsed))
+         (emacs (alist-get 'emacs servers)))
+    (check "mcp-config-type" (alist-get 'type emacs) "http")
+    (check "mcp-config-url-mcp-path"
+           (and (string-suffix-p "/mcp" (alist-get 'url emacs)) t) t))
+  (delete-file file))
+
+;; apply_diff must be allowlisted: proxied MCP tools are denied by default,
+;; so without this every edit is refused before the human sees an ediff.
+(let* ((file (claude-client--settings-file))
+       (parsed (with-temp-buffer
+                 (insert-file-contents file)
+                 (json-parse-string (buffer-string)
+                                    :object-type 'alist :array-type 'list))))
+  (let ((allow (alist-get 'allow (alist-get 'permissions parsed))))
+    (check "settings-allows-apply-diff"
+           (and (member "mcp__emacs__apply_diff" allow) t) t))
+  (delete-file file))
+
+;;;; Stream framing
+;;
+;; stream-json is NDJSON: one object per line.  The filter must tolerate a
+;; chunk boundary landing mid-line, since the pipe splits wherever it likes.
+
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed buf (concat claude-test--init "\n"))
+        (check "frame-single-line" (claude-test--kinds buf) '(started)))
+    (kill-buffer buf)))
+
+;; A line split across two chunks is buffered until its newline arrives.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (let* ((whole (concat claude-test--init "\n"))
+             (cut (/ (length whole) 2)))
+        (claude-test--feed buf (substring whole 0 cut))
+        (check "frame-partial-not-yet" (claude-test--kinds buf) nil)
+        (claude-test--feed buf (substring whole cut))
+        (check "frame-partial-completed" (claude-test--kinds buf) '(started)))
+    (kill-buffer buf)))
+
+;; Several objects arriving in one chunk all get dispatched.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed
+         buf (concat claude-test--init "\n" claude-test--text-msg "\n"))
+        (check "frame-multiple-in-chunk"
+               (claude-test--kinds buf) '(started text)))
+    (kill-buffer buf)))
+
+;; Garbage lines are skipped rather than aborting the stream.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed buf "not json at all\n"
+                           (concat claude-test--init "\n"))
+        (check "frame-skips-garbage" (claude-test--kinds buf) '(started)))
+    (kill-buffer buf)))
+
+;;;; Event mapping
+
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed buf (concat claude-test--init "\n"))
+        (with-current-buffer buf
+          (check "init-records-session" claude-client--session-id "abc-123")
+          (let ((e (car claude-client--events)))
+            (check "init-kind" (plist-get e :kind) 'started)
+            (check "init-model" (plist-get e :model) "claude-opus-5"))))
+    (kill-buffer buf)))
+
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed buf (concat claude-test--text-msg "\n"))
+        (with-current-buffer buf
+          (let ((e (car claude-client--events)))
+            (check "text-kind" (plist-get e :kind) 'text)
+            (check "text-content" (plist-get e :text) "I'll write the file."))))
+    (kill-buffer buf)))
+
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed buf (concat claude-test--tool-use "\n"))
+        (with-current-buffer buf
+          (let ((e (car claude-client--events)))
+            (check "tool-use-kind" (plist-get e :kind) 'tool-use)
+            (check "tool-use-name"
+                   (plist-get e :name) "mcp__emacs__apply_diff"))))
+    (kill-buffer buf)))
+
+;; tool_result content is a plain string in practice; the list form is also
+;; accepted, so both shapes must land as text.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed buf (concat claude-test--tool-result "\n"))
+        (with-current-buffer buf
+          (let ((e (car claude-client--events)))
+            (check "tool-result-kind" (plist-get e :kind) 'tool-result)
+            (check "tool-result-text"
+                   (plist-get e :text) "Status: applied\nnew\n"))))
+    (kill-buffer buf)))
+
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed
+         buf (concat "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"content\":[{\"type\":\"text\",\"text\":\"from list\"}]}]}}" "\n"))
+        (with-current-buffer buf
+          (check "tool-result-list-form"
+                 (plist-get (car claude-client--events) :text) "from list")))
+    (kill-buffer buf)))
+
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed buf (concat claude-test--result "\n"))
+        (with-current-buffer buf
+          (let ((e (car claude-client--events)))
+            (check "result-kind" (plist-get e :kind) 'finished)
+            (check "result-subtype" (plist-get e :subtype) "success"))))
+    (kill-buffer buf)))
+
+;; Unknown top-level types are ignored, not turned into stray events.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed buf "{\"type\":\"rate_limit_event\"}\n")
+        (check "ignores-unknown-type" (claude-test--kinds buf) nil))
+    (kill-buffer buf)))
+
+;; Empty assistant text blocks produce no event (the CLI emits these while
+;; streaming partial messages).
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed
+         buf "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"   \"}]}}\n")
+        (check "skips-empty-text" (claude-test--kinds buf) nil))
+    (kill-buffer buf)))
+
+;;;; Event ordering and the subscriber hook
+
+;; The log is append-only and in arrival order -- this is what issue #39
+;; subscribes to, so ordering is a contract, not an implementation detail.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed buf
+                           (concat claude-test--init "\n")
+                           (concat claude-test--text-msg "\n")
+                           (concat claude-test--tool-use "\n")
+                           (concat claude-test--tool-result "\n")
+                           (concat claude-test--result "\n"))
+        (check "event-order"
+               (claude-test--kinds buf)
+               '(started text tool-use tool-result finished)))
+    (kill-buffer buf)))
+
+;; Every event is announced to `claude-client-event-functions' with its
+;; buffer -- the seam that lets #39 attach an Org transcript subscriber
+;; without touching the renderer.
+(let* ((buf (claude-test--buffer))
+       (seen nil)
+       (claude-client-event-functions
+        (list (lambda (b e) (push (cons b (plist-get e :kind)) seen)))))
+  (unwind-protect
+      (progn
+        (claude-test--feed buf
+                           (concat claude-test--init "\n")
+                           (concat claude-test--result "\n"))
+        (check "hook-called-per-event" (length seen) 2)
+        (check "hook-receives-buffer" (car (car seen)) buf)
+        (check "hook-order" (mapcar #'cdr (reverse seen)) '(started finished)))
+    (kill-buffer buf)))
+
+;;;; Rendering
+
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed buf
+                           (concat claude-test--init "\n")
+                           (concat claude-test--text-msg "\n")
+                           (concat claude-test--tool-use "\n")
+                           (concat claude-test--result "\n"))
+        (let ((text (claude-test--text buf)))
+          (check "render-has-text"
+                 (and (string-match-p "I'll write the file\\." text) t) t)
+          (check "render-has-tool"
+                 (and (string-match-p "mcp__emacs__apply_diff" text) t) t)
+          (check "render-has-banner"
+                 (and (string-match-p "claude-opus-5" text) t) t)))
+    (kill-buffer buf)))
+
+;; The buffer is read-only for the human but still writable by the renderer.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (check "mode-is-special" (derived-mode-p 'special-mode) 'special-mode)
+        (check "buffer-read-only" buffer-read-only t))
+    (kill-buffer buf)))


### PR DESCRIPTION
First slice of #40: drive Claude Code without `eat`. `claude-client.el` spawns the CLI headless, frames its `stream-json` output as NDJSON (one object per line, not SSE's blank-line separator), turns each message into an event, and renders into an ordinary `special-mode` buffer. Modelled on `opencode-client.el` — stream parse, event model, render — but over a subprocess rather than HTTP+SSE.

Edits are gated at the MCP tool boundary rather than by a permission prompt. The built-in mutating tools are disabled with `--disallowedTools` and the mcp-emacs server is passed via `--mcp-config`, so a write can only happen by calling `apply_diff`, which opens an ediff the human answers. Two things that bite if you get them wrong, both now asserted in tests: `MultiEdit` has to be disabled alongside `Edit` or Claude batches file changes past the gate, and the proxied MCP tools need an explicit `--settings` allowlist or every edit is refused before the human sees anything. The CLI's `can_use_tool` control request is deliberately unused — it is never emitted in headless mode on 2.1.220, and the result's `permission_denials` are a post-hoc audit record, not a gate.

Events accumulate in an append-only per-buffer log and are announced on `claude-client-event-functions`, so rendering is one subscriber rather than the only consumer — the seam #39 needs for an Org-transcript subscriber.

Verified live against the running mcp-emacs server: a read-only prompt renders and completes, and an edit prompt opens an ediff which, on accept, leaves the buffer at the proposed content. 40 new tests feed captured stream-json lines straight to the filter (no CLI spawned) covering flag construction, generated MCP/settings config, NDJSON framing including a line split across chunks, event mapping for both `tool_result` content shapes, event ordering, and the subscriber hook; 325 pass across all suites. Four mutations — dropping `MultiEdit`, removing partial-line buffering, disabling the hook, emptying the allowlist — each fail the intended test.

First slice only: one-shot prompt, no multi-turn stdin, no `--resume`, no window management. Known limitation: on runs that open an ediff, the review restores a window configuration captured before the conversation buffer existed, so the buffer loses its window — the edit itself is unaffected.
