### PR TITLE
Bound tool results to a few lines

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -91,7 +91,7 @@ and its context carry across turns.
 - `M-x claude-client-list` / `-switch` / `-toggle` / `-quit` — manage conversations.
 
 In the conversation buffer: `s` send, `i` interrupt, `n` add note, `r` resume,
-`g` start, `k` quit.
+`g` start, `k` quit, `TAB` expand the tool result under point.
 
 **Appearance.** The buffer separates what the harness did from what the model
 said. Structural chrome — the session banner, prompts, tool calls and their
@@ -106,6 +106,16 @@ copied in, so no markdown mode is ever active in the conversation buffer and
 its single-letter keys keep working. `markdown-mode` is a soft dependency:
 without it prose renders as plain text and the chrome faces still apply.
 
+Tool results are bounded to `claude-client-tool-result-lines` (default 6),
+because a `git diff` or a whole-file `Read` otherwise dumps its entire payload
+and buries the prose — which defeats facing the two separately. Tool *input*
+has always been bounded the same way, to one 60-column line. The elision says
+how many lines it hid, and `TAB` on the result shows it in full (`TAB` again
+re-collapses); nothing is discarded, since the full text stays in the event log.
+Lines that are a bare field label with no value — the dozen `labels:` /
+`assignees:` rows `gh issue view` answers with — are dropped outright. Set the
+option to `nil` to show every line.
+
 **Notes.** A note written mid-turn abandons that turn immediately and is
 delivered as the next one (`claude-client-note-interrupts`, on by default); with
 it off, notes queue instead. `claude-client-max-pending-notes` (default 20)
@@ -114,7 +124,8 @@ bounds the queue, dropping oldest first.
 Key options: `claude-client-executable`, `-model`, `-mcp-config`,
 `-disallowed-tools`, `-allowed-mcp-tools`, `-system-prompt`,
 `-window-direction` (default `right`), `-window-width` / `-height`,
-`-focus-on-show`, `-restore-window-after-review`.
+`-focus-on-show`, `-restore-window-after-review`,
+`-tool-result-lines` (default 6).
 
 ## opencode client
 

--- a/elisp/claude-client.el
+++ b/elisp/claude-client.el
@@ -156,6 +156,26 @@ it.  nil means keep everything."
   :type '(choice (const :tag "Unbounded" nil) integer)
   :group 'claude-client)
 
+(defcustom claude-client-tool-result-lines 6
+  "How many lines of a tool result to show before eliding the rest.
+A `git diff' or a whole-file `Read' otherwise dumps its entire payload
+into the conversation and buries the model's prose, which defeats facing
+chrome separately from prose (issue #61).  Tool *input* has always been
+bounded to one 60-column line by `claude-client--tool-input-summary';
+this is the same bound for the answer.
+
+Six is enough for a status line plus context, or the head of a diff.
+The elided lines are not lost: the full text stays in
+`claude-client--events', the elision says how many were dropped, and
+TAB (`claude-client-toggle-tool-result') on the result shows it in full.
+nil means show everything.
+
+This bounds *display* only.  Truncating to a single line was tried
+before and reverted -- it hid the answer -- so the floor here is a few
+lines with a way to see the rest, not one line."
+  :type '(choice (const :tag "Unbounded" nil) integer)
+  :group 'claude-client)
+
 (defcustom claude-client-window-direction 'right
   "Direction in which the conversation window is placed.
 An ordinary window in this direction, so it can be split, navigated and
@@ -220,6 +240,17 @@ tools first and then report that it cannot edit."
   "Parsed conversation events, oldest first.
 Each is a plist: :kind, plus kind-specific keys.  This is the render
 model, and the append-only log issue #39 wants to subscribe to.")
+
+(defvar-local claude-client--expanded-results nil
+  "Indices into `claude-client--events' whose tool result is shown in full.
+Expansion is display state, not part of the log, so it is kept beside the
+events rather than written into them -- issue #39 wants that log to stay
+an append-only record of what happened.
+
+Keyed by index because events carry no identity of their own, and the
+list is append-only: an index stays valid as long as the log it indexes
+does.  Starting a fresh conversation discards the log, so this is
+cleared alongside it in `claude-client-start'.")
 
 (defvar-local claude-client--session-id nil
   "Claude session id, from the `system'/`init' event.")
@@ -781,11 +812,61 @@ input, so a call reads as \"[tool: apply_diff] /tmp/x\"."
             (unless (string-empty-p line)
               (truncate-string-to-width line 60 nil nil "…"))))))))
 
-(defun claude-client--render-event (event)
+(defconst claude-client--empty-field-regexp
+  "\\`[ \t]*[a-z_][a-z0-9_ -]*:[ \t]*\\'"
+  "A line that is a field label with no value, e.g. \"labels:\".
+`gh issue view' answers with a dozen of these; they are pure noise in
+the conversation.  Deliberately narrow -- lowercase label, nothing after
+the colon -- so it cannot eat a real line of prose or code.")
+
+(defun claude-client--tool-result-lines (text)
+  "Return TEXT's lines, dropping ones that are an empty field label.
+See `claude-client--empty-field-regexp' (issue #61)."
+  (seq-remove (lambda (l)
+                (string-match-p claude-client--empty-field-regexp l))
+              (split-string text "\n")))
+
+(defun claude-client--render-tool-result (event index)
+  "Return the display string for tool-result EVENT at INDEX, or nil.
+Bounded to `claude-client-tool-result-lines' unless INDEX is in
+`claude-client--expanded-results' -- see that custom for why.  The
+elision line carries INDEX as a `claude-client-result' text property, so
+`claude-client-toggle-tool-result' can tell which result point is on
+without re-deriving positions."
+  (let ((text (string-trim (or (plist-get event :text) ""))))
+    (unless (string-empty-p text)
+      (let* ((lines (claude-client--tool-result-lines text))
+             (limit claude-client-tool-result-lines)
+             (expanded (memq index claude-client--expanded-results))
+             (elided (and limit (not expanded)
+                          (> (length lines) limit)))
+             (shown (if elided (seq-take lines limit) lines))
+             (body (claude-client--faced
+                    (mapconcat (lambda (l) (concat "  → " l)) shown "\n")
+                    'claude-client-tool-result-face)))
+        (if (not shown)
+            ;; Every line was an empty field label: nothing worth a row.
+            nil
+          (concat
+           body
+           (when elided
+             (concat
+              "\n"
+              (claude-client--faced
+               (format "  → … %d more line%s (TAB to expand)"
+                       (- (length lines) limit)
+                       (if (= 1 (- (length lines) limit)) "" "s"))
+               'claude-client-pending-face)))))))))
+
+(defun claude-client--render-event (event &optional index)
   "Return a display string for EVENT, or nil to skip it.
 Structural chrome carries its own face; the model's prose is fontified
 as markdown.  The plain text is kept stable -- callers and tests match
-on it -- so this only adds properties."
+on it -- so this only adds properties.
+
+INDEX is EVENT's position in `claude-client--events', needed only by
+tool results to track expansion; it is optional so that callers and
+tests can render a lone event."
   (pcase (plist-get event :kind)
     ('started
      (claude-client--faced
@@ -799,14 +880,7 @@ on it -- so this only adds properties."
              (when-let* ((input (claude-client--tool-input-summary event)))
                (claude-client--faced (concat " " input)
                                      'claude-client-tool-input-face))))
-    ('tool-result
-     (let ((text (string-trim (or (plist-get event :text) ""))))
-       (unless (string-empty-p text)
-         (claude-client--faced
-          (mapconcat (lambda (l) (concat "  → " l))
-                     (split-string text "\n")
-                     "\n")
-          'claude-client-tool-result-face))))
+    ('tool-result (claude-client--render-tool-result event index))
     ('finished
      (claude-client--faced
       (format "── %s ──" (or (plist-get event :subtype) "done"))
@@ -854,15 +928,56 @@ on it -- so this only adds properties."
     (_ nil)))
 
 (defun claude-client--render ()
-  "Re-render this buffer's event log."
+  "Re-render this buffer's event log.
+Each tool result's rows carry a `claude-client-result' property holding
+its event index, so `claude-client-toggle-tool-result' can act on the
+result under point."
   (let ((at-end (eobp))
-        (inhibit-read-only t))
+        (inhibit-read-only t)
+        (index -1))
     (erase-buffer)
     (dolist (event claude-client--events)
-      (when-let ((s (claude-client--render-event event)))
-        (insert s)
-        (unless (string-suffix-p "\n" s) (insert "\n"))))
+      (setq index (1+ index))
+      (when-let* ((s (claude-client--render-event event index)))
+        (let ((start (point)))
+          (insert s)
+          (unless (string-suffix-p "\n" s) (insert "\n"))
+          (when (eq (plist-get event :kind) 'tool-result)
+            (put-text-property start (point) 'claude-client-result index)))))
     (when at-end (goto-char (point-max)))))
+
+(defun claude-client--result-at-point ()
+  "Return the event index of the tool result at point, or nil.
+Also looks at the position before point, so the command still works with
+point at end of line -- where `char-after' is the newline past the
+property."
+  (or (get-text-property (point) 'claude-client-result)
+      (and (> (point) (point-min))
+           (get-text-property (1- (point)) 'claude-client-result))))
+
+;;;###autoload
+(defun claude-client-toggle-tool-result ()
+  "Show the tool result at point in full, or re-collapse it.
+Results are bounded to `claude-client-tool-result-lines' so a large
+payload cannot bury the model's prose; this reaches the rest.  The full
+text was never discarded -- it is in `claude-client--events' -- so this
+only flips display state and re-renders.
+
+Point is restored by line rather than by character offset: expanding
+rewrites the whole buffer, so the old position would otherwise land
+somewhere unrelated."
+  (interactive)
+  (let ((index (claude-client--result-at-point)))
+    (unless index
+      (user-error "No tool result at point"))
+    (let ((line (line-number-at-pos)))
+      (setq claude-client--expanded-results
+            (if (memq index claude-client--expanded-results)
+                (delq index claude-client--expanded-results)
+              (cons index claude-client--expanded-results)))
+      (claude-client--render)
+      (goto-char (point-min))
+      (forward-line (1- line)))))
 
 ;;;; Turns
 
@@ -985,7 +1100,10 @@ file change opens an ediff for the human to accept or reject."
       (setq claude-client--events nil
             claude-client--stdout ""
             claude-client--session-id nil
-            claude-client--interrupted nil)
+            claude-client--interrupted nil
+            ;; Indices into the log that was just discarded would
+            ;; otherwise expand unrelated results in the new one.
+            claude-client--expanded-results nil)
       (let ((text (claude-client--prompt-with-notes prompt))
             (proc (make-process
                    :name "claude-client"
@@ -1212,6 +1330,7 @@ turn to end)."
     (define-key map (kbd "s") #'claude-client-send)
     (define-key map (kbd "r") #'claude-client-resume)
     (define-key map (kbd "i") #'claude-client-interrupt)
+    (define-key map (kbd "TAB") #'claude-client-toggle-tool-result)
     map)
   "Keymap for `claude-client-mode'.
 The single-letter keys are only reachable in plain Emacs; under evil they
@@ -1225,7 +1344,10 @@ re-registers them.  The evil-safe `C-c'-prefixed vocabulary lives in
     ("n" . claude-client-add-note)
     ("s" . claude-client-send)
     ("r" . claude-client-resume)
-    ("i" . claude-client-interrupt))
+    ("i" . claude-client-interrupt)
+    ;; Not single-letter, but evil's motion state does claim TAB
+    ;; (`evil-jump-forward'), so it needs re-registering the same way.
+    ("TAB" . claude-client-toggle-tool-result))
   "The single-letter bindings to re-register with evil.
 Mirrors `claude-client-mode-map'; kept as data so both paths bind the
 same set.")

--- a/test/claude-client-test.el
+++ b/test/claude-client-test.el
@@ -435,6 +435,168 @@ records."
 (let ((s (claude-client--render-event '(:kind tool-result :text "   "))))
   (check "empty-tool-result-skipped" s nil))
 
+;;;; Bounded tool results (issue #61)
+
+;; A `git diff' or whole-file `Read' used to dump its entire payload and
+;; bury the prose.  Bounded now -- but *not* back to one line, which was
+;; tried before and reverted (see `tool-result-keeps-lines' above): the
+;; floor is a few lines plus a way to reach the rest.
+(let* ((long (mapconcat (lambda (i) (format "line %d" i))
+                        (number-sequence 1 20) "\n"))
+       (event (list :kind 'tool-result :text long))
+       (s (substring-no-properties (claude-client--render-event event 0)))
+       (lines (split-string s "\n")))
+  ;; Six shown plus the elision row.
+  (check "bounded-result-line-count" (length lines) 7)
+  (check "bounded-result-keeps-head" (car lines) "  → line 1")
+  (check "bounded-result-stops-at-limit" (nth 5 lines) "  → line 6")
+  (check "bounded-result-counts-remainder"
+         (nth 6 lines) "  → … 14 more lines (TAB to expand)")
+  ;; The elision is faced as pending, not as result text: it is chrome
+  ;; about the result rather than part of the answer.
+  (check "elision-faced"
+         (claude-test--face-at (claude-client--render-event event 0)
+                               (- (length s) 3))
+         'claude-client-pending-face))
+
+;; Singular, because "1 more lines" reads as a bug.
+(let* ((seven (mapconcat #'number-to-string (number-sequence 1 7) "\n"))
+       (s (substring-no-properties
+           (claude-client--render-event (list :kind 'tool-result :text seven) 0))))
+  (check "bounded-result-singular"
+         (and (string-match-p "… 1 more line (TAB" s) t) t))
+
+;; Under the limit nothing is elided, and no affordance is advertised.
+(let ((s (substring-no-properties
+          (claude-client--render-event
+           '(:kind tool-result :text "one\ntwo\nthree") 0))))
+  (check "short-result-not-elided" (and (string-match-p "more line" s) t) nil)
+  (check "short-result-intact" s "  → one\n  → two\n  → three"))
+
+;; Expansion is keyed by event index, so the *other* result stays bounded.
+(let* ((long (mapconcat (lambda (i) (format "l%d" i)) (number-sequence 1 20) "\n"))
+       (event (list :kind 'tool-result :text long))
+       (claude-client--expanded-results '(3)))
+  (check "expanded-index-shows-all"
+         (length (split-string
+                  (substring-no-properties (claude-client--render-event event 3))
+                  "\n"))
+         20)
+  (check "unexpanded-index-still-bounded"
+         (length (split-string
+                  (substring-no-properties (claude-client--render-event event 4))
+                  "\n"))
+         7))
+
+;; nil is the documented escape hatch: show everything.
+(let* ((long (mapconcat (lambda (i) (format "l%d" i)) (number-sequence 1 20) "\n"))
+       (claude-client-tool-result-lines nil)
+       (s (substring-no-properties
+           (claude-client--render-event (list :kind 'tool-result :text long) 0))))
+  (check "unbounded-custom-shows-all" (length (split-string s "\n")) 20))
+
+;; `gh issue view' answers with a dozen empty field labels; they are noise.
+(let ((s (substring-no-properties
+          (claude-client--render-event
+           '(:kind tool-result
+             :text "title: Fix it\nlabels:\nassignees:\nmilestone:\nbody: real")
+           0))))
+  (check "empty-fields-dropped" s "  → title: Fix it\n  → body: real"))
+
+;; The pattern must not eat real content that happens to contain a colon.
+(let ((s (substring-no-properties
+          (claude-client--render-event
+           '(:kind tool-result :text "Status: applied\nlabels: bug\n  (let ((x 1))") 0))))
+  (check "populated-fields-kept"
+         s "  → Status: applied\n  → labels: bug\n  →   (let ((x 1))"))
+
+;; A result that is nothing but empty labels earns no row at all.
+(let ((s (claude-client--render-event
+          '(:kind tool-result :text "labels:\nassignees:") 0)))
+  (check "all-empty-fields-skipped" s nil))
+
+;;;; Toggling a result (issue #61)
+
+;; Round-trip through the real command in a real buffer: the rows carry
+;; their event index, TAB expands, TAB again collapses, and the prose
+;; after the result survives both.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (setq claude-client--events
+              (list '(:kind tool-use :name "Bash")
+                    (list :kind 'tool-result
+                          :text (mapconcat (lambda (i) (format "l%d" i))
+                                           (number-sequence 1 30) "\n"))
+                    '(:kind text :text "prose after")))
+        (claude-client--render)
+        (let ((collapsed (count-lines (point-min) (point-max))))
+          ;; Line 3 is the first result row (banner-less: tool-use, then
+          ;; six result rows).
+          (goto-char (point-min))
+          (forward-line 2)
+          (check "result-rows-carry-index" (claude-client--result-at-point) 1)
+          (claude-client-toggle-tool-result)
+          (check "toggle-expands"
+                 (> (count-lines (point-min) (point-max)) collapsed) t)
+          (check "expanded-shows-last-line"
+                 (and (string-match-p "→ l30" (buffer-string)) t) t)
+          (goto-char (point-min))
+          (forward-line 2)
+          (claude-client-toggle-tool-result)
+          (check "toggle-collapses-again"
+                 (count-lines (point-min) (point-max)) collapsed)
+          (check "prose-survives-toggling"
+                 (and (string-match-p "prose after" (buffer-string)) t) t)))
+    (kill-buffer buf)))
+
+;; Point sits at end of line often enough that looking only at
+;; `char-after' would make TAB fail there.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (setq claude-client--events
+              (list (list :kind 'tool-result :text "a\nb")))
+        (claude-client--render)
+        (goto-char (point-min))
+        (end-of-line)
+        (check "index-found-at-eol" (claude-client--result-at-point) 0))
+    (kill-buffer buf)))
+
+;; Off a result it refuses rather than toggling something arbitrary.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (setq claude-client--events '((:kind text :text "just prose")))
+        (claude-client--render)
+        (goto-char (point-min))
+        (check "toggle-off-result-errors"
+               (condition-case nil
+                   (progn (claude-client-toggle-tool-result) 'no-error)
+                 (user-error 'user-error))
+               'user-error))
+    (kill-buffer buf)))
+
+;; Starting a conversation discards the log, so stale indices must not
+;; survive to expand unrelated results in the new one.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (setq claude-client--expanded-results '(0 1 2))
+        (let ((claude-client-executable "definitely-not-a-real-binary"))
+          (ignore-errors (claude-client-start "hi")))
+        (check "start-clears-expansion" claude-client--expanded-results nil))
+    (kill-buffer buf)))
+
+;; TAB is bound in the mode map, and re-registered for evil -- motion
+;; state claims it as `evil-jump-forward', so without that it is dead.
+(check "tab-bound"
+       (lookup-key claude-client-mode-map (kbd "TAB"))
+       #'claude-client-toggle-tool-result)
+(check "tab-in-evil-keys"
+       (cdr (assoc "TAB" claude-client--evil-keys))
+       'claude-client-toggle-tool-result)
+
 ;; Prose keeps its exact text either way; only the properties differ.
 (let* ((prose "Use **bold** and `code`.\n")
        (s (claude-client--render-event (list :kind 'text :text prose))))


### PR DESCRIPTION
`claude-client--render-event` mapped `"  → "` over every line of a tool result with no limit, so a `git diff` or a whole-file `Read` dumped its entire payload into the conversation — a ~10-event session reached 28KB, one diff contributing 283 lines. The prose ended up buried in tool output, which defeats the point of facing chrome separately from it. The asymmetry was the tell: tool *input* has been bounded to one 60-column line all along; only the answer was unbounded.

Results now show `claude-client-tool-result-lines` (default 6) and say how many lines they hid. Truncating to a single line was tried before and reverted because it hid the answer, so the floor here is a few lines **plus** a way to reach the rest: `TAB` on a result expands it, `TAB` again re-collapses. Nothing is discarded — the full text was always kept in the event log.

Expansion is tracked as a set of event indices held beside the log rather than a flag written into the events, so the log stays the append-only record #39 wants to subscribe to. Starting a conversation clears the set along with the events it indexes.

Also drops lines that are a bare field label with no value — the dozen `labels:` / `assignees:` rows `gh issue view` answers with. That pattern is deliberately narrow, so a real line that merely contains a colon survives.

Closes #61