### PR TITLE
Let orgspec callers state which project they mean

### DIFF
--- a/elisp/orgspec-commands.el
+++ b/elisp/orgspec-commands.el
@@ -35,13 +35,70 @@
   "Directory (relative to the project root) holding specs and changes."
   :type 'string :group 'orgspec)
 
+(declare-function project-root "project" (project))
+
+(defvar orgspec-project-root nil
+  "Project root the orgspec commands act on, overriding project detection.
+Nil means resolve from ambient editor state -- `project-current', then
+`default-directory'.  Bind or set this when the caller knows the project
+and the current buffer is not in it: an agent driving the `orgspec_*' MCP
+tools has no control over which buffer the Emacs it is talking to happens
+to be visiting, so \"whatever `project-current' says\" is not an input it
+can supply.  Every orgspec path is derived from this, so one binding
+covers new/status/apply/archive alike.")
+
+(defun orgspec-commands--base ()
+  "Return the project directory the orgspec root lives under.
+`orgspec-project-root' wins when set; otherwise fall back to the ambient
+project, then `default-directory'."
+  (file-name-as-directory
+   (expand-file-name
+    (or orgspec-project-root
+        (and (fboundp 'project-current)
+             (when-let* ((p (project-current nil)))
+               (project-root p)))
+        default-directory))))
+
 (defun orgspec-commands--root ()
-  "Return the absolute orgspec root for the current project."
-  (let ((base (or (and (fboundp 'project-current)
-                       (when-let ((p (project-current nil)))
-                         (project-root p)))
-                  default-directory)))
-    (expand-file-name orgspec-root base)))
+  "Return the absolute orgspec root for the project being acted on."
+  (expand-file-name orgspec-root (orgspec-commands--base)))
+
+(defun orgspec-commands--guessed-project-p ()
+  "Return non-nil when the acted-on project was inferred, not stated.
+`orgspec-project-root' and a real `project-current' are both statements
+about which project is meant; falling through to `default-directory' is
+a guess, and a guess is what silently plants an `orgspec/' tree in an
+unrelated repository."
+  (not (or orgspec-project-root
+           (and (fboundp 'project-current) (project-current nil)))))
+
+(defun orgspec-commands--assert-initialised ()
+  "Signal a `user-error' unless it is safe to act on the resolved root.
+An existing `orgspec/' means the project already opted in, so anything
+goes.  Without one, only a *stated* project may create the tree: a root
+that came from `default-directory' alone is a guess, and creating a
+spec tree there is the silent-write bug this guards."
+  (let ((root (orgspec-commands--root)))
+    (when (and (not (file-directory-p root))
+               (orgspec-commands--guessed-project-p))
+      (user-error
+       (concat "Refusing to create %s: no project was stated and none was "
+               "detected, so this path is a guess from `default-directory'. "
+               "Set `orgspec-project-root' (or the `root' tool argument) "
+               "to the project you mean")
+       root))))
+
+(defun orgspec-commands--assert-exists ()
+  "Signal a `user-error' unless the resolved orgspec root exists.
+For commands that read or rewrite an established tree, where creating
+one would make no sense."
+  (let ((root (orgspec-commands--root)))
+    (unless (file-directory-p root)
+      (user-error
+       (concat "No orgspec root at %s. "
+               "Set `orgspec-project-root' if this is the wrong project, "
+               "or run `orgspec-init' to start using orgspec here")
+       root))))
 
 (defun orgspec-commands--changes-dir () (expand-file-name "changes" (orgspec-commands--root)))
 (defun orgspec-commands--specs-dir () (expand-file-name "specs" (orgspec-commands--root)))
@@ -65,10 +122,29 @@
 ")
 
 ;;;###autoload
+(defun orgspec-init ()
+  "Create the orgspec root for the project being acted on.
+The one command that may bring `orgspec/' into existence, so that every
+other command can refuse a root that is not there rather than silently
+creating one in whichever project happened to be resolved.  Returns the
+root; harmless if it already exists."
+  (interactive)
+  (let ((root (orgspec-commands--root)))
+    (make-directory (expand-file-name "changes" root) t)
+    (make-directory (expand-file-name "specs" root) t)
+    (when (called-interactively-p 'interactive)
+      (message "orgspec root: %s" root))
+    root))
+
+;;;###autoload
 (defun orgspec-new (id)
   "Scaffold a new change ID under the orgspec changes directory.
-Creates changes/ID/change.org from the template.  Returns the file path."
+Creates changes/ID/change.org from the template.  Returns the file path.
+Brings the orgspec root into existence when the project is a stated one,
+but refuses to create a tree at a path merely guessed from
+`default-directory' -- see `orgspec-commands--assert-initialised'."
   (interactive "sChange id: ")
+  (orgspec-commands--assert-initialised)
   (let ((file (orgspec-commands--change-file id)))
     (when (file-exists-p file)
       (user-error "Change %s already exists" id))
@@ -143,6 +219,7 @@ whole set returned without writing anything, so callers can write it
 atomically (`orgspec-archive') or diff it before writing
 (`orgspec-review-fold').  Signals if the change has no delta
 requirements.  Order matches the change's area grouping."
+  (orgspec-commands--assert-exists)
   (orgspec-commands--assert-no-clarifications id)
   (let* ((change (orgspec-commands--read-change id))
          (reqs (orgspec-change-requirements change))

--- a/elisp/orgspec-mcp.el
+++ b/elisp/orgspec-mcp.el
@@ -98,17 +98,43 @@
          (file (orgspec-commands--change-file id)))
     (format "%s -> %s" name (orgspec-lifecycle-advance file name role))))
 
-(defun orgspec-mcp--agenda (_args)
+(defun orgspec-mcp--agenda (&optional _args)
   (orgspec-agenda-install (orgspec-commands--changes-dir))
   (format "registered agenda command under key %S" orgspec-agenda-key))
 
-;;;; Tool descriptors
+;;;; Project routing
+;;
+;; A caller reaching these tools over HTTP cannot see, let alone choose,
+;; which buffer the target Emacs is visiting, so leaving the project to
+;; `project-current' makes the acted-on repository unspecifiable from the
+;; caller's side.  Every tool therefore accepts an optional `root'.
+
+(defconst orgspec-mcp--root-description
+  "Absolute path of the project to act on. Omit to use the Emacs session's current project."
+  "Shared description for the `root' argument of every orgspec tool.")
+
+(defun orgspec-mcp--with-root (handler)
+  "Return HANDLER wrapped to honour the `root' argument in its args alist.
+Binds `orgspec-project-root', so every orgspec path the handler resolves
+belongs to the requested project rather than to whichever buffer the
+Emacs session happens to be in."
+  (lambda (args)
+    (let ((orgspec-project-root (or (alist-get 'root args)
+                                    orgspec-project-root)))
+      (funcall handler args))))
+
+(defun orgspec-mcp--root-prop ()
+  "Return the `root' property pair for a tool schema."
+  (list "root" (mcp-emacs-server--prop
+                "string" orgspec-mcp--root-description)))
 
 (defun orgspec-mcp--id-schema (desc)
   (mcp-emacs-server--obj
    "type" "object"
-   "properties" (mcp-emacs-server--obj
-                 "id" (mcp-emacs-server--prop "string" desc))
+   "properties" (apply #'mcp-emacs-server--obj
+                       (append
+                        (list "id" (mcp-emacs-server--prop "string" desc))
+                        (orgspec-mcp--root-prop)))
    "required" (vector "id")))
 
 (defconst orgspec-mcp--tools
@@ -121,9 +147,11 @@
          :description "Report task-checkbox completion for one change or all active changes"
          :schema (mcp-emacs-server--obj
                   "type" "object"
-                  "properties" (mcp-emacs-server--obj
-                                "id" (mcp-emacs-server--prop
-                                      "string" "Change id, or omit for all active changes")))
+                  "properties" (apply #'mcp-emacs-server--obj
+                                      (append
+                                       (list "id" (mcp-emacs-server--prop
+                                                   "string" "Change id, or omit for all active changes"))
+                                       (orgspec-mcp--root-prop))))
          :handler #'orgspec-mcp--status)
    (list :name "orgspec_parse"
          :description "Read a change's delta as structured data (per-requirement op/area/scenarios)"
@@ -145,30 +173,54 @@
          :description "Set a delta requirement's lifecycle TODO keyword (active/blocked/removed/done)"
          :schema (mcp-emacs-server--obj
                   "type" "object"
-                  "properties" (mcp-emacs-server--obj
-                                "id" (mcp-emacs-server--prop "string" "Change id")
-                                "requirement" (mcp-emacs-server--prop
-                                               "string" "Exact requirement headline text")
-                                "role" (mcp-emacs-server--obj
-                                        "type" "string"
-                                        "description" "Lifecycle role"
-                                        "enum" (vector "active" "blocked" "removed" "done")))
+                  "properties" (apply #'mcp-emacs-server--obj
+                                      (append
+                                       (list "id" (mcp-emacs-server--prop "string" "Change id")
+                                             "requirement" (mcp-emacs-server--prop
+                                                            "string" "Exact requirement headline text")
+                                             "role" (mcp-emacs-server--obj
+                                                     "type" "string"
+                                                     "description" "Lifecycle role"
+                                                     "enum" (vector "active" "blocked" "removed" "done")))
+                                       (orgspec-mcp--root-prop)))
                   "required" (vector "id" "requirement" "role"))
          :handler #'orgspec-mcp--advance)
    (list :name "orgspec_agenda"
          :description "Register the orgspec in-flight-requirements agenda custom command"
-         :schema (mcp-emacs-server--no-args)
+         :schema (mcp-emacs-server--obj
+                  "type" "object"
+                  "properties" (apply #'mcp-emacs-server--obj
+                                      (orgspec-mcp--root-prop)))
          :handler #'orgspec-mcp--agenda))
   "orgspec MCP tool descriptors, registered onto the server's extra-tools.")
 
 ;;;; Registration
+
+(defun orgspec-mcp--routed-tools ()
+  "Return `orgspec-mcp--tools' with every handler wrapped for `root'.
+Wrapping once here, rather than in each handler, keeps the routing off
+the handlers and applies to any tool added later."
+  (mapcar (lambda (tl)
+            (let ((copy (copy-sequence tl)))
+              (plist-put copy :handler
+                         (orgspec-mcp--with-root (plist-get tl :handler)))))
+          orgspec-mcp--tools))
+
+(defun orgspec-mcp-call (name args)
+  "Invoke orgspec tool NAME with ARGS through its registered handler.
+Goes via `orgspec-mcp--routed-tools', so `root' routing applies exactly
+as it does for a request arriving at the server."
+  (let ((tool (seq-find (lambda (tl) (equal (plist-get tl :name) name))
+                        (orgspec-mcp--routed-tools))))
+    (unless tool (error "No orgspec tool named %s" name))
+    (funcall (plist-get tool :handler) args)))
 
 (defun orgspec-mcp-register ()
   "Register the orgspec tools onto `mcp-emacs-server-extra-tools'.
 Idempotent: replaces any previously registered orgspec descriptors."
   (let ((names (mapcar (lambda (tl) (plist-get tl :name)) orgspec-mcp--tools)))
     (setq mcp-emacs-server-extra-tools
-          (append orgspec-mcp--tools
+          (append (orgspec-mcp--routed-tools)
                   (seq-remove (lambda (tl) (member (plist-get tl :name) names))
                               mcp-emacs-server-extra-tools)))))
 

--- a/test/orgspec-mcp-test.el
+++ b/test/orgspec-mcp-test.el
@@ -30,7 +30,9 @@
        (orgspec-root "orgspec")
        (org-todo-keywords '((sequence "TODO" "STRT" "WAIT" "|" "DONE" "KILL"))))
   (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
-    (orgspec-mcp--new '((id . "add-auth")))
+    ;; No ambient project here, so the tool is told which one to act on --
+    ;; the routing an agent over HTTP has to use anyway.
+    (orgspec-mcp-call "orgspec_new" `((id . "add-auth") (root . ,root)))
     (let ((f (orgspec-commands--change-file "add-auth")))
       (check "new-created" (file-exists-p f) t)
       (with-temp-file f
@@ -46,3 +48,59 @@
            (orgspec-mcp--advance
             '((id . "add-auth") (requirement . "Login required") (role . "active")))
            (format "Login required -> %s" orgspec-todo-active))))
+
+;;;; Project routing (issue #57)
+
+;; Every tool advertises the optional `root' argument, so a caller over
+;; HTTP can name the project instead of inheriting the session's buffer.
+(check "root-in-every-schema"
+       (seq-every-p
+        (lambda (tl)
+          (let ((props (alist-get "properties" (plist-get tl :schema) nil nil #'equal)))
+            (and props (assoc "root" props) t)))
+        mcp-emacs-server-extra-tools)
+       t)
+
+;; `root' wins over the ambient project: the write lands in the stated
+;; project, not in the one `default-directory' would have chosen.
+(let* ((stated (make-temp-file "orgspec-stated-" t))
+       (ambient (make-temp-file "orgspec-ambient-" t))
+       (default-directory (file-name-as-directory ambient))
+       (orgspec-root "orgspec"))
+  (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
+    (orgspec-mcp-call "orgspec_new" `((id . "routed") (root . ,stated)))
+    (check "root-routes-write"
+           (file-exists-p (expand-file-name "orgspec/changes/routed/change.org" stated))
+           t)
+    (check "root-spares-ambient"
+           (file-exists-p (expand-file-name "orgspec/changes/routed/change.org" ambient))
+           nil)))
+
+;; With no project stated and none detectable, the root is a guess from
+;; `default-directory' -- creating a tree there is the bug, so refuse.
+(let* ((elsewhere (make-temp-file "orgspec-guess-" t))
+       (default-directory (file-name-as-directory elsewhere))
+       (orgspec-root "orgspec")
+       (orgspec-project-root nil))
+  (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
+    (check "guessed-root-refused"
+           (condition-case err
+               (progn (orgspec-mcp-call "orgspec_new" '((id . "nope"))) :created)
+             (user-error (and (string-match-p "guess" (error-message-string err))
+                              :refused)))
+           :refused)
+    (check "guessed-root-writes-nothing"
+           (file-directory-p (expand-file-name "orgspec" elsewhere)) nil)))
+
+;; An existing tree is opt-in enough: no root needed to keep working in it.
+(let* ((initialised (make-temp-file "orgspec-existing-" t))
+       (default-directory (file-name-as-directory initialised))
+       (orgspec-root "orgspec")
+       (orgspec-project-root nil))
+  (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
+    (make-directory (expand-file-name "orgspec/changes" initialised) t)
+    (check "existing-tree-needs-no-root"
+           (progn (orgspec-mcp-call "orgspec_new" '((id . "ok")))
+                  (file-exists-p
+                   (expand-file-name "orgspec/changes/ok/change.org" initialised)))
+           t)))


### PR DESCRIPTION
Fixes #57.

## The problem

Every orgspec path was derived from `orgspec-commands--root`, which read the project out of ambient editor state with no way to pass one in. Running `/orgspec:propose` for an mcp-emacs change, from a session whose working directory was `~/git/gbastkowski/dotfiles`, scaffolded the change into **dotfiles** — creating an `orgspec/` tree from scratch in a repo that has never used orgspec, without complaint.

The MCP tools are the sharp end. A caller reaching `orgspec_*` over HTTP cannot see, let alone choose, which buffer the target Emacs is visiting, so "whatever `project-current` says right now" is not an input it can supply. `orgspec_archive` writes `specs/` and `git mv`s the change directory.

## What this changes

**1. The project can be stated.** New `orgspec-project-root` variable, honoured by the resolver. Since every path helper goes through it, one binding covers new/status/parse/validate/archive/review/advance/agenda alike — no signature churn.

**2. Every MCP tool takes an optional `root`.** Wired by wrapping each handler at registration rather than inside the handlers, so the routing lives in one place and applies to any tool added later. `orgspec-mcp-call` invokes a tool through that same wrapper, which is what the new tests use.

**3. A guessed root no longer creates a tree.** This is the part that turned a wrong guess into a silent write. The distinction drawn is *stated vs. guessed*:

| Situation | Behaviour |
|---|---|
| `orgspec/` already exists | anything goes — the project opted in |
| project stated (`orgspec-project-root` / `root`) or a real `project-current` | may create the tree |
| neither: root came from `default-directory` alone | **refused**, with a message naming the fix |

So first-time use in a real project still just works, and `orgspec-init` makes the opt-in explicit when you want it. `orgspec-archive`, which rewrites specs, requires a tree that already exists.

## Note on one existing test

`orgspec-mcp-test.el` drove `orgspec_new` in a temp directory with `project-current` stubbed to nil — a "guess" under the new rule, so it started failing. That was a fair signal rather than a stale test: it is exactly what a first-time user does. Rather than weaken the guard I had it state its project via the `root` argument, which is the routing an agent has to use anyway. Worth a look in review, since it is the one behavioural change to an existing caller.

## Verification

- Whole repo: 18 suites, **531 pass, 0 fail**, all exit 0.
- `orgspec-mcp` suite 9 → 15 tests. New coverage: `root` present in every schema; `root` routing writes to the stated project and leaves the ambient one untouched; a guessed root is refused *and* writes nothing; an existing tree needs no `root`.
- Byte-compiles with no new warnings.
- Checked against the original failure in a live Emacs: routing resolves to whichever of dotfiles/mcp-emacs is named, and a project-less guess is refused with the message above.