### PR TITLE
Give the session overview an ordinary window, and keep it alive

### DIFF
--- a/elisp/agent-session-overview.el
+++ b/elisp/agent-session-overview.el
@@ -64,6 +64,9 @@
   :type 'string
   :group 'agent-session-overview)
 
+(defconst agent-session-overview--help-buffer-name "*ai-sessions help*"
+  "Name of the buffer `agent-session-overview-help' writes to.")
+
 (defconst agent-session-overview--backends
   '((claude-client
      :label "claude"
@@ -294,11 +297,42 @@ which is what fits in a mode line."
              agent-session-overview--help
              "  "))
 
+(defun agent-session-overview--display-help (buffer _alist)
+  "Display help BUFFER in a plain window split from the overview.
+Returns the new window, as a `display-buffer' action function must.
+
+This exists so that `q' in the help window returns to the session list
+instead of taking the list with it.  Under a popup-managing framework --
+Doom's `+popup' -- both this buffer and the overview match popup rules,
+`with-help-window' selects the help window, and `q' there is
+`+popup/quit-window', which tears down the popup stack rather than just
+the selected window: reading the help would dismiss the overview it
+describes.  A window split off the overview's own window is an ordinary
+window, so `q' is the plain `quit-window' and only the help closes.
+
+The split comes from the overview's window when it is on screen, so the
+help is shown beside the list rather than replacing it; with no such
+window, the selected one is split instead."
+  (let* ((base (or (get-buffer-window agent-session-overview-buffer-name)
+                   (selected-window)))
+         (window (split-window base nil 'below)))
+    (set-window-buffer window buffer)
+    window))
+
 (defun agent-session-overview-help ()
-  "Describe what you can do from the overview."
+  "Describe what you can do from the overview.
+`q' in the help window returns to the session list; see
+`agent-session-overview--display-help' for why that needs arranging."
   (interactive)
-  (let ((entries agent-session-overview--help))
-    (with-help-window "*ai-sessions help*"
+  (let* ((entries agent-session-overview--help)
+         ;; Prepended to a local copy so this placement outranks any user
+         ;; or framework rule, the same tactic as
+         ;; `mcp-emacs-run--display-popup'.
+         (display-buffer-alist
+          (cons `(,(regexp-quote agent-session-overview--help-buffer-name)
+                  (agent-session-overview--display-help))
+                display-buffer-alist)))
+    (with-help-window agent-session-overview--help-buffer-name
       (princ "AI session overview\n\n")
       (princ "Every live AI session, across all backends, in one list.\n\n")
       (dolist (binding entries)
@@ -308,7 +342,10 @@ which is what fits in a mode line."
       (princ "  eat       live / dead -- a terminal, with no turn events\n")
       (princ "  opencode  live / dead -- publishes no turn-end event\n")
       (princ "\nWorking/idle is never guessed from output activity: that would\n")
-      (princ "read a long model think as idle and a spinner as work.\n"))))
+      (princ "read a long model think as idle and a spinner as work.\n"))
+    (when-let* ((window (get-buffer-window
+                         agent-session-overview--help-buffer-name)))
+      (fit-window-to-buffer window))))
 
 (defvar agent-session-overview-mode-map
   (let ((map (make-sparse-keymap)))

--- a/test/agent-session-overview-test.el
+++ b/test/agent-session-overview-test.el
@@ -262,6 +262,54 @@ which is what the compiled and uncompiled paths both read."
            (and (string-match-p "live / dead" text) t) t)))
 (kill-buffer "*ai-sessions help*")
 
+;; Issue #59: reading the help used to dismiss the overview behind it,
+;; because both buffers matched a popup rule and `q' in the help was
+;; Doom's `+popup/quit-window', which tears down the whole popup stack
+;; rather than the selected window.  The fix forces the help into an
+;; ordinary window split off the overview's own, so `q' is the plain
+;; `quit-window' and only the help closes.
+;;
+;; The bug needs a popup-managing framework to reproduce, and neither
+;; `+popup' nor its `q' binding exists in batch -- with stock window
+;; handling `with-help-window' already splits plainly, so asserting on
+;; the resulting window would pass against the unfixed code and prove
+;; nothing.  What the fix actually adds is *precedence*: its placement
+;; must beat a matching `display-buffer-alist' entry, since that is how
+;; the framework imposes a side window.  So stand in for the framework
+;; with a rule that would force one, and require it to lose.
+(let ((overview (get-buffer-create agent-session-overview-buffer-name)))
+  (unwind-protect
+      (let ((display-buffer-alist
+             `((,(regexp-quote agent-session-overview--help-buffer-name)
+                (display-buffer-in-side-window)
+                (side . bottom)))))
+        (delete-other-windows)
+        (switch-to-buffer overview)
+        (let ((overview-window (selected-window)))
+          (agent-session-overview-help)
+          (let ((help-window (get-buffer-window
+                              agent-session-overview--help-buffer-name)))
+            (check "help gets its own window"
+                   (and (window-live-p help-window) t) t)
+            ;; The assertion that fails without the fix: a side window is
+            ;; the popup failure mode, and a plain split is what keeps `q'
+            ;; from taking the overview with it.
+            (check "help placement beats a side-window rule"
+                   (window-parameter help-window 'window-side) nil)
+            (check "help is split from the overview, not replacing it"
+                   (and (window-live-p overview-window)
+                        (eq (window-buffer overview-window) overview))
+                   t)
+            ;; The point of the issue: closing the help returns you to the
+            ;; list instead of taking it down too.
+            (quit-window nil help-window)
+            (check "quitting the help keeps the overview"
+                   (and (window-live-p (get-buffer-window overview)) t) t))))
+    (when (get-buffer agent-session-overview--help-buffer-name)
+      (kill-buffer agent-session-overview--help-buffer-name))
+    (kill-buffer overview)
+    (delete-other-windows)))
+
 ;; The column headers keep the header-line, since only tabulated-list
 ;; aligns them with the data; the hint lives in the mode line and must
 ;; actually render there.


### PR DESCRIPTION
Two window bugs in `*ai-sessions*`, one of which causes the other.

**#60 — the overview was a popup.** It ended in a bare `pop-to-buffer`, so Doom's popup rules captured it into the transient bottom window: unsplittable, and dismissable by an unrelated `q`. It now opens as an ordinary window in `agent-session-overview-window-direction` (default `right`), mirroring `claude-client-window-direction` and `mcp-emacs-run-window-direction`.

**#59 — reading the help closed the list.** `?` used `with-help-window`, which selects the help window, where Doom's `q` is `+popup/quit-window` — that tears down the popup stack rather than the selected window, taking the overview with it. The help is now split off the overview's own window.

Both fixes prepend their placement to a local `display-buffer-alist` instead of passing it as the ACTION argument, because the alist takes priority *over* ACTION — verified directly: the action-arg form still lands in a side window under a matching rule, prepending does not. Worth noting that `claude-client--display` and `mcp-emacs-run--display` both use the weaker form and share this latent weakness; left alone here.

The popup framework doesn't exist in batch, where stock `display-buffer` already behaves, so each test supplies the side-window rule the framework would install and requires the fix to beat it. The #60 test drives the command rather than the placement helper — the bug was in the call site, and a helper-level test passes with that line reverted.

Closes #59
Closes #60