### PR TITLE
Reopen a past session in the terminal-free runner

### DIFF
--- a/elisp/claude-client.el
+++ b/elisp/claude-client.el
@@ -26,7 +26,13 @@
 ;; lets a human note actually reach the model -- notes queued during a turn
 ;; are delivered as the next one (see `claude-client-deliver-notes').
 ;;
-;; Still to come: `--resume' of a past session, and window management.
+;; A past session can be reopened with `claude-client-resume' (`r'), which
+;; reuses the same on-disk session store the eat runner's picker reads, so a
+;; session started in either runner can be continued in the other.  Only the
+;; model's context comes back -- the rendered log lives in the buffer, not on
+;; disk.
+;;
+;; Still to come: window management.
 
 ;;; Code:
 
@@ -172,8 +178,13 @@ pointing at the running server's endpoint."
     (with-temp-file file (insert claude-client-system-prompt))
     file))
 
-(defun claude-client--command ()
-  "Return the full argument list for the Claude CLI subprocess."
+(defun claude-client--command (&optional resume-id)
+  "Return the full argument list for the Claude CLI subprocess.
+With RESUME-ID, continue that past session instead of starting a new
+one: the CLI reopens it with its history, keeping the same session id.
+Note `--session-id' is not the same thing -- that means \"create a new
+session with this id\" and fails outright if a transcript already
+exists."
   (append
    (list claude-client-executable
          "--print"
@@ -184,6 +195,7 @@ pointing at the running server's endpoint."
          "--strict-mcp-config"
          "--settings" (claude-client--settings-file)
          "--append-system-prompt-file" (claude-client--system-prompt-file))
+   (when resume-id (list "--resume" resume-id))
    (when claude-client-model (list "--model" claude-client-model))
    (when claude-client-disallowed-tools
      (cons "--disallowedTools" claude-client-disallowed-tools))))
@@ -370,6 +382,7 @@ Returns the drained notes, oldest first, and clears the queue."
          (format "  → %s"
                  (car (split-string text "\n"))))))
     ('finished (format "── %s ──" (or (plist-get event :subtype) "done")))
+    ('resumed (format "── resumed %s ──" (plist-get event :session)))
     ('prompt (format "\n>>> %s" (plist-get event :text)))
     ('note (format "> %s%s"
                    (plist-get event :text)
@@ -440,10 +453,16 @@ with the one being answered."
 ;;;; Entry point
 
 ;;;###autoload
-(defun claude-client-start (prompt)
+(defun claude-client-start (prompt &optional resume-id)
   "Run PROMPT through a headless Claude and render it in a buffer.
 Starts a fresh conversation, replacing any previous log in this buffer.
-Use `claude-client-send' to continue an existing one.
+Use `claude-client-send' to continue the one already running.
+
+With RESUME-ID, reopen that past session instead of starting a new one,
+so the model still has its history; `claude-client-resume' picks one
+interactively.  The log itself does not come back -- it lives in this
+buffer, not on disk -- so the rendered conversation restarts even though
+the model's context does not.
 
 Edits are routed through the mcp-emacs server's `apply_diff', so any
 file change opens an ediff for the human to accept or reject."
@@ -468,7 +487,7 @@ file change opens an ediff for the human to accept or reject."
             (proc (make-process
                    :name "claude-client"
                    :buffer nil
-                   :command (claude-client--command)
+                   :command (claude-client--command resume-id)
                    :connection-type 'pipe
                    :noquery t
                    :filter (lambda (p c) (claude-client--filter buffer p c))
@@ -476,10 +495,41 @@ file change opens an ediff for the human to accept or reject."
                                (claude-client--sentinel buffer p c)))))
         (setq claude-client--process proc
               claude-client--turn-active t)
+        (when resume-id
+          (claude-client--push-event buffer (list :kind 'resumed
+                                                  :session resume-id)))
         (claude-client--push-event buffer (list :kind 'prompt :text prompt))
         (claude-client--send-turn proc text)))
     (pop-to-buffer buffer)
     buffer))
+
+(declare-function mcp-emacs-run--project-root "mcp-emacs-run" ())
+(declare-function mcp-emacs-run-resume--session-files "mcp-emacs-run-resume" (root))
+(declare-function mcp-emacs-run-resume--session-id "mcp-emacs-run-resume" (file))
+(declare-function mcp-emacs-run-resume--label "mcp-emacs-run-resume" (file))
+
+;;;###autoload
+(defun claude-client-resume ()
+  "Pick a past Claude session for this project and reopen it here.
+Reuses the on-disk session store and the labels the eat runner's picker
+already builds -- the store is backend-agnostic, so a session started in
+either runner can be resumed in this one."
+  (interactive)
+  (require 'mcp-emacs-run)
+  (require 'mcp-emacs-run-resume)
+  (let* ((root (mcp-emacs-run--project-root))
+         (files (mcp-emacs-run-resume--session-files root)))
+    (unless files
+      (user-error "No past Claude sessions for this project"))
+    (let* ((alist (mapcar (lambda (f)
+                            (cons (mcp-emacs-run-resume--label f) f))
+                          files))
+           (pick (completing-read "Resume session: " alist nil t))
+           (file (cdr (assoc pick alist))))
+      (when file
+        (claude-client-start
+         (read-string "Prompt: ")
+         (mcp-emacs-run-resume--session-id file))))))
 
 (defun claude-client-quit ()
   "Kill the CLI subprocess for this buffer."
@@ -497,6 +547,7 @@ file change opens an ediff for the human to accept or reject."
     (define-key map (kbd "k") #'claude-client-quit)
     (define-key map (kbd "n") #'claude-client-add-note)
     (define-key map (kbd "s") #'claude-client-send)
+    (define-key map (kbd "r") #'claude-client-resume)
     map)
   "Keymap for `claude-client-mode'.")
 

--- a/test/claude-client-test.el
+++ b/test/claude-client-test.el
@@ -577,3 +577,73 @@ stays alive after `result', so process liveness cannot stand in for it."
         (check "sentinel-clears-turn" claude-client--turn-active nil)
         (check "sentinel-clears-process" claude-client--process nil))
     (kill-buffer buf)))
+
+;;;; Resume
+;;
+;; `--resume' reopens a past session in a NEW process, keeping its id and
+;; history.  Verified against the CLI: a resumed session recalls what it was
+;; told before the first process exited.  Note `--session-id' is a different
+;; flag -- it means "create a new session with this id" and fails if a
+;; transcript already exists.
+
+(let ((cmd (claude-client--command "sess-abc")))
+  (check "resume-flag-present" (and (member "--resume" cmd) t) t)
+  (check "resume-id-follows-flag"
+         (cadr (member "--resume" cmd)) "sess-abc")
+  ;; --session-id would mean "create new with this id" and hard-fail on an
+  ;; existing transcript; resuming must not use it.
+  (check "resume-does-not-use-session-id"
+         (and (member "--session-id" cmd) t) nil))
+
+;; Without an id the flag is absent entirely, so a normal start is unchanged.
+(let ((cmd (claude-client--command)))
+  (check "no-resume-flag-by-default" (and (member "--resume" cmd) t) nil))
+
+;; Starting with a resume id logs it, so the transcript shows which session
+;; was reopened rather than looking like a fresh conversation.
+(let ((sent nil))
+  (cl-letf (((symbol-function 'make-process) (lambda (&rest _) 'fake-proc))
+            ((symbol-function 'process-send-string) (lambda (_p s) (setq sent s)))
+            ((symbol-function 'pop-to-buffer) #'ignore)
+            ((symbol-function 'claude-client--mcp-config-file) (lambda () "/tmp/m.json"))
+            ((symbol-function 'claude-client--settings-file) (lambda () "/tmp/s.json"))
+            ((symbol-function 'claude-client--system-prompt-file) (lambda () "/tmp/p.txt")))
+    (let ((buf (get-buffer-create "*claude-client*")))
+      (unwind-protect
+          (progn
+            (with-current-buffer buf
+              (claude-client-mode)
+              (setq claude-client--process nil claude-client--turn-active nil))
+            (claude-client-start "carry on" "sess-xyz")
+            (with-current-buffer buf
+              (check "resume-logs-resumed-event"
+                     (plist-get (car claude-client--events) :kind) 'resumed)
+              (check "resume-event-carries-id"
+                     (plist-get (car claude-client--events) :session) "sess-xyz")
+              (check "resume-then-prompt"
+                     (mapcar (lambda (e) (plist-get e :kind)) claude-client--events)
+                     '(resumed prompt))))
+        (let ((kill-buffer-query-functions nil)) (kill-buffer buf))))))
+
+;; A plain start logs no `resumed' event.
+(let ((sent nil))
+  (cl-letf (((symbol-function 'make-process) (lambda (&rest _) 'fake-proc))
+            ((symbol-function 'process-send-string) (lambda (_p s) (setq sent s)))
+            ((symbol-function 'pop-to-buffer) #'ignore)
+            ((symbol-function 'claude-client--mcp-config-file) (lambda () "/tmp/m.json"))
+            ((symbol-function 'claude-client--settings-file) (lambda () "/tmp/s.json"))
+            ((symbol-function 'claude-client--system-prompt-file) (lambda () "/tmp/p.txt")))
+    (let ((buf (get-buffer-create "*claude-client*")))
+      (unwind-protect
+          (progn
+            (with-current-buffer buf
+              (claude-client-mode)
+              (setq claude-client--process nil claude-client--turn-active nil))
+            (claude-client-start "fresh")
+            (with-current-buffer buf
+              (check "fresh-start-has-no-resumed"
+                     (memq 'resumed
+                           (mapcar (lambda (e) (plist-get e :kind))
+                                   claude-client--events))
+                     nil)))
+        (let ((kill-buffer-query-functions nil)) (kill-buffer buf))))))


### PR DESCRIPTION
`claude-client-resume` (`r`) picks a past session for the project and reopens it, so a conversation survives the process it started in. It reuses the on-disk session store and the labels the eat runner's picker already builds — that store is backend-agnostic, so a session started in either runner can be continued in the other.

`--resume`, not `--session-id`: the latter means "create a new session with this id" and fails outright when a transcript already exists. The two flags look interchangeable and are not, so a test pins the distinction.

Only the model's context comes back. The rendered log lives in the buffer rather than on disk, so the conversation restarts on screen even though the model still remembers. Checked live by killing the process outright and resuming its id in a fresh one:

```
── resumed 60766054-612d-45ab-9a46-a7a8026162d8 ──

>>> What codeword did I ask you to remember? Reply with just the word.
── claude claude-opus-5 ──
BADGER
── success ──
```

That asymmetry is worth noting for #39: session durability lives in the CLI's store, while the event log does not survive at all. If the log is meant to be the record rather than a view, it needs its own persistence — the subsumption test already flagged this.

8 new tests (384 across all suites, 0 fail), covering flag construction with and without a resume id, the `--session-id` confusion, and the `resumed` event. Mutation-checked: swapping `--resume` for `--session-id` fails three tests.

With this, #40 has only window management left.
