### PR TITLE
Give the conversation its own window, and keep it through a review

### DIFF
--- a/elisp/claude-client.el
+++ b/elisp/claude-client.el
@@ -32,7 +32,12 @@
 ;; model's context comes back -- the rendered log lives in the buffer, not on
 ;; disk.
 ;;
-;; Still to come: window management.
+;; The conversation window is an ordinary window placed with
+;; `display-buffer-in-direction' (`claude-client-window-direction'), matching
+;; the eat runner's placement.  It is also re-shown after an ediff review
+;; resolves: the review restores a window configuration captured before the
+;; conversation existed, which would otherwise hide it exactly when the
+;; result arrives (issue #44).
 
 ;;; Code:
 
@@ -97,6 +102,46 @@ re-planning an in-flight turn is a separate decision."
   :type 'boolean
   :group 'claude-client)
 
+(defcustom claude-client-window-direction 'right
+  "Direction in which the conversation window is placed.
+An ordinary window in this direction, so it can be split, navigated and
+closed like any other -- mirroring `mcp-emacs-run-window-direction' so
+both runners feel the same.  `nil' uses plain `pop-to-buffer' and lets
+`display-buffer-alist' decide."
+  :type '(choice (const right) (const left) (const above) (const below)
+                 (const :tag "Let display-buffer decide" nil))
+  :group 'claude-client)
+
+(defcustom claude-client-window-width 0.4
+  "Width of the conversation window, as a fraction of the frame.
+Used when `claude-client-window-direction' is `left' or `right'."
+  :type 'number
+  :group 'claude-client)
+
+(defcustom claude-client-window-height 0.4
+  "Height of the conversation window, as a fraction of the frame.
+Used when `claude-client-window-direction' is `above' or `below'."
+  :type 'number
+  :group 'claude-client)
+
+(defcustom claude-client-focus-on-show nil
+  "When non-nil, select the conversation window when it is shown.
+Off by default: the runner is something to watch while working
+elsewhere, so stealing point on every redisplay would be disruptive."
+  :type 'boolean
+  :group 'claude-client)
+
+(defcustom claude-client-restore-window-after-review t
+  "Re-show the conversation window after an ediff review resolves.
+The review captures the window configuration before it starts and
+restores it on quit (so side windows come back).  When the review was
+triggered by a tool call from this buffer, that snapshot predates the
+conversation window, so restoring it takes the conversation off screen
+exactly when its result arrives.  Re-displaying afterwards keeps it
+visible without touching the review's own restore."
+  :type 'boolean
+  :group 'claude-client)
+
 (defcustom claude-client-system-prompt
   "You are running inside Emacs. You have no Write or Edit tools.
 To change a file you must call mcp__emacs__apply_diff with the absolute
@@ -138,11 +183,12 @@ stays alive after emitting `result' (it waits on stdin for a follow-up
 turn), so `process-live-p' reports `run' long after the turn is over
 and cannot answer \"is the model working right now?\".")
 
-(defvar claude-client-event-functions nil
+(defvar claude-client-event-functions '(claude-client--reshow-after-review)
   "Abnormal hook run with (BUFFER EVENT) for every parsed event.
 Each EVENT is a plist as stored in `claude-client--events'.  This is
-the subscriber seam: rendering is one consumer, and issue #39's Org
-transcript can be another without touching this file.")
+the subscriber seam: rendering is one consumer, the Org transcript
+\(issue #39) another, and keeping the conversation window visible across
+an ediff review a third -- none of which the runner has to know about.")
 
 ;;;; Spawning
 
@@ -199,6 +245,42 @@ exists."
    (when claude-client-model (list "--model" claude-client-model))
    (when claude-client-disallowed-tools
      (cons "--disallowedTools" claude-client-disallowed-tools))))
+
+;;;; Windows
+
+(defun claude-client--display (buffer)
+  "Display BUFFER in the conversation window and return that window.
+Placed with `display-buffer-in-direction' so it stays an ordinary,
+splittable window rather than a dedicated side window -- the same shape
+`mcp-emacs-run--display' gives the eat runner."
+  (let* ((window
+          (if (null claude-client-window-direction)
+              (display-buffer buffer)
+            (let ((size (if (memq claude-client-window-direction '(left right))
+                            `(window-width . ,claude-client-window-width)
+                          `(window-height . ,claude-client-window-height))))
+              (display-buffer
+               buffer
+               `((display-buffer-in-direction)
+                 (direction . ,claude-client-window-direction)
+                 ,size))))))
+    (when (and window claude-client-focus-on-show)
+      (select-window window))
+    window))
+
+(defun claude-client--reshow-after-review (buffer event)
+  "Re-display BUFFER when EVENT reports a finished tool call.
+Subscriber for `claude-client-event-functions'.  An `apply_diff' review
+restores the window configuration it captured before it opened, which
+predates this conversation window when the review came from this
+buffer's own tool call -- so without this the conversation vanishes at
+the moment its result lands.  Only re-shows a buffer that was already
+displayed, so this never forces a hidden conversation on screen."
+  (when (and claude-client-restore-window-after-review
+             (eq (plist-get event :kind) 'tool-result)
+             (buffer-live-p buffer)
+             (not (get-buffer-window buffer t)))
+    (claude-client--display buffer)))
 
 ;;;; Event model
 
@@ -500,7 +582,7 @@ file change opens an ediff for the human to accept or reject."
                                                   :session resume-id)))
         (claude-client--push-event buffer (list :kind 'prompt :text prompt))
         (claude-client--send-turn proc text)))
-    (pop-to-buffer buffer)
+    (claude-client--display buffer)
     buffer))
 
 (declare-function mcp-emacs-run--project-root "mcp-emacs-run" ())

--- a/test/claude-client-test.el
+++ b/test/claude-client-test.el
@@ -647,3 +647,111 @@ stays alive after `result', so process liveness cannot stand in for it."
                                    claude-client--events))
                      nil)))
         (let ((kill-buffer-query-functions nil)) (kill-buffer buf))))))
+
+;;;; Window management
+;;
+;; Placement mirrors the eat runner: an ordinary window in a configurable
+;; direction, not a dedicated side window.
+
+(let ((captured nil))
+  (cl-letf (((symbol-function 'display-buffer)
+             (lambda (_buf &optional action) (setq captured action) nil)))
+    (let ((claude-client-window-direction 'right)
+          (claude-client-window-width 0.4))
+      (claude-client--display (current-buffer))
+      (check "display-uses-in-direction"
+             (and (memq 'display-buffer-in-direction (car captured)) t) t)
+      (check "display-honours-direction"
+             (alist-get 'direction captured) 'right)
+      (check "display-sets-width"
+             (alist-get 'window-width captured) 0.4))
+    ;; Vertical placement sizes by height instead.
+    (let ((claude-client-window-direction 'below)
+          (claude-client-window-height 0.3))
+      (claude-client--display (current-buffer))
+      (check "display-vertical-uses-height"
+             (alist-get 'window-height captured) 0.3))
+    ;; nil hands the decision to display-buffer-alist: no action argument at
+    ;; all, rather than an in-direction action.
+    (let ((claude-client-window-direction nil))
+      (setq captured 'untouched)
+      (claude-client--display (current-buffer))
+      (check "display-nil-direction-plain" captured nil))))
+
+;; Focus is not stolen by default.
+(let ((selected nil))
+  (cl-letf (((symbol-function 'display-buffer) (lambda (&rest _) 'win))
+            ((symbol-function 'select-window) (lambda (w) (setq selected w))))
+    (let ((claude-client-focus-on-show nil))
+      (claude-client--display (current-buffer))
+      (check "no-focus-by-default" selected nil))
+    (let ((claude-client-focus-on-show t))
+      (claude-client--display (current-buffer))
+      (check "focus-when-requested" selected 'win))))
+
+;;;; Re-show after an ediff review (#44)
+;;
+;; `mcp-emacs--ediff-review' restores the window configuration it captured
+;; before the review, and does so BEFORE calling its on-resolve callback
+;; (mcp-emacs.el: set-window-configuration then on-resolve).  When the review
+;; came from this buffer's own tool call that snapshot predates the
+;; conversation window, so by the time the tool result arrives the
+;; conversation is already off screen.
+
+(let ((buf (claude-test--buffer))
+      (shown nil))
+  (unwind-protect
+      (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) nil))
+                ((symbol-function 'claude-client--display)
+                 (lambda (b) (setq shown b))))
+        (let ((claude-client-restore-window-after-review t))
+          (claude-client--reshow-after-review
+           buf (list :kind 'tool-result :text "Status: applied"))
+          (check "reshow-after-tool-result" shown buf)))
+    (kill-buffer buf)))
+
+;; Only tool results trigger it; ordinary text must not fight the user's
+;; window layout on every streamed message.
+(let ((buf (claude-test--buffer))
+      (shown nil))
+  (unwind-protect
+      (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) nil))
+                ((symbol-function 'claude-client--display)
+                 (lambda (b) (setq shown b))))
+        (let ((claude-client-restore-window-after-review t))
+          (claude-client--reshow-after-review buf (list :kind 'text :text "hi"))
+          (check "no-reshow-on-text" shown nil)))
+    (kill-buffer buf)))
+
+;; A conversation that is already visible is left alone.
+(let ((buf (claude-test--buffer))
+      (shown nil))
+  (unwind-protect
+      (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) 'win))
+                ((symbol-function 'claude-client--display)
+                 (lambda (b) (setq shown b))))
+        (let ((claude-client-restore-window-after-review t))
+          (claude-client--reshow-after-review
+           buf (list :kind 'tool-result :text "x"))
+          (check "no-reshow-when-visible" shown nil)))
+    (kill-buffer buf)))
+
+;; Opt-out respected.
+(let ((buf (claude-test--buffer))
+      (shown nil))
+  (unwind-protect
+      (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) nil))
+                ((symbol-function 'claude-client--display)
+                 (lambda (b) (setq shown b))))
+        (let ((claude-client-restore-window-after-review nil))
+          (claude-client--reshow-after-review
+           buf (list :kind 'tool-result :text "x"))
+          (check "reshow-opt-out" shown nil)))
+    (kill-buffer buf)))
+
+;; The re-show is installed as a subscriber, not wired into the runner: the
+;; log stays the seam, and this is just one more reader of it.
+(check "reshow-is-a-subscriber"
+       (and (memq #'claude-client--reshow-after-review
+                  claude-client-event-functions) t)
+       t)


### PR DESCRIPTION
Closes #44. Finishes the window-management item on #40.

The runner used a bare `pop-to-buffer`, so the conversation landed wherever `display-buffer` happened to put it. It now takes an ordinary window in `claude-client-window-direction`, mirroring `mcp-emacs-run-window-direction` so both runners feel the same — splittable and closable rather than a dedicated side window, and not stealing focus by default, since the runner is something to watch while working elsewhere.

The conversation also disappeared whenever an `apply_diff` review resolved (#44). The review restores the window configuration it captured before opening, and does so *before* calling its on-resolve callback (`mcp-emacs.el`: `set-window-configuration` then `on-resolve`). When the review came from this buffer's own tool call, that snapshot predates the conversation window — so the conversation went off screen exactly as its result arrived.

Rather than touch the review, whose restore exists to bring side windows back (#21/#36), the client re-shows itself when a tool result lands and it is no longer displayed. Only when it was already visible, so a hidden conversation is never forced on screen. The fix is a subscriber on the event hook, not a change to the runner: the log stays the seam, and keeping a window visible is just another reader of it.

Verified live twice, on a full run that opened an ediff and had it accepted: `client=alive window=SHOWN`, the edit landed, and the conversation stayed visible through `finished`. 17 new tests (396 across all suites, 0 fail) covering placement in each direction, the focus preference, the `nil` passthrough to `display-buffer-alist`, and the re-show — fires on a tool result, not on ordinary text, not when already visible, and respects its opt-out. Mutation-checked: uninstalling the subscriber and firing it on every event kind each fail the intended test.

One caveat on the diagnosis. An earlier run of the same scenario ended with the conversation buffer *killed* rather than hidden, which this fix would not help with — a re-show cannot resurrect a dead buffer. I could not reproduce that with a kill-buffer tracer installed (zero kills across two subsequent runs), and the surviving evidence points at my own test cleanup racing the run rather than at the client. Worth reopening if it recurs in normal use.
