### PR TITLE
Handle several notes arriving during one turn

### DIFF
--- a/elisp/claude-client.el
+++ b/elisp/claude-client.el
@@ -117,6 +117,20 @@ available either way for a deliberate stop."
   :type 'boolean
   :group 'claude-client)
 
+(defcustom claude-client-max-pending-notes 20
+  "How many undelivered notes to keep before dropping the oldest.
+Backpressure for the case where the human keeps writing while the model
+is slow or wedged.  Without a bound the queue grows until it is
+delivered as one enormous prompt, and the newest thought -- the one most
+likely to matter -- competes with everything stale in front of it.
+
+Dropping the oldest is the deliberate choice: the recent note is the
+current intent.  A drop is recorded in the log, so the record still
+shows that something was said and lost rather than quietly discarding
+it.  nil means keep everything."
+  :type '(choice (const :tag "Unbounded" nil) integer)
+  :group 'claude-client)
+
 (defcustom claude-client-window-direction 'right
   "Direction in which the conversation window is placed.
 An ordinary window in this direction, so it can be split, navigated and
@@ -406,8 +420,21 @@ delivered straight away either way."
         (running (and claude-client--turn-active t)))
     (when (string-empty-p note)
       (user-error "Empty note"))
-    (setq claude-client--pending-notes
-          (append claude-client--pending-notes (list note)))
+    ;; Coalesce an exact repeat: writing the same thing twice while the model
+    ;; has seen neither says nothing new, and sending it twice only spends
+    ;; context.  Anything genuinely different is kept, in order.
+    (unless (member note claude-client--pending-notes)
+      (setq claude-client--pending-notes
+            (append claude-client--pending-notes (list note))))
+    ;; Bound the queue: the newest note is the current intent, so when the
+    ;; model is too slow to drain them the oldest go.  Each drop is logged --
+    ;; the record should show that something was said and lost.
+    (when claude-client-max-pending-notes
+      (while (> (length claude-client--pending-notes)
+                claude-client-max-pending-notes)
+        (let ((dropped (pop claude-client--pending-notes)))
+          (claude-client--push-event
+           (current-buffer) (list :kind 'note-dropped :text dropped)))))
     (claude-client--push-event
      (current-buffer)
      (list :kind 'note :text note
@@ -418,7 +445,13 @@ delivered straight away either way."
      ;; Redirect now: abandon the turn.  The drain happens when `result'
      ;; arrives for the interrupted turn, which also marks the turn over --
      ;; draining here would race that and deliver into a dying turn.
+     ;;
+     ;; `claude-client--interrupted' also serves as the backpressure guard:
+     ;; a second note arriving before the abandoned turn has finished dying
+     ;; must not fire another interrupt.  The turn is already ending and the
+     ;; note is already queued, so it rides out on the same delivery.
      ((and running claude-client-note-interrupts
+           (not claude-client--interrupted)
            (process-live-p claude-client--process))
       (setq claude-client--interrupted t)
       (claude-client--push-event (current-buffer) (list :kind 'interrupted))
@@ -509,6 +542,7 @@ Returns the drained notes, oldest first, and clears the queue."
     ('finished (format "── %s ──" (or (plist-get event :subtype) "done")))
     ('resumed (format "── resumed %s ──" (plist-get event :session)))
     ('interrupted "── interrupted ──")
+    ('note-dropped (format "  (dropped unsent note: %s)" (plist-get event :text)))
     ('prompt (format "\n>>> %s" (plist-get event :text)))
     ('note (format "> %s%s"
                    (plist-get event :text)
@@ -580,6 +614,8 @@ instead when the point is to redirect rather than to stop."
     (user-error "No turn is running"))
   (unless (process-live-p claude-client--process)
     (user-error "No live Claude process"))
+  (when claude-client--interrupted
+    (user-error "This turn is already being interrupted"))
   (setq claude-client--interrupted t)
   (claude-client--push-event (current-buffer) (list :kind 'interrupted))
   (claude-client--send-interrupt claude-client--process))

--- a/test/claude-client-test.el
+++ b/test/claude-client-test.el
@@ -538,8 +538,8 @@ stays alive after `result', so process liveness cannot stand in for it."
         (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
                   ((symbol-function 'process-send-string)
                    (lambda (_p s) (setq sent s))))
-          (setq claude-client--process 'fake
-                claude-client-deliver-notes t)
+          (setq claude-client--process 'fake)
+          (setq-local claude-client-deliver-notes t)
           (claude-test--with-running-turn
            (claude-client-add-note "reconsider the approach"))
           (setq claude-client--turn-active t)
@@ -558,8 +558,8 @@ stays alive after `result', so process liveness cannot stand in for it."
         (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
                   ((symbol-function 'process-send-string)
                    (lambda (_p s) (setq sent s))))
-          (setq claude-client--process 'fake
-                claude-client-deliver-notes nil)
+          (setq claude-client--process 'fake)
+          (setq-local claude-client-deliver-notes nil)
           (let ((claude-client-note-interrupts nil))
             (claude-test--with-running-turn (claude-client-add-note "quiet note")))
           (setq claude-client--turn-active t)
@@ -807,10 +807,10 @@ stays alive after `result', so process liveness cannot stand in for it."
         (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
                   ((symbol-function 'process-send-string)
                    (lambda (_p s) (setq sent s))))
-          (setq claude-client--process 'fake
-                claude-client-note-interrupts t)
-          (claude-test--with-running-turn
-           (claude-client-add-note "stop, do the other thing"))
+          (setq claude-client--process 'fake)
+          (let ((claude-client-note-interrupts t))
+            (claude-test--with-running-turn
+             (claude-client-add-note "stop, do the other thing")))
           (check "note-interrupts-turn"
                  (and sent (string-match-p "interrupt" sent) t) t)
           (check "note-logs-interrupted"
@@ -829,9 +829,9 @@ stays alive after `result', so process liveness cannot stand in for it."
         (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
                   ((symbol-function 'process-send-string)
                    (lambda (_p s) (setq sent s))))
-          (setq claude-client--process 'fake
-                claude-client-note-interrupts nil)
-          (claude-test--with-running-turn (claude-client-add-note "later"))
+          (setq claude-client--process 'fake)
+          (let ((claude-client-note-interrupts nil))
+            (claude-test--with-running-turn (claude-client-add-note "later")))
           (check "no-interrupt-when-opted-out" sent nil)
           (check "opted-out-note-queues"
                  claude-client--pending-notes '("later"))))
@@ -846,10 +846,10 @@ stays alive after `result', so process liveness cannot stand in for it."
         (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
                   ((symbol-function 'process-send-string)
                    (lambda (_p s) (setq sent s))))
-          (setq claude-client--process 'fake
-                claude-client-note-interrupts t
-                claude-client-deliver-notes t)
-          (claude-test--with-running-turn (claude-client-add-note "change course"))
+          (setq claude-client--process 'fake)
+          (let ((claude-client-note-interrupts t)
+                (claude-client-deliver-notes t))
+            (claude-test--with-running-turn (claude-client-add-note "change course")))
           (setq sent nil)
           ;; The interrupted turn's result arrives; the note goes out now.
           (setq claude-client--turn-active t)
@@ -870,14 +870,117 @@ stays alive after `result', so process liveness cannot stand in for it."
         (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
                   ((symbol-function 'process-send-string)
                    (lambda (_p s) (setq sent s))))
-          (setq claude-client--process 'fake
-                claude-client-note-interrupts nil
-                claude-client-deliver-notes t)
-          (claude-test--with-running-turn (claude-client-add-note "fyi"))
+          (setq claude-client--process 'fake)
+          (let ((claude-client-note-interrupts nil)
+                (claude-client-deliver-notes t))
+            (claude-test--with-running-turn (claude-client-add-note "fyi")))
           (setq sent nil claude-client--turn-active t)
           (claude-test--feed buf (concat claude-test--result "\n"))
           (check "uninterrupted-has-no-replan-framing"
                  (and sent (string-match-p "Do not resume" sent)) nil)
           (check "uninterrupted-still-carries-note"
                  (and sent (string-match-p "fyi" sent) t) t)))
+    (kill-buffer buf)))
+
+;;;; Backpressure (issue #39)
+;;
+;; Several notes in quick succession while the model is slow.  Once a turn is
+;; being interrupted it is already ending, so further notes ride out on the
+;; same delivery rather than firing more interrupts into a dying turn.
+
+;; Two notes during one turn interrupt it once, and both are delivered.
+(let ((buf (claude-test--buffer))
+      (interrupts 0))
+  (unwind-protect
+      (with-current-buffer buf
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                  ((symbol-function 'process-send-string)
+                   (lambda (_p s)
+                     (when (string-match-p "interrupt" s)
+                       (setq interrupts (1+ interrupts))))))
+          (setq claude-client--process 'fake claude-client--turn-active t)
+          (claude-client-add-note "first")
+          (claude-client-add-note "second")
+          (check "one-interrupt-for-many-notes" interrupts 1)
+          (check "later-notes-still-queued"
+                 claude-client--pending-notes '("first" "second"))
+          (check "one-interrupted-event"
+                 (length (seq-filter
+                          (lambda (e) (eq (plist-get e :kind) 'interrupted))
+                          claude-client--events))
+                 1)))
+    (kill-buffer buf)))
+
+;; An exact repeat says nothing new, so it is coalesced rather than sent twice.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                  ((symbol-function 'process-send-string) (lambda (&rest _) nil)))
+          (setq claude-client--process 'fake claude-client--turn-active t)
+          (claude-client-add-note "same thing")
+          (claude-client-add-note "same thing")
+          (check "duplicate-note-coalesced"
+                 claude-client--pending-notes '("same thing"))
+          ;; Still logged twice: the human did write it twice.
+          (check "duplicate-still-recorded"
+                 (length (seq-filter (lambda (e) (eq (plist-get e :kind) 'note))
+                                     claude-client--events))
+                 2)))
+    (kill-buffer buf)))
+
+;; Explicitly interrupting a turn that is already being interrupted is
+;; refused rather than sending a second control request.
+(let ((buf (claude-test--buffer))
+      (interrupts 0))
+  (unwind-protect
+      (with-current-buffer buf
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                  ((symbol-function 'process-send-string)
+                   (lambda (_p s)
+                     (when (string-match-p "interrupt" s)
+                       (setq interrupts (1+ interrupts))))))
+          (setq claude-client--process 'fake claude-client--turn-active t)
+          (claude-client-interrupt)
+          (check "second-interrupt-refused"
+                 (condition-case _ (progn (claude-client-interrupt) nil)
+                   (user-error t))
+                 t)
+          (check "second-interrupt-not-sent" interrupts 1)))
+    (kill-buffer buf)))
+
+;; The queue is bounded: the newest note is the current intent, so the oldest
+;; are dropped when the model is too slow to drain them.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                  ((symbol-function 'process-send-string) (lambda (&rest _) nil)))
+          (setq claude-client--process 'fake claude-client--turn-active t)
+          (let ((claude-client-max-pending-notes 3))
+            (dolist (n '("n1" "n2" "n3" "n4" "n5"))
+              (claude-client-add-note n))
+            (check "queue-bounded" (length claude-client--pending-notes) 3)
+            (check "newest-kept"
+                   claude-client--pending-notes '("n3" "n4" "n5"))
+            ;; A drop is recorded, not silent.
+            (check "drops-logged"
+                   (mapcar (lambda (e) (plist-get e :text))
+                           (seq-filter
+                            (lambda (e) (eq (plist-get e :kind) 'note-dropped))
+                            claude-client--events))
+                   '("n1" "n2")))))
+    (kill-buffer buf)))
+
+;; nil means keep everything.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                  ((symbol-function 'process-send-string) (lambda (&rest _) nil)))
+          (setq claude-client--process 'fake claude-client--turn-active t)
+          (let ((claude-client-max-pending-notes nil))
+            (dolist (n '("a" "b" "c" "d")) (claude-client-add-note n))
+            (check "unbounded-keeps-all"
+                   (length claude-client--pending-notes) 4))))
     (kill-buffer buf)))


### PR DESCRIPTION
The last of #39's three open questions. Making a note interrupt (#53) exposed three ways rapid notes misbehaved — each found by probing the current behaviour rather than reading it:

- **A second note fired another interrupt** into a turn that was already dying, and logged a second `interrupted` event for one interruption. The interrupt flag now doubles as the backpressure guard: once a turn is being abandoned, later notes ride out on the same delivery. `claude-client-interrupt` refuses a second stop for the same reason.
- **An exact repeat queued twice** and was sent twice, spending context to say nothing new. Repeats are coalesced — though both are still recorded, because the human did write it twice.
- **The queue was unbounded.** A slow or wedged model meant notes piling up until they arrived as one enormous prompt, with the newest thought — the one most likely to matter — behind everything stale. `claude-client-max-pending-notes` bounds it at 20 and drops the oldest, because the recent note is the current intent. Drops are logged rather than silent, so the record still shows something was said and lost.

Verified live — three notes during one essay:

```
prompt started note interrupted note note text finished notes-delivered started text finished
```

One interrupt, the duplicate coalesced, two notes delivered, and the model answered the last of them.

11 new tests, 443 across all suites, 0 fail. Mutation-checked: removing the re-interrupt guard fails two tests, removing dedup fails one, removing the bound fails three.

Also scopes the defcustom mutations in the test file, which were global `setq` and leaked into every test that ran after them — that contamination made two of these new tests fail while the same case passed standalone, so it was the harness at fault rather than the code.

With this, #39's three open questions are all answered: interruption (#53), ordering (dissolved by the aggregate decision — Org is the single writer of record), and backpressure. What remains on the issue is the per-project transcript keying noted on #52.
