### PR TITLE
Continue a conversation over one CLI process

### DIFF
--- a/elisp/claude-client.el
+++ b/elisp/claude-client.el
@@ -20,8 +20,13 @@
 ;;   `permission_denials' in the result are a post-hoc audit record rather
 ;;   than a gate.
 ;;
-;; This first slice is deliberately one-shot: spawn, stream, render.
-;; Multi-turn stdin, `--resume', and window management are follow-ups.
+;; Turns are multi-turn over one subprocess: `claude-client-start' opens a
+;; conversation and `claude-client-send' continues it, reusing the same CLI
+;; so the session id and its context carry across turns.  That is also what
+;; lets a human note actually reach the model -- notes queued during a turn
+;; are delivered as the next one (see `claude-client-deliver-notes').
+;;
+;; Still to come: `--resume' of a past session, and window management.
 
 ;;; Code:
 
@@ -70,6 +75,20 @@ Proxied MCP tools are denied by default, so the write path
 \(`apply_diff') has to be listed here or every edit is refused before
 the human ever sees the ediff."
   :type '(repeat string)
+  :group 'claude-client)
+
+(defcustom claude-client-deliver-notes t
+  "When non-nil, hand queued notes to the model as a turn of their own.
+A note is always recorded immediately.  This controls whether it also
+*reaches* the model: with multi-turn stdin the notes drained at the end
+of a turn can be sent straight back as the next one, so \"add a thought
+at any time\" changes what the model does rather than only what the log
+says.  Set to nil to keep notes as a record the human relays by hand.
+
+This is the conservative half of the interruption question (#39): notes
+are delivered between turns, never mid tool-call.  Aborting or
+re-planning an in-flight turn is a separate decision."
+  :type 'boolean
   :group 'claude-client)
 
 (defcustom claude-client-system-prompt
@@ -281,6 +300,9 @@ running it is queued for the next one."
 
 (defun claude-client--drain-notes (buffer)
   "Surface BUFFER's pending notes now that its turn has ended.
+When `claude-client-deliver-notes' is non-nil and the process is still
+alive, the notes are also sent to the model as the next turn -- which is
+what makes a note actually reach it rather than only being recorded.
 Returns the drained notes, oldest first, and clears the queue."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
@@ -288,7 +310,15 @@ Returns the drained notes, oldest first, and clears the queue."
         (setq claude-client--pending-notes nil)
         (when notes
           (claude-client--push-event
-           buffer (list :kind 'notes-delivered :notes notes)))
+           buffer (list :kind 'notes-delivered :notes notes))
+          (when (and claude-client-deliver-notes
+                     (not claude-client--turn-active)
+                     (process-live-p claude-client--process))
+            (setq claude-client--turn-active t)
+            (claude-client--send-turn
+             claude-client--process
+             (concat "Notes from the human:\n"
+                     (mapconcat (lambda (n) (concat "- " n)) notes "\n")))))
         notes))))
 
 ;;;; Streaming
@@ -321,7 +351,10 @@ Returns the drained notes, oldest first, and clears the queue."
   (unless (process-live-p proc)
     (when (buffer-live-p buffer)
       (with-current-buffer buffer
-        (setq claude-client--process nil)))))
+        ;; The process dying ends any turn with it; leaving the flag set
+        ;; would wedge the buffer against ever starting another.
+        (setq claude-client--process nil
+              claude-client--turn-active nil)))))
 
 ;;;; Rendering
 
@@ -337,6 +370,7 @@ Returns the drained notes, oldest first, and clears the queue."
          (format "  → %s"
                  (car (split-string text "\n"))))))
     ('finished (format "── %s ──" (or (plist-get event :subtype) "done")))
+    ('prompt (format "\n>>> %s" (plist-get event :text)))
     ('note (format "> %s%s"
                    (plist-get event :text)
                    (if (plist-get event :pending) "  (pending)" "")))
@@ -357,11 +391,60 @@ Returns the drained notes, oldest first, and clears the queue."
         (unless (string-suffix-p "\n" s) (insert "\n"))))
     (when at-end (goto-char (point-max)))))
 
+;;;; Turns
+
+(defun claude-client--prompt-with-notes (prompt)
+  "Return PROMPT with this buffer's pending notes appended, and clear them.
+Notes the human wrote before a turn started are carried into that turn's
+prompt rather than dropped."
+  (let ((carried claude-client--pending-notes))
+    (setq claude-client--pending-notes nil)
+    (if carried
+        (concat prompt "\n\nNotes from the human:\n"
+                (mapconcat (lambda (n) (concat "- " n)) carried "\n"))
+      prompt)))
+
+(defun claude-client--send-turn (proc text)
+  "Write TEXT to PROC as one stream-json user turn."
+  (process-send-string
+   proc
+   (concat (json-encode
+            `((type . "user")
+              (message . ((role . "user")
+                          (content . [((type . "text") (text . ,text))])))))
+           "\n")))
+
+;;;###autoload
+(defun claude-client-send (prompt)
+  "Send PROMPT as the next turn of this conversation.
+Reuses the running CLI process, so the model keeps the session and its
+context; `claude-client-start' is only needed for the first turn or
+after the process has gone.  Refuses while a turn is in flight -- the
+CLI reads one turn at a time, and writing a second would interleave
+with the one being answered."
+  (interactive "sPrompt: ")
+  (unless (derived-mode-p 'claude-client-mode)
+    (user-error "Not in a Claude conversation buffer"))
+  (cond
+   (claude-client--turn-active
+    (user-error "A turn is already running; add a note with `n' instead"))
+   ((not (process-live-p claude-client--process))
+    (user-error "No live Claude process; start one with `g'"))
+   (t
+    (let ((text (claude-client--prompt-with-notes prompt)))
+      (claude-client--push-event (current-buffer)
+                                 (list :kind 'prompt :text prompt))
+      (setq claude-client--turn-active t)
+      (claude-client--send-turn claude-client--process text)))))
+
 ;;;; Entry point
 
 ;;;###autoload
 (defun claude-client-start (prompt)
   "Run PROMPT through a headless Claude and render it in a buffer.
+Starts a fresh conversation, replacing any previous log in this buffer.
+Use `claude-client-send' to continue an existing one.
+
 Edits are routed through the mcp-emacs server's `apply_diff', so any
 file change opens an ediff for the human to accept or reject."
   (interactive "sPrompt: ")
@@ -374,39 +457,27 @@ file change opens an ediff for the human to accept or reject."
       ;; waits for a human whose answer no longer goes anywhere.
       (when claude-client--turn-active
         (user-error "A Claude run is already active here; `k' to kill it first"))
+      ;; A previous conversation's process is replaced, not left behind.
+      (when (process-live-p claude-client--process)
+        (delete-process claude-client--process))
       (let ((inhibit-read-only t)) (erase-buffer))
-      ;; Notes queued before this run (or left over from the last one) are
-      ;; carried into the prompt rather than dropped -- a note the human
-      ;; wrote must not vanish just because the log was reset.
-      (let ((carried claude-client--pending-notes))
-        (setq claude-client--events nil
-              claude-client--stdout ""
-              claude-client--session-id nil
-              claude-client--pending-notes nil)
-        (let ((text (if carried
-                        (concat prompt "\n\nNotes from the human:\n"
-                                (mapconcat (lambda (n) (concat "- " n))
-                                           carried "\n"))
-                      prompt))
-              (proc (make-process
-                     :name "claude-client"
-                     :buffer nil
-                     :command (claude-client--command)
-                     :connection-type 'pipe
-                     :noquery t
-                     :filter (lambda (p c) (claude-client--filter buffer p c))
-                     :sentinel (lambda (p c)
-                                 (claude-client--sentinel buffer p c)))))
-          (setq claude-client--process proc
-                claude-client--turn-active t)
-          (process-send-string
-           proc
-           (concat (json-encode
-                    `((type . "user")
-                      (message . ((role . "user")
-                                  (content . [((type . "text")
-                                               (text . ,text))])))))
-                   "\n")))))
+      (setq claude-client--events nil
+            claude-client--stdout ""
+            claude-client--session-id nil)
+      (let ((text (claude-client--prompt-with-notes prompt))
+            (proc (make-process
+                   :name "claude-client"
+                   :buffer nil
+                   :command (claude-client--command)
+                   :connection-type 'pipe
+                   :noquery t
+                   :filter (lambda (p c) (claude-client--filter buffer p c))
+                   :sentinel (lambda (p c)
+                               (claude-client--sentinel buffer p c)))))
+        (setq claude-client--process proc
+              claude-client--turn-active t)
+        (claude-client--push-event buffer (list :kind 'prompt :text prompt))
+        (claude-client--send-turn proc text)))
     (pop-to-buffer buffer)
     buffer))
 
@@ -425,6 +496,7 @@ file change opens an ediff for the human to accept or reject."
     (define-key map (kbd "g") #'claude-client-start)
     (define-key map (kbd "k") #'claude-client-quit)
     (define-key map (kbd "n") #'claude-client-add-note)
+    (define-key map (kbd "s") #'claude-client-send)
     map)
   "Keymap for `claude-client-mode'.")
 

--- a/test/claude-client-test.el
+++ b/test/claude-client-test.el
@@ -317,9 +317,11 @@ stays alive after `result', so process liveness cannot stand in for it."
 (let ((buf (claude-test--buffer)))
   (unwind-protect
       (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t)))
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                  ((symbol-function 'process-send-string) (lambda (&rest _) nil)))
           ;; Process "alive", but the turn ended: the note must still drain.
-          (setq claude-client--turn-active nil)
+          (setq claude-client--process 'fake
+                claude-client--turn-active nil)
           (claude-client-add-note "after the turn")
           (check "live-process-is-not-an-active-turn"
                  claude-client--pending-notes nil)))
@@ -466,3 +468,112 @@ stays alive after `result', so process liveness cannot stand in for it."
             (with-current-buffer buf
               (check "restart-clears-queue" claude-client--pending-notes nil)))
         (let ((kill-buffer-query-functions nil)) (kill-buffer buf))))))
+
+;;;; Multi-turn stdin
+;;
+;; A follow-up turn reuses the running CLI, so the model keeps its session
+;; and context.  Verified against the real CLI: a second turn on the same
+;; process returns the same `session_id' and can recall the first turn.
+
+;; `claude-client-send' writes a well-formed user turn and marks the turn
+;; active, without respawning.
+(let ((buf (claude-test--buffer))
+      (sent nil))
+  (unwind-protect
+      (with-current-buffer buf
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                  ((symbol-function 'process-send-string)
+                   (lambda (_p s) (setq sent s)))
+                  ;; A respawn here would be the bug: the point is reuse.
+                  ((symbol-function 'make-process)
+                   (lambda (&rest _) (error "must not spawn"))))
+          (setq claude-client--process 'fake claude-client--turn-active nil)
+          (claude-client-send "second turn")
+          (let ((msg (json-parse-string sent :object-type 'alist
+                                        :array-type 'array)))
+            (check "send-type-user" (alist-get 'type msg) "user")
+            (check "send-text"
+                   (alist-get 'text
+                              (aref (alist-get 'content
+                                               (alist-get 'message msg)) 0))
+                   "second turn"))
+          (check "send-marks-turn-active" claude-client--turn-active t)
+          (check "send-logs-prompt"
+                 (plist-get (car (last claude-client--events)) :kind) 'prompt)))
+    (kill-buffer buf)))
+
+;; Sending while a turn is in flight is refused: the CLI reads one turn at a
+;; time, so a second write would interleave with the one being answered.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t)))
+          (setq claude-client--process 'fake claude-client--turn-active t)
+          (check "send-refused-mid-turn"
+                 (condition-case _ (progn (claude-client-send "x") nil)
+                   (user-error t))
+                 t)))
+    (kill-buffer buf)))
+
+;; With no live process there is nothing to continue.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (setq claude-client--process nil claude-client--turn-active nil)
+        (check "send-refused-without-process"
+               (condition-case _ (progn (claude-client-send "x") nil)
+                 (user-error t))
+               t))
+    (kill-buffer buf)))
+
+;; Notes drained at turn end are delivered to the model as the next turn --
+;; this is what makes a note change what the model does, not just the log.
+(let ((buf (claude-test--buffer))
+      (sent nil))
+  (unwind-protect
+      (with-current-buffer buf
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                  ((symbol-function 'process-send-string)
+                   (lambda (_p s) (setq sent s))))
+          (setq claude-client--process 'fake
+                claude-client-deliver-notes t)
+          (claude-test--with-running-turn
+           (claude-client-add-note "reconsider the approach"))
+          (setq claude-client--turn-active t)
+          (claude-test--feed buf (concat claude-test--result "\n"))
+          (check "notes-delivered-to-model"
+                 (and sent (string-match-p "reconsider the approach" sent) t) t)
+          (check "note-delivery-starts-a-turn" claude-client--turn-active t)))
+    (kill-buffer buf)))
+
+;; Delivery is opt-out: with it off the note is still recorded, but nothing
+;; is sent and no new turn begins.
+(let ((buf (claude-test--buffer))
+      (sent nil))
+  (unwind-protect
+      (with-current-buffer buf
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                  ((symbol-function 'process-send-string)
+                   (lambda (_p s) (setq sent s))))
+          (setq claude-client--process 'fake
+                claude-client-deliver-notes nil)
+          (claude-test--with-running-turn (claude-client-add-note "quiet note"))
+          (setq claude-client--turn-active t)
+          (claude-test--feed buf (concat claude-test--result "\n"))
+          (check "no-delivery-when-disabled" sent nil)
+          (check "no-turn-when-disabled" claude-client--turn-active nil)
+          (check "note-still-recorded"
+                 (and (memq 'notes-delivered (claude-test--kinds buf)) t) t)))
+    (kill-buffer buf)))
+
+;; A dead process ends the turn with it; otherwise the buffer would be
+;; wedged against ever starting another run.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (setq claude-client--turn-active t)
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) nil)))
+          (claude-client--sentinel buf 'fake "exited"))
+        (check "sentinel-clears-turn" claude-client--turn-active nil)
+        (check "sentinel-clears-process" claude-client--process nil))
+    (kill-buffer buf)))


### PR DESCRIPTION
The runner could only ask one question: every prompt spawned a fresh CLI and reset the log. `claude-client-send` (`s`) now writes a further turn to the running process, which keeps the session id and the context with it. Checked against the CLI before building on it, and end to end afterwards — a second turn recalls what the first one was told, under the same `session_id`.

Sending is refused while a turn is in flight. The CLI reads one turn at a time, so a second write would interleave with the one being answered; the human is pointed at a note instead.

**This is what makes a note reach the model rather than only the log.** Notes drained at the end of a turn are now sent back as the next turn, so a thought written mid-run changes what the model does. Live:

```
prompt started text finished          ← "remember 42"
prompt started text finished          ← recalled "42", same session
prompt started note text finished     ← note arrives mid-count
notes-delivered started text finished ← note becomes a turn → "STOPPED"
```

While it counted to 30, a note asking it to stop was queued, delivered when the count finished, and answered. The count still ran to completion — that is the cost of not interrupting, and it is now something measured rather than assumed. `claude-client-deliver-notes` turns delivery off for anyone who wants notes kept as a record they relay by hand.

For #39 this is the missing half of the interruption question: notes are delivered *between* turns, never mid tool-call. Aborting or re-planning an in-flight turn is now a decision that can actually be implemented and compared against this baseline, which it could not be with a one-shot runner.

Also: the sentinel clears the turn flag when the process dies, or a buffer whose CLI crashed mid-turn could never start another run.

13 new tests (376 across all suites, 0 fail) covering turn framing, the mid-turn refusal, the missing-process refusal, note delivery on and off, and the sentinel path.
