### PR TITLE
Let the human add notes to the runner's event log

### DIFF
--- a/elisp/claude-client.el
+++ b/elisp/claude-client.el
@@ -100,6 +100,19 @@ model, and the append-only log issue #39 wants to subscribe to.")
 (defvar-local claude-client--session-id nil
   "Claude session id, from the `system'/`init' event.")
 
+(defvar-local claude-client--pending-notes nil
+  "Notes added by the human that the model has not been shown yet.
+Oldest first.  A note is logged the moment it is written -- it is part
+of the shared record immediately -- but it is only handed to the model
+when the current turn ends.  See `claude-client-add-note'.")
+
+(defvar-local claude-client--turn-active nil
+  "Non-nil while a turn is in flight, i.e. between spawn and `result'.
+Tracked from the stream rather than from the process: `claude --print'
+stays alive after emitting `result' (it waits on stdin for a follow-up
+turn), so `process-live-p' reports `run' long after the turn is over
+and cannot answer \"is the model working right now?\".")
+
 (defvar claude-client-event-functions nil
   "Abnormal hook run with (BUFFER EVENT) for every parsed event.
 Each EVENT is a plist as stored in `claude-client--events'.  This is
@@ -217,8 +230,66 @@ pointing at the running server's endpoint."
       (claude-client--push-event
        buffer (list :kind 'finished
                     :subtype (alist-get 'subtype msg)
-                    :denials (alist-get 'permission_denials msg))))
+                    :denials (alist-get 'permission_denials msg)))
+      ;; Turn over: anything the human wrote while it ran is surfaced now.
+      ;; Drained after `finished' so the log reads in the order things
+      ;; actually happened.
+      (when (buffer-live-p buffer)
+        (with-current-buffer buffer (setq claude-client--turn-active nil)))
+      (claude-client--drain-notes buffer))
      (t nil))))
+
+;;;; Notes from the human (issue #39, `NoteAdded')
+
+;; The second writer.  Until now the log had one producer (the runner) and
+;; readers; a note is the human producing to the same log, which is what the
+;; event-stream direction is actually for.
+;;
+;; Delivery is deliberately conservative in this slice: the note is logged
+;; and visible *immediately*, but it is only handed to the model when the
+;; current turn ends.  Nothing is aborted mid tool-call.  That is not a
+;; claim that queueing is the right interruption rule -- it is the honest
+;; behaviour for a one-shot runner that has no way to steer a turn in
+;; flight (no multi-turn stdin, no `--resume').  Deciding finish/abort/
+;; re-plan is still the open question in #39, and it needs a runner that
+;; can act on the answer.
+
+;;;###autoload
+(defun claude-client-add-note (text)
+  "Add TEXT to this conversation's log as a human note.
+The note is recorded at once, so it is part of the shared record the
+moment it is written and every subscriber sees it.  If a turn is
+running the model is shown the note when that turn ends; if nothing is
+running it is queued for the next one."
+  (interactive "sNote: ")
+  (unless (derived-mode-p 'claude-client-mode)
+    (user-error "Not in a Claude conversation buffer"))
+  (let ((note (string-trim text))
+        (running (and claude-client--turn-active t)))
+    (when (string-empty-p note)
+      (user-error "Empty note"))
+    (setq claude-client--pending-notes
+          (append claude-client--pending-notes (list note)))
+    (claude-client--push-event
+     (current-buffer)
+     (list :kind 'note :text note :pending running))
+    ;; With no turn running there is nothing to wait for: the drain fires on
+    ;; `result', so a note added while idle would otherwise sit queued until
+    ;; some later turn happened to end -- or forever, if none did.
+    (unless running
+      (claude-client--drain-notes (current-buffer)))))
+
+(defun claude-client--drain-notes (buffer)
+  "Surface BUFFER's pending notes now that its turn has ended.
+Returns the drained notes, oldest first, and clears the queue."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let ((notes claude-client--pending-notes))
+        (setq claude-client--pending-notes nil)
+        (when notes
+          (claude-client--push-event
+           buffer (list :kind 'notes-delivered :notes notes)))
+        notes))))
 
 ;;;; Streaming
 
@@ -266,6 +337,13 @@ pointing at the running server's endpoint."
          (format "  → %s"
                  (car (split-string text "\n"))))))
     ('finished (format "── %s ──" (or (plist-get event :subtype) "done")))
+    ('note (format "> %s%s"
+                   (plist-get event :text)
+                   (if (plist-get event :pending) "  (pending)" "")))
+    ('notes-delivered
+     (format "── %d note%s to carry forward ──"
+             (length (plist-get event :notes))
+             (if (= 1 (length (plist-get event :notes))) "" "s")))
     (_ nil)))
 
 (defun claude-client--render ()
@@ -294,30 +372,41 @@ file change opens an ediff for the human to accept or reject."
       ;; One conversation buffer, one subprocess.  Silently restarting would
       ;; orphan the running CLI -- and any ediff it is blocked on, which then
       ;; waits for a human whose answer no longer goes anywhere.
-      (when (process-live-p claude-client--process)
+      (when claude-client--turn-active
         (user-error "A Claude run is already active here; `k' to kill it first"))
       (let ((inhibit-read-only t)) (erase-buffer))
-      (setq claude-client--events nil
-            claude-client--stdout ""
-            claude-client--session-id nil)
-      (let ((proc (make-process
-                   :name "claude-client"
-                   :buffer nil
-                   :command (claude-client--command)
-                   :connection-type 'pipe
-                   :noquery t
-                   :filter (lambda (p c) (claude-client--filter buffer p c))
-                   :sentinel (lambda (p c)
-                               (claude-client--sentinel buffer p c)))))
-        (setq claude-client--process proc)
-        (process-send-string
-         proc
-         (concat (json-encode
-                  `((type . "user")
-                    (message . ((role . "user")
-                                (content . [((type . "text")
-                                             (text . ,prompt))])))))
-                 "\n"))))
+      ;; Notes queued before this run (or left over from the last one) are
+      ;; carried into the prompt rather than dropped -- a note the human
+      ;; wrote must not vanish just because the log was reset.
+      (let ((carried claude-client--pending-notes))
+        (setq claude-client--events nil
+              claude-client--stdout ""
+              claude-client--session-id nil
+              claude-client--pending-notes nil)
+        (let ((text (if carried
+                        (concat prompt "\n\nNotes from the human:\n"
+                                (mapconcat (lambda (n) (concat "- " n))
+                                           carried "\n"))
+                      prompt))
+              (proc (make-process
+                     :name "claude-client"
+                     :buffer nil
+                     :command (claude-client--command)
+                     :connection-type 'pipe
+                     :noquery t
+                     :filter (lambda (p c) (claude-client--filter buffer p c))
+                     :sentinel (lambda (p c)
+                                 (claude-client--sentinel buffer p c)))))
+          (setq claude-client--process proc
+                claude-client--turn-active t)
+          (process-send-string
+           proc
+           (concat (json-encode
+                    `((type . "user")
+                      (message . ((role . "user")
+                                  (content . [((type . "text")
+                                               (text . ,text))])))))
+                   "\n")))))
     (pop-to-buffer buffer)
     buffer))
 
@@ -326,7 +415,8 @@ file change opens an ediff for the human to accept or reject."
   (interactive)
   (when (process-live-p claude-client--process)
     (delete-process claude-client--process))
-  (setq claude-client--process nil))
+  (setq claude-client--process nil
+        claude-client--turn-active nil))
 
 ;;;; Major mode
 
@@ -334,6 +424,7 @@ file change opens an ediff for the human to accept or reject."
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "g") #'claude-client-start)
     (define-key map (kbd "k") #'claude-client-quit)
+    (define-key map (kbd "n") #'claude-client-add-note)
     map)
   "Keymap for `claude-client-mode'.")
 

--- a/elisp/mcp-emacs-remote.el
+++ b/elisp/mcp-emacs-remote.el
@@ -260,6 +260,19 @@ degrades to silence instead of a malformed entry."
       (format "  - %s runner %s"
               (mcp-emacs-remote--timestamp)
               (or (plist-get event :subtype) "done"))))
+    ;; The human writing to the log, not the runner.  Recorded on the same
+    ;; channel and in the same order as everything else -- that is the point
+    ;; of one shared log rather than two side-by-side records.
+    ('note
+     (mcp-emacs-remote--append
+      (format "  - %s human :: %s"
+              (mcp-emacs-remote--timestamp)
+              (or (plist-get event :text) ""))))
+    ('notes-delivered
+     (mcp-emacs-remote--append
+      (format "  - %s carried %d note(s) forward"
+              (mcp-emacs-remote--timestamp)
+              (length (plist-get event :notes)))))
     (_ nil)))
 
 (defun mcp-emacs-remote--tap-runner-event (buffer event)

--- a/test/claude-client-test.el
+++ b/test/claude-client-test.el
@@ -277,3 +277,192 @@
         (check "mode-is-special" (derived-mode-p 'special-mode) 'special-mode)
         (check "buffer-read-only" buffer-read-only t))
     (kill-buffer buf)))
+
+;;;; Human notes (issue #39, `NoteAdded')
+;;
+;; A note is the second writer to the log.  It must be recorded immediately
+;; -- that is the whole point, the human can add a thought at any time --
+;; but in this slice it reaches the model only when the turn ends.
+;;
+;; Whether a turn is running changes the behaviour, so most of these tests
+;; have to fake a live process: with none, a note has nothing to wait for
+;; and drains at once.
+
+(defmacro claude-test--with-running-turn (&rest body)
+  "Run BODY with this buffer marked as having a turn in flight.
+Turn state is tracked from the stream, not the process: `claude --print'
+stays alive after `result', so process liveness cannot stand in for it."
+  `(let ((claude-client--turn-active t))
+     ,@body))
+
+;; The note lands in the log as soon as it is written, and waits while a
+;; turn is running.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (claude-test--with-running-turn
+         (claude-client-add-note "look at the error handling"))
+        (check "note-logged-immediately" (claude-test--kinds buf) '(note))
+        (check "note-text"
+               (plist-get (car claude-client--events) :text)
+               "look at the error handling")
+        (check "note-queued"
+               claude-client--pending-notes '("look at the error handling")))
+    (kill-buffer buf)))
+
+;; Turn state must not be inferred from the process.  `claude --print' stays
+;; alive after emitting `result' (it waits on stdin), so a live process is
+;; not evidence of a turn in flight -- reading it that way left notes queued
+;; forever once a run had finished.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t)))
+          ;; Process "alive", but the turn ended: the note must still drain.
+          (setq claude-client--turn-active nil)
+          (claude-client-add-note "after the turn")
+          (check "live-process-is-not-an-active-turn"
+                 claude-client--pending-notes nil)))
+    (kill-buffer buf)))
+
+;; The stream is what starts and ends a turn.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (setq claude-client--turn-active t)
+        (claude-test--feed buf (concat claude-test--result "\n"))
+        (check "result-clears-turn-active" claude-client--turn-active nil))
+    (kill-buffer buf)))
+
+;; With no turn running the note has nothing to wait for, so it is delivered
+;; straight away rather than sitting queued for a turn that may never come.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (claude-client-add-note "idle note")
+        (check "idle-note-drains-now" claude-client--pending-notes nil)
+        (check "idle-note-delivery-event"
+               (claude-test--kinds buf) '(note notes-delivered)))
+    (kill-buffer buf)))
+
+;; Empty and whitespace notes are rejected rather than logged as blanks.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (check "empty-note-errors"
+               (condition-case _ (progn (claude-client-add-note "   ") nil)
+                 (user-error t))
+               t)
+        (check "empty-note-not-logged" (claude-test--kinds buf) nil))
+    (kill-buffer buf)))
+
+;; Notes keep their order and all of them are queued.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (claude-test--with-running-turn
+         (claude-client-add-note "first")
+         (claude-client-add-note "second"))
+        (check "notes-ordered" claude-client--pending-notes '("first" "second")))
+    (kill-buffer buf)))
+
+;; Notes are drained when the turn's `result' arrives -- after the
+;; `finished' event, so the log reads in the order things happened.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (claude-test--feed buf (concat claude-test--init "\n"))
+        (claude-test--with-running-turn
+         (claude-client-add-note "mid-turn thought"))
+        (check "note-pending-during-turn"
+               claude-client--pending-notes '("mid-turn thought"))
+        (claude-test--feed buf (concat claude-test--result "\n"))
+        (check "notes-drained-at-turn-end" claude-client--pending-notes nil)
+        (check "drain-order"
+               (claude-test--kinds buf)
+               '(started note finished notes-delivered))
+        (check "delivered-carries-notes"
+               (plist-get (car (last claude-client--events)) :notes)
+               '("mid-turn thought")))
+    (kill-buffer buf)))
+
+;; A turn that ends with no notes produces no delivery event.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (progn
+        (claude-test--feed buf
+                           (concat claude-test--init "\n")
+                           (concat claude-test--result "\n"))
+        (check "no-notes-no-delivery-event"
+               (claude-test--kinds buf) '(started finished)))
+    (kill-buffer buf)))
+
+;; Notes are announced on the subscriber hook like any other event, so the
+;; transcript sees the human's writes on the same channel as the runner's.
+(let* ((buf (claude-test--buffer))
+       (seen nil)
+       (claude-client-event-functions
+        (list (lambda (_b e) (push (plist-get e :kind) seen)))))
+  (unwind-protect
+      (with-current-buffer buf
+        (claude-test--with-running-turn
+         (claude-client-add-note "via hook"))
+        (check "note-reaches-subscribers" seen '(note)))
+    (kill-buffer buf)))
+
+;; Notes render, and a note added while a turn is running is marked pending.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (claude-test--with-running-turn
+         (claude-client-add-note "rendered note"))
+        (check "note-rendered"
+               (and (string-match-p "> rendered note" (claude-test--text buf)) t) t)
+        (check "note-pending-marked"
+               (plist-get (car claude-client--events) :pending) t))
+    (kill-buffer buf)))
+
+;; A note outside a conversation buffer is refused rather than silently lost.
+(with-temp-buffer
+  (check "note-outside-conversation-errors"
+         (condition-case _ (progn (claude-client-add-note "x") nil)
+           (user-error t))
+         t))
+
+;; Starting a run resets the event log, so a note queued beforehand has to be
+;; carried into the outgoing prompt or the human's words are silently lost.
+;; Stub the subprocess and capture what would be written to its stdin.
+(let ((sent nil))
+  (cl-letf (((symbol-function 'make-process) (lambda (&rest _) 'fake-proc))
+            ((symbol-function 'process-send-string)
+             (lambda (_p s) (setq sent s)))
+            ((symbol-function 'pop-to-buffer) #'ignore)
+            ;; Keep the real buffer out of the way of an interactive session.
+            ((symbol-function 'claude-client--mcp-config-file) (lambda () "/tmp/m.json"))
+            ((symbol-function 'claude-client--settings-file) (lambda () "/tmp/s.json"))
+            ((symbol-function 'claude-client--system-prompt-file) (lambda () "/tmp/p.txt")))
+    (let ((buf (get-buffer-create "*claude-client*")))
+      (unwind-protect
+          (progn
+            (with-current-buffer buf
+              (claude-client-mode)
+              (setq claude-client--process nil)
+              (claude-test--with-running-turn
+               (claude-client-add-note "remember the timeout")))
+            (claude-client-start "do the thing")
+            (let ((text (alist-get
+                         'text
+                         (aref (alist-get
+                                'content
+                                (alist-get 'message
+                                           (json-parse-string
+                                            sent :object-type 'alist
+                                            :array-type 'array)))
+                               0))))
+              (check "restart-carries-note"
+                     (and (string-match-p "remember the timeout" text) t) t)
+              (check "restart-keeps-prompt"
+                     (and (string-match-p "do the thing" text) t) t))
+            (with-current-buffer buf
+              (check "restart-clears-queue" claude-client--pending-notes nil)))
+        (let ((kill-buffer-query-functions nil)) (kill-buffer buf))))))

--- a/test/mcp-emacs-remote-test.el
+++ b/test/mcp-emacs-remote-test.el
@@ -211,6 +211,27 @@
   (mcp-emacs-remote--tap-runner-event nil (list :kind 'text :text "should not appear"))
   (check "runner-disabled-silent" (remote--transcript-text) nil))
 
+;; The human's own writes land in the same transcript, on the same channel
+;; as the runner's events -- one shared record, not two.
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
+    (mcp-emacs-remote--tap-runner-event
+     nil (list :kind 'note :text "check the error path" :pending t))
+    (check "runner-note-recorded"
+           (and (string-match-p "human :: check the error path"
+                                (remote--transcript-text))
+                t)
+           t)))
+
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
+    (mcp-emacs-remote--tap-runner-event
+     nil (list :kind 'notes-delivered :notes '("a" "b")))
+    (check "runner-notes-delivered-recorded"
+           (and (string-match-p "carried 2 note" (remote--transcript-text)) t) t)))
+
 ;; An unknown event kind is ignored rather than guessed at, so adding a new
 ;; kind to the runner cannot produce a malformed transcript entry.
 (remote--kill-transcripts)


### PR DESCRIPTION
The log has had one producer and several readers. A note is the second producer: the human writing to the same log the runner writes to, which is what the event-stream direction (#39) is actually for. Bound to `n` in the conversation buffer, or `claude-client-add-note`.

A note is recorded the moment it is written, so it is part of the shared record immediately and every subscriber sees it. The transcript now interleaves both actors in the order things happened:

```org
  - [10:48:41] human     :: mid-turn note
  - [10:48:42] assistant :: 1
  - [10:48:42] runner success
  - [10:48:42] carried 1 note(s) forward
  - [10:55:18] human     :: idle note
```

Delivery to the model is deliberately conservative: notes queue while a turn is in flight and are surfaced when it ends, and a note added while idle is delivered at once. Nothing is aborted mid tool-call. Notes queued before a run are folded into the outgoing prompt, so resetting the log cannot silently discard something the human wrote.

**This is not a claim that queueing is the right interruption rule.** It is the honest behaviour for a one-shot runner with no way to steer a turn in flight. Deciding finish/abort/re-plan is still the open question in #39, and it needs multi-turn stdin from #40 first — the two issues are coupled now.

One bug worth calling out, because the unit tests passed the whole time it was broken. Turn state was initially read from `process-live-p`, but `claude --print` stays alive after emitting `result` to wait on stdin, so a live process is not evidence of a turn in flight — a note added after a run finished stayed queued forever. Turn state is now tracked from the stream (`started` → `result`), with a test pinning that specific confusion. Only a live run surfaced it.

23 new tests, 363 pass across all suites. Mutation-checked: disabling the drain fails three tests, and dropping the prompt carry-forward initially failed nothing, so `restart-carries-note` was added to close that gap.

Verified live end to end: a note added mid-turn queues and drains at `finished`; a note added while idle (`turn-active=nil`, `proc-live=t`) delivers immediately.
