### PR TITLE
Observe Org task changes in the shared event log

### DIFF
--- a/elisp/mcp-emacs-remote.el
+++ b/elisp/mcp-emacs-remote.el
@@ -58,6 +58,11 @@
 ;; on the writer's side.
 (defvar claude-client-event-functions)
 
+;; Defined in mcp-emacs, which is loaded via mcp-emacs-run; declared so this
+;; file compiles standalone.  Org-side observations land in the same
+;; transcript as the runner's events (issue #39).
+(defvar mcp-emacs-org-task-event-functions)
+
 (defgroup mcp-emacs-remote nil
   "Remote-control an interactive Claude session from Emacs."
   :group 'tools)
@@ -275,6 +280,50 @@ degrades to silence instead of a malformed entry."
               (length (plist-get event :notes)))))
     (_ nil)))
 
+;;;; Org-task subscriber (issue #39)
+
+;; The Org file is the aggregate and owns this state; these events only
+;; *observe* that it changed.  Recording them here puts the human's Org
+;; edits and the runner's activity in one shared record, without the log
+;; becoming a second source of truth -- nothing here is ever replayed to
+;; reconstruct state.
+
+(defun mcp-emacs-remote--record-org-task-event (event)
+  "Record an org-task EVENT into the transcript.
+EVENT is a plist as published on `mcp-emacs-org-task-event-functions'.
+Unknown kinds are ignored rather than guessed at."
+  (let ((file (file-name-nondirectory (or (plist-get event :path) "?"))))
+    (pcase (plist-get event :kind)
+      ('session-status
+       (mcp-emacs-remote--append
+        (format "  - %s org session :: %s [%s]"
+                (mcp-emacs-remote--timestamp)
+                (plist-get event :status) file)))
+      ('item-status
+       (mcp-emacs-remote--append
+        (format "  - %s org item :: %s → %s [%s]"
+                (mcp-emacs-remote--timestamp)
+                (plist-get event :ref) (plist-get event :status) file)))
+      ('item-added
+       (mcp-emacs-remote--append
+        (format "  - %s org item added :: %s %s [%s]"
+                (mcp-emacs-remote--timestamp)
+                (plist-get event :status) (plist-get event :text) file)))
+      ('note
+       (mcp-emacs-remote--append
+        (format "  - %s org note :: %s [%s]"
+                (mcp-emacs-remote--timestamp)
+                (car (split-string (or (plist-get event :text) "") "\n"))
+                file)))
+      (_ nil))))
+
+(defun mcp-emacs-remote--tap-org-task-event (event)
+  "Subscriber for `mcp-emacs-org-task-event-functions'.
+Records EVENT when recording is enabled.  Errors are swallowed: an
+observer must never break the Org write it is observing."
+  (when mcp-emacs-remote-enabled
+    (ignore-errors (mcp-emacs-remote--record-org-task-event event))))
+
 (defun mcp-emacs-remote--tap-runner-event (buffer event)
   "Subscriber for `claude-client-event-functions'.
 Records EVENT from conversation BUFFER when recording is enabled.
@@ -297,7 +346,9 @@ Also sets `mcp-emacs-remote-enabled'."
   (when (fboundp 'mcp-emacs-ide-stop)
     (advice-add 'mcp-emacs-ide-stop :before #'mcp-emacs-remote--tap-stop))
   (add-hook 'claude-client-event-functions
-            #'mcp-emacs-remote--tap-runner-event))
+            #'mcp-emacs-remote--tap-runner-event)
+  (add-hook 'mcp-emacs-org-task-event-functions
+            #'mcp-emacs-remote--tap-org-task-event))
 
 ;;;###autoload
 (defun mcp-emacs-remote-disable ()
@@ -311,7 +362,9 @@ Also sets `mcp-emacs-remote-enabled'."
   (when (fboundp 'mcp-emacs-ide-stop)
     (advice-remove 'mcp-emacs-ide-stop #'mcp-emacs-remote--tap-stop))
   (remove-hook 'claude-client-event-functions
-               #'mcp-emacs-remote--tap-runner-event))
+               #'mcp-emacs-remote--tap-runner-event)
+  (remove-hook 'mcp-emacs-org-task-event-functions
+               #'mcp-emacs-remote--tap-org-task-event))
 
 (provide 'mcp-emacs-remote)
 ;;; mcp-emacs-remote.el ends here

--- a/elisp/mcp-emacs.el
+++ b/elisp/mcp-emacs.el
@@ -766,6 +766,30 @@ plain text for a missing/invalid path or a file with no task heading."
               (mapconcat #'identity lines "\n")))))
     (user-error (error-message-string err))))
 
+(defvar mcp-emacs-org-task-event-functions nil
+  "Abnormal hook run with (EVENT) after an org-task write succeeds.
+EVENT is a plist: `:kind' (`session-status' / `item-status' / `note' /
+`item-added'), `:path', and kind-specific keys.
+
+These are **observations, not commands**.  The Org file is the aggregate
+and owns this state (issue #39); an event says \"Org changed\", and
+nothing may reconstruct state by replaying the log.  The point is that
+the human's edits and the AI's writes land in one shared record, not
+that the record becomes a second source of truth.
+
+Only successful writes emit -- a rejected keyword or an item that could
+not be identified changed nothing, so there is nothing to observe.")
+
+(defun mcp-emacs-org-task--emit (kind path &rest props)
+  "Run `mcp-emacs-org-task-event-functions' for a KIND change to PATH.
+PROPS are extra plist keys.  Errors in a subscriber are swallowed: an
+observer must never break the write it is observing."
+  (let ((event (append (list :kind kind :path path) props)))
+    (condition-case err
+        (run-hook-with-args 'mcp-emacs-org-task-event-functions event)
+      (error (message "org-task event subscriber failed: %s"
+                      (error-message-string err))))))
+
 (defun mcp-emacs-org-task-set-session-status (path status)
   "Set the session STATUS (an Org keyword) of the task file at PATH.
 Reject a keyword not in `org-todo-keywords-1', leaving the status
@@ -782,6 +806,7 @@ unchanged.  Edits the live buffer only; does not save."
           (if (not (mcp-emacs-org-task--goto-task))
               "No task heading found in file"
             (org-todo status)
+            (mcp-emacs-org-task--emit 'session-status path :status status)
             (format "Set session status to %s" status))))
     (user-error (error-message-string err))))
 
@@ -801,6 +826,8 @@ item is touched.  Edits the live buffer only; does not save."
           (if (mcp-emacs-org-task--find-item ref)
               (progn
                 (org-todo status)
+                (mcp-emacs-org-task--emit 'item-status path
+                                          :ref ref :status status)
                 (format "Set item %S to %s" ref status))
             (format "TODO item not found: %s" ref))))
     (user-error (error-message-string err))))
@@ -829,6 +856,7 @@ does not save."
               (let ((inhibit-read-only t))
                 (unless (bolp) (insert "\n"))
                 (insert note "\n")))
+            (mcp-emacs-org-task--emit 'note path :text note)
             "Appended progress note")))
     (user-error (error-message-string err))))
 
@@ -859,6 +887,8 @@ content.  Edits the live buffer only; does not save."
                 (org-end-of-subtree t t)
                 (unless (bolp) (insert "\n"))
                 (insert (make-string (1+ task-level) ?*) " " kw " " text "\n")
+                (mcp-emacs-org-task--emit 'item-added path
+                                          :text text :status kw)
                 (format "Appended TODO item: %s %s" kw text))))))
     (user-error (error-message-string err))))
 

--- a/test/mcp-emacs-apply-diff-test.el
+++ b/test/mcp-emacs-apply-diff-test.el
@@ -289,3 +289,101 @@ and `control' is the fake control buffer."
   (check "async-missing-path-defers" calls nil)
   (sleep-for 2)
   (check "async-missing-path-answers" (length calls) 1))
+
+;;;; Org-task domain events (issue #39)
+;;
+;; The Org file is the aggregate; these events observe that it changed.  The
+;; contract that matters is "only on success": a rejected keyword or an
+;; unidentifiable item changes nothing, so there is nothing to observe.
+
+(require 'org)
+
+(defun mcp--org-fixture (text)
+  "Write TEXT to a temp .org file and return its path."
+  (let ((f (make-temp-file "mcp-orgtask-" nil ".org" text)))
+    f))
+
+(defmacro mcp--with-org-events (var &rest body)
+  "Run BODY collecting org-task events into VAR (oldest first)."
+  (declare (indent 1))
+  `(let* ((,var nil)
+          (mcp-emacs-org-task-event-functions
+           (list (lambda (e) (setq ,var (append ,var (list e)))))))
+     ,@body))
+
+;; A successful status change emits one observation carrying the new state.
+(let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
+  (unwind-protect
+      (mcp--with-org-events evs
+        (mcp-emacs-org-task-set-session-status f "DONE")
+        (check "emit-session-status-count" (length evs) 1)
+        (check "emit-session-status-kind" (plist-get (car evs) :kind) 'session-status)
+        (check "emit-session-status-value" (plist-get (car evs) :status) "DONE")
+        (check "emit-session-status-path" (plist-get (car evs) :path) f))
+    (let ((b (find-buffer-visiting f)))
+      (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
+    (delete-file f)))
+
+;; A rejected keyword changes nothing, so it must emit nothing.
+(let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
+  (unwind-protect
+      (mcp--with-org-events evs
+        (mcp-emacs-org-task-set-session-status f "NOT-A-KEYWORD")
+        (check "no-emit-on-rejected-keyword" evs nil))
+    (let ((b (find-buffer-visiting f)))
+      (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
+    (delete-file f)))
+
+;; An item that cannot be identified changes nothing either.
+(let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n** TODO one\n")))
+  (unwind-protect
+      (mcp--with-org-events evs
+        (mcp-emacs-org-task-set-item-status f "no such item" "DONE")
+        (check "no-emit-on-unknown-item" evs nil))
+    (let ((b (find-buffer-visiting f)))
+      (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
+    (delete-file f)))
+
+;; Appending an item observes the text and the keyword it was given.
+(let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
+  (unwind-protect
+      (mcp--with-org-events evs
+        (mcp-emacs-org-task-append-item f "a new item" "TODO")
+        (check "emit-item-added-kind" (plist-get (car evs) :kind) 'item-added)
+        (check "emit-item-added-text" (plist-get (car evs) :text) "a new item"))
+    (let ((b (find-buffer-visiting f)))
+      (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
+    (delete-file f)))
+
+;; A note observes its text.
+(let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
+  (unwind-protect
+      (mcp--with-org-events evs
+        (mcp-emacs-org-task-append-note f "progress note")
+        (check "emit-note-kind" (plist-get (car evs) :kind) 'note)
+        (check "emit-note-text" (plist-get (car evs) :text) "progress note"))
+    (let ((b (find-buffer-visiting f)))
+      (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
+    (delete-file f)))
+
+;; A failing subscriber must not break the Org write it observes -- the
+;; aggregate comes first, the record second.
+(let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
+  (unwind-protect
+      (let ((mcp-emacs-org-task-event-functions
+             (list (lambda (_e) (error "subscriber blew up")))))
+        ;; The write must return normally, not signal: the outer handler only
+        ;; catches `user-error', so an unguarded subscriber error escapes as a
+        ;; plain `error' and takes the tool call down with it.
+        (check "write-survives-bad-subscriber"
+               (condition-case _
+                   (progn (mcp-emacs-org-task-set-session-status f "DONE") t)
+                 (error nil))
+               t)
+        ;; And the Org file really did change.
+        (with-current-buffer (find-file-noselect f)
+          (check "write-applied-despite-subscriber"
+                 (and (string-match-p "DONE" (buffer-string)) t) t)))
+    (let ((b (find-buffer-visiting f)))
+      (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
+    (delete-file f)))

--- a/test/mcp-emacs-remote-test.el
+++ b/test/mcp-emacs-remote-test.el
@@ -272,3 +272,88 @@
            nil)))
 
 (remote--kill-transcripts)
+
+;; --- Org-task subscriber (issue #39) -----------------------------------------
+;;
+;; The Org file is the aggregate; these events only observe that it changed.
+;; They land in the same transcript as the runner's, so one record shows both
+;; the human's Org edits and the AI's activity in the order they happened.
+
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
+    (mcp-emacs-remote--tap-org-task-event
+     (list :kind 'session-status :path "/tmp/s.org" :status "STRT"))
+    (check "org-session-status-recorded"
+           (and (string-match-p "org session :: STRT" (remote--transcript-text)) t) t)))
+
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
+    (mcp-emacs-remote--tap-org-task-event
+     (list :kind 'item-status :path "/tmp/s.org" :ref "write tests" :status "DONE"))
+    (check "org-item-status-recorded"
+           (and (string-match-p "org item :: write tests" (remote--transcript-text)) t) t)))
+
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
+    (mcp-emacs-remote--tap-org-task-event
+     (list :kind 'item-added :path "/tmp/s.org" :text "new thing" :status "TODO"))
+    (check "org-item-added-recorded"
+           (and (string-match-p "org item added :: TODO new thing"
+                                (remote--transcript-text)) t) t)))
+
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
+    (mcp-emacs-remote--tap-org-task-event
+     (list :kind 'note :path "/tmp/s.org" :text "first line\nsecond"))
+    (check "org-note-first-line-only"
+           (and (string-match-p "org note :: first line" (remote--transcript-text))
+                (not (string-match-p "second" (remote--transcript-text))) t)
+           t)))
+
+;; Disabled -> silent, and no transcript buffer created.
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled nil))
+  (mcp-emacs-remote--tap-org-task-event
+   (list :kind 'session-status :path "/tmp/s.org" :status "STRT"))
+  (check "org-disabled-silent" (remote--transcript-text) nil))
+
+;; Unknown kinds are ignored rather than guessed at.
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
+    (mcp-emacs-remote--tap-org-task-event (list :kind 'brand-new :path "/tmp/s.org"))
+    (check "org-unknown-kind-ignored" (remote--transcript-text) nil)))
+
+;; A transcript failure must never break the Org write being observed.
+(remote--kill-transcripts)
+(let ((mcp-emacs-remote-enabled t))
+  (cl-letf (((symbol-function 'mcp-emacs-remote--append)
+             (lambda (&rest _) (error "boom"))))
+    (check "org-error-swallowed"
+           (condition-case _
+               (progn (mcp-emacs-remote--tap-org-task-event
+                       (list :kind 'note :path "/tmp/s.org" :text "x"))
+                      t)
+             (error nil))
+           t)))
+
+;; enable/disable manage the org-task hook too.
+(let ((mcp-emacs-org-task-event-functions nil)
+      (claude-client-event-functions nil))
+  (cl-letf (((symbol-function 'advice-add) #'ignore)
+            ((symbol-function 'advice-remove) #'ignore))
+    (mcp-emacs-remote-enable)
+    (check "org-enable-subscribes"
+           (and (memq #'mcp-emacs-remote--tap-org-task-event
+                      mcp-emacs-org-task-event-functions) t) t)
+    (mcp-emacs-remote-disable)
+    (check "org-disable-unsubscribes"
+           (memq #'mcp-emacs-remote--tap-org-task-event
+                 mcp-emacs-org-task-event-functions)
+           nil)))
+
+(remote--kill-transcripts)


### PR DESCRIPTION
Implements the decision recorded on #39: the Org file stays the aggregate, the log observes it.

The runner published its activity to a log the transcript subscribed to, but the human's side of the same workflow — editing the Org checklist — was invisible there. The four org-task writes now emit on `mcp-emacs-org-task-event-functions`, and the transcript subscribes, so one record shows both actors in the order things happened. Verified live:

```org
  - [13:18:34] org session :: STRT [scratch-demo.org]
  - [13:18:34] assistant   :: AI working
  - [13:18:34] org item    :: first item → DONE [scratch-demo.org]
  - [13:18:34] result      :: Status: applied
```

These are **observations, not commands**. The Org file owns this state; an event says "Org changed", and nothing reconstructs state by replaying the log. That is what keeps the shared record from becoming a second source of truth for the same checklist — and it is also why the log not surviving a restart is now a deliberate property rather than the gap the subsumption test called it.

Two contracts worth naming, both under test:

- **Only successful writes emit.** A rejected keyword or an item that could not be identified changed nothing, so there is nothing to observe.
- **A throwing subscriber cannot break the write.** Caught at the emit site, not left to the caller: the org-task functions' outer handler only catches `user-error`, so an unguarded observer error would escape as a plain `error` and take the tool call down with it. The aggregate comes first, the record second.

21 new tests, 417 across all suites, 0 fail. Mutation-checked — emitting on a failed lookup, and removing the subscriber guard, each fail the intended test. The second one initially did not: the guard test asserted `stringp` on the return value, which held even with the guard removed, so it was rewritten to assert the write does not signal.

One limitation found while testing live: the transcript is keyed by project root, so an Org file outside the current project records into a different transcript than the runner's events. The one-shared-record property holds per project, not globally.

No CI signal — Actions has not run for this repo since 2026-08-06 13:57. All 17 suites pass locally.
