### PR TITLE
Make selection sharing work for any backend

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -328,11 +328,34 @@ transcript work regardless of which backend is driving the session.
 **The interface.** The base class declares a `cl-defgeneric` lifecycle
 interface — `agent-backend-connect`, `-quit`, `-send`, `-interrupt`,
 `-add-note`, `-note-policy`, `-reply-permission`, `-reply-question`,
-`-list-sessions`, `-resume`, `-seed-history`, `-project-root`, and `-render`.
-The optional capabilities (permission/question replies, sessions, resume,
-history seeding, project root, render) have no-op or `user-error` defaults on
-the base class, so a minimal backend implements only connect, quit, send,
-interrupt, add-note, and note-policy and compiles without stubs.
+`-list-sessions`, `-resume`, `-seed-history`, `-project-root`, `-render`, and
+`-mention`. The optional capabilities (permission/question replies, sessions,
+resume, history seeding, project root, render, mention) have no-op,
+`user-error` or delegating defaults on the base class, so a minimal backend
+implements only connect, quit, send, interrupt, add-note, and note-policy and
+compiles without stubs.
+
+**Sharing what you are looking at.** `M-x agent-backend-mention-selection`, run
+from a *code* buffer, hands the active region (or the line at point) to
+whichever conversation is live — previously an eat-runner-only verb
+([#56](https://github.com/gbastkowski/mcp-emacs/issues/56)). What gets sent is
+a project-relative pointer, `@elisp/foo.el:12-40`, not the text: the agent can
+read the file itself, and a pointer stays right as the code moves on. Buffers
+with no file send their text instead, since there is nothing to point at.
+
+The target is resolved in tiers — same project and visible, same project
+hidden, any project visible, any project hidden — and you are asked only when
+the winning tier is ambiguous. Conversations are found by scanning for a
+buffer-local backend instance, so there is no registry and a new client is
+found for free.
+
+A mention is deliberately **not** a turn. `agent-backend-mention` defaults to
+routing through `agent-backend-add-note`, which already means "the human said
+this, deliver it with the next turn". Claude overrides it, because both of its
+note paths are wrong here: mid-turn a note abandons the turn in flight, and
+with nothing running a note drains *immediately* — which would submit the
+mention as a turn of its own. So Claude queues the mention and logs it as
+pending, and the next prompt you send carries it along.
 
 **The event vocabulary.** Every conversation event is published as a plist with
 a `:kind` symbol on the abnormal hook `agent-backend-event-functions`, run with

--- a/elisp/agent-backend.el
+++ b/elisp/agent-backend.el
@@ -115,6 +115,21 @@ Optional: the default is a no-op.  Publishing events (see
 `agent-backend--publish') is decoupled from rendering; a backend may
 render by other means.")
 
+(cl-defgeneric agent-backend-mention (backend text)
+  "Offer TEXT to BACKEND's conversation without sending a turn.
+A reference to what the human is looking at -- see
+`agent-backend-selection-reference' -- handed over for the model to pick
+up on its next turn, so the human can keep composing around it (issue
+#56).
+
+Deliberately not `agent-backend-send': mentioning is *not* a turn.  The
+eat runner could do this by typing into a live TUI input line, which the
+API-driven clients have no equivalent of -- they submit a turn or
+nothing.  So each backend decides where unsent text goes; the default
+routes it through `agent-backend-add-note', which is exactly the
+existing \"human said something, deliver it with the next turn\"
+channel.")
+
 ;;;; Default implementations
 
 (cl-defmethod agent-backend-note-policy ((backend agent-backend))
@@ -158,6 +173,15 @@ render by other means.")
   (ignore backend)
   nil)
 
+(cl-defmethod agent-backend-mention ((backend agent-backend) text)
+  "Default mention: hand TEXT to BACKEND as a human note.
+Notes already mean \"the human said this; deliver it with the next
+turn\", which is what a mention needs -- so every backend gets a working
+mention from its `agent-backend-add-note' without implementing anything
+new.  A backend with a real editable prompt line should override this to
+insert there instead."
+  (agent-backend-add-note backend text))
+
 ;;;; Events
 
 (defvar agent-backend-event-functions nil
@@ -189,12 +213,122 @@ Publishing is decoupled from rendering: this only notifies subscribers
 and never touches BUFFER's contents or display."
   (run-hook-with-args 'agent-backend-event-functions buffer event))
 
-;;;; Major mode
+;;;; Sharing what the human is looking at
+
+;; Declared here rather than where `project' is required: this file must
+;; byte-compile standalone, and `project' is only consulted when present.
+(declare-function project-root "project" (project))
 
 (defvar-local agent-backend--instance nil
   "The `agent-backend' instance driving this buffer.
 The derived client mode sets it with `setq-local' when it creates its
-conversation buffer.")
+conversation buffer.  Defined before its users below, which scan for it
+across buffers to find a conversation to talk to.")
+
+(defun agent-backend--current-project-root ()
+  "Return the current project root, or the buffer's directory as a fallback."
+  (or (when (and (featurep 'project) (fboundp 'project-current))
+        (when-let* ((proj (project-current nil)))
+          (expand-file-name (project-root proj))))
+      (expand-file-name default-directory)))
+
+(defun agent-backend-selection-reference ()
+  "Return a reference to the current selection, for embedding in a prompt.
+In a file-visiting buffer, an at-mention of the project-relative path
+with the active region's line span (or the line at point with no region)
+-- a pointer the agent can read for itself, which beats pasting the text
+and stays right if the file moves on.  Otherwise the selected text
+verbatim, since there is no path to point at.
+
+Generalised out of `mcp-emacs-run--selection-reference' (issue #56): the
+verb belongs to every backend, not to the terminal runner that happened
+to implement it first."
+  (let* ((beg (if (use-region-p) (region-beginning) (point)))
+         (end (if (use-region-p) (region-end) (point)))
+         (file (buffer-file-name)))
+    (if file
+        (let* ((root (agent-backend--current-project-root))
+               (rel (file-relative-name file root))
+               (start-line (line-number-at-pos beg))
+               ;; A region ending at column 0 covers up to the previous line.
+               (end-line (line-number-at-pos (if (and (use-region-p) (> end beg)
+                                                      (save-excursion
+                                                        (goto-char end) (bolp)))
+                                                 (1- end)
+                                               end))))
+          (if (and (use-region-p) (/= start-line end-line))
+              (format "@%s:%d-%d" rel start-line end-line)
+            (format "@%s:%d" rel start-line)))
+      (if (use-region-p)
+          (buffer-substring-no-properties beg end)
+        (buffer-substring-no-properties (line-beginning-position)
+                                        (line-end-position))))))
+
+(defun agent-backend--conversation-buffers ()
+  "Return every live conversation buffer, across all backends.
+A `buffer-list' scan for a buffer-local `agent-backend--instance' -- no
+registry, and nothing per-backend to keep in step, the same choice
+`agent-session-overview--sessions' makes.  Any client that sets the
+instance is found for free."
+  (seq-filter (lambda (buffer)
+                (buffer-local-value 'agent-backend--instance buffer))
+              (buffer-list)))
+
+(defun agent-backend--resolve-conversation ()
+  "Return the conversation buffer to receive what the human is sharing.
+Candidates are ranked in tiers and the first non-empty tier wins:
+
+  1. same project as the current buffer, and visible in a window
+  2. same project, hidden
+  3. any project, visible
+  4. any project, hidden
+
+Visible beats hidden because a conversation on screen is the one being
+worked with; same-project beats other projects because that is what the
+selection is about.  With several candidates in the winning tier, ask.
+Generalised from `mcp-emacs-run--resolve-session' (issue #56), which
+ranks the same way over eat buffers only."
+  (let ((all (agent-backend--conversation-buffers)))
+    (unless all
+      (user-error "No live agent conversation; start one with `agent-backend-start'"))
+    (let* ((root (agent-backend--current-project-root))
+           (visible (lambda (buffer) (get-buffer-window buffer t)))
+           (same (seq-filter
+                  (lambda (buffer)
+                    (equal (expand-file-name
+                            (buffer-local-value 'default-directory buffer))
+                           root))
+                  all))
+           (tiers (list (seq-filter visible same)
+                        (seq-remove visible same)
+                        (seq-filter visible all)
+                        (seq-remove visible all)))
+           (tier (seq-find #'identity tiers)))
+      (if (cdr tier)
+          (get-buffer
+           (completing-read "Conversation: " (mapcar #'buffer-name tier)
+                            nil t))
+        (car tier)))))
+
+;;;###autoload
+(defun agent-backend-mention-selection ()
+  "Share what you are looking at with the current agent conversation.
+Sends a reference to the active region (or the line at point) -- see
+`agent-backend-selection-reference' -- to the conversation resolved by
+`agent-backend--resolve-conversation', without submitting a turn.  Run
+this from the code buffer, not the conversation.
+
+Requires a live conversation; it does not start one.  Replaces
+`mcp-emacs-run-mention-selection', which only ever worked for the eat
+runner (issue #56)."
+  (interactive)
+  (let ((reference (agent-backend-selection-reference))
+        (buffer (agent-backend--resolve-conversation)))
+    (with-current-buffer buffer
+      (agent-backend-mention agent-backend--instance reference))
+    (message "Shared %s with %s" reference (buffer-name buffer))))
+
+;;;; Major mode
 
 (defun agent-backend-send-command (prompt)
   "Send PROMPT to this buffer's backend."

--- a/elisp/claude-client.el
+++ b/elisp/claude-client.el
@@ -1279,6 +1279,33 @@ interrupt-or-queue delivery policy -- unchanged."
       (with-current-buffer buffer
         (claude-client-add-note text)))))
 
+(cl-defmethod agent-backend-mention ((backend claude-client-backend) text)
+  "Queue TEXT as a mention in BACKEND's conversation without sending a turn.
+Deliberately not `claude-client-add-note', which is wrong for a mention
+at both ends: mid-turn a note abandons the turn in flight
+(`claude-client-note-interrupts'), and with nothing running it drains
+*immediately* -- delivering the mention as a turn of its own.  Pointing
+at some code is neither of those; it should sit in the conversation
+until the human's next prompt carries it along.
+
+So the text is queued and logged, and nothing is delivered.  The queue
+is `claude-client--pending-notes', whose existing drain already appends
+carried text to the next prompt -- see
+`claude-client--prompt-with-notes'."
+  (let ((buffer (oref backend buffer)))
+    (when (buffer-live-p buffer)
+      (with-current-buffer buffer
+        (let ((mention (string-trim text)))
+          (unless (string-empty-p mention)
+            ;; Coalesced like a note: mentioning the same lines twice
+            ;; before the model has seen either says nothing new.
+            (unless (member mention claude-client--pending-notes)
+              (setq claude-client--pending-notes
+                    (append claude-client--pending-notes (list mention))))
+            ;; `pending' is the truth here: nothing is being delivered.
+            (claude-client--push-event
+             buffer (list :kind 'note :text mention :pending t))))))))
+
 (cl-defmethod agent-backend-note-policy ((_backend claude-client-backend))
   "Return Claude's note delivery policy.
 `:interrupt' when `claude-client-note-interrupts' is on (a note

--- a/elisp/mcp-emacs-run.el
+++ b/elisp/mcp-emacs-run.el
@@ -352,30 +352,12 @@ Signal a `user-error' when there is no live session."
 
 (defun mcp-emacs-run--selection-reference ()
   "Return a reference to the current selection for embedding in a prompt.
-In a file-visiting buffer, return an at-mention of the project-relative
-path with the active region's line span (or the single line at point
-when no region is active).  Otherwise return the selected text verbatim
-\(or the current line when no region is active)."
-  (let* ((beg (if (use-region-p) (region-beginning) (point)))
-         (end (if (use-region-p) (region-end) (point)))
-         (file (buffer-file-name)))
-    (if file
-        (let* ((root (mcp-emacs-run--project-root))
-               (rel (file-relative-name file root))
-               (start-line (line-number-at-pos beg))
-               ;; A region ending at column 0 covers up to the previous line.
-               (end-line (line-number-at-pos (if (and (use-region-p) (> end beg)
-                                                       (save-excursion
-                                                         (goto-char end) (bolp)))
-                                                  (1- end)
-                                                end))))
-          (if (and (use-region-p) (/= start-line end-line))
-              (format "@%s:%d-%d" rel start-line end-line)
-            (format "@%s:%d" rel start-line)))
-      (if (use-region-p)
-          (buffer-substring-no-properties beg end)
-        (buffer-substring-no-properties (line-beginning-position)
-                                        (line-end-position))))))
+Now a thin alias for `agent-backend-selection-reference', which this
+function was generalised into when the verb became backend-agnostic
+(issue #56).  Kept so the runner's own callers and the reference tests
+keep working from one implementation rather than two that can drift."
+  (require 'agent-backend)
+  (agent-backend-selection-reference))
 
 ;;;; Popup output window
 
@@ -648,7 +630,12 @@ Builds a reference for the active region (or point) with
 `mcp-emacs-run--selection-reference' and sends it to the current
 project's runner session without submitting, so the user can keep
 typing around the reference.  Requires a live session; does not launch
-one.  Mirrors claude-code-ide's `insert-at-mentioned'."
+one.  Mirrors claude-code-ide's `insert-at-mentioned'.
+
+Superseded by `agent-backend-mention-selection', which does this for
+whichever backend is live rather than for the eat runner only (issue
+#56).  This stays while the runner does, since typing into its TUI input
+line is a genuinely different mechanism from queueing a mention."
   (interactive)
   (let ((reference (mcp-emacs-run--selection-reference)))
     (mcp-emacs-run--send-to-buffer (mcp-emacs-run--resolve-session)

--- a/test/agent-backend-test.el
+++ b/test/agent-backend-test.el
@@ -47,3 +47,97 @@
   (check "default-note-policy" (agent-backend-note-policy b) :steer)
   (oset b note-policy :queue)
   (check "oset-note-policy" (agent-backend-note-policy b) :queue))
+
+;;;; Sharing a selection (issue #56)
+
+(require 'project)
+
+;; The reference is a project-relative pointer, not the text itself: the
+;; agent can read the file for itself, and a pointer stays right as the
+;; file moves on.
+(let ((buf (find-file-noselect
+            (expand-file-name "elisp/agent-backend.el"))))
+  (with-current-buffer buf
+    (goto-char (point-min))
+    (forward-line 11)
+    (let ((beg (point)))
+      (forward-line 3)
+      (let ((transient-mark-mode t))
+        (set-mark beg)
+        (activate-mark)
+        ;; 12-14, not 12-15: the region ends at column 0 of line 15, so
+        ;; it covers up to the previous line -- selecting three whole
+        ;; lines should not claim a fourth.
+        (check "ref-region-is-project-relative"
+               (agent-backend-selection-reference)
+               "@elisp/agent-backend.el:12-14")
+        (deactivate-mark))
+      ;; No region: the single line at point.
+      (goto-char (point-min))
+      (forward-line 4)
+      (check "ref-no-region-is-one-line"
+             (agent-backend-selection-reference)
+             "@elisp/agent-backend.el:5")))
+  (kill-buffer buf))
+
+;; With no file to point at there is no path, so the text itself is the
+;; only useful reference.
+(with-temp-buffer
+  (insert "alpha\nbeta\n")
+  (goto-char (point-min))
+  (check "ref-nonfile-no-region" (agent-backend-selection-reference) "alpha"))
+
+;; Resolution finds any buffer holding an instance -- no registry, so a
+;; new client is found for free.
+(let ((conv (get-buffer-create "*fake-conversation*")))
+  (unwind-protect
+      (progn
+        (with-current-buffer conv
+          (setq-local agent-backend--instance (make-instance 'agent-backend)))
+        (check "conversation-found"
+               (memq conv (agent-backend--conversation-buffers))
+               (list conv))
+        (check "resolves-the-only-one"
+               (agent-backend--resolve-conversation) conv))
+    (kill-buffer conv)))
+
+;; A buffer without an instance is not a conversation.
+(let ((plain (get-buffer-create "*not-a-conversation*")))
+  (unwind-protect
+      (check "plain-buffer-ignored"
+             (memq plain (agent-backend--conversation-buffers)) nil)
+    (kill-buffer plain)))
+
+;; Refuses rather than silently doing nothing when nothing is live.
+(check "no-conversation-errors"
+       (condition-case nil
+           (progn (agent-backend--resolve-conversation) 'no-error)
+         (user-error 'user-error))
+       'user-error)
+
+;; Same project beats another project, and visible beats hidden -- the
+;; selection is about the project you are in, and an on-screen
+;; conversation is the one being worked with.
+(let* ((here (expand-file-name default-directory))
+       (mine (get-buffer-create "*conv-same-project*"))
+       (other (get-buffer-create "*conv-other-project*")))
+  (unwind-protect
+      (progn
+        (with-current-buffer mine
+          (setq-local default-directory here)
+          (setq-local agent-backend--instance (make-instance 'agent-backend)))
+        (with-current-buffer other
+          (setq-local default-directory "/tmp/somewhere-else/")
+          (setq-local agent-backend--instance (make-instance 'agent-backend)))
+        (check "same-project-wins"
+               (agent-backend--resolve-conversation) mine))
+    (kill-buffer mine)
+    (kill-buffer other)))
+
+;; The default mention routes through add-note, so a backend that
+;; implements only the required verbs still gets a working mention.
+(let ((noted nil))
+  (cl-letf (((symbol-function 'agent-backend-add-note)
+             (lambda (_backend text) (setq noted text))))
+    (agent-backend-mention (make-instance 'agent-backend) "@foo.el:1")
+    (check "default-mention-uses-add-note" noted "@foo.el:1")))

--- a/test/claude-client-test.el
+++ b/test/claude-client-test.el
@@ -588,6 +588,74 @@ records."
         (check "start-clears-expansion" claude-client--expanded-results nil))
     (kill-buffer buf)))
 
+;;;; Mentions (issue #56)
+
+;; A mention must *queue*, not deliver.  Both of add-note's paths are
+;; wrong for it: mid-turn a note abandons the turn, and with nothing
+;; running add-note drains immediately -- which would send the mention as
+;; a turn of its own, the opposite of "without submitting".  Found by
+;; running the command, not by reading the code.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (agent-backend-mention (claude-client-backend :buffer buf)
+                               "@elisp/foo.el:12-40")
+        (check "mention-is-queued"
+               claude-client--pending-notes '("@elisp/foo.el:12-40"))
+        (check "mention-delivers-nothing"
+               (memq 'notes-delivered (claude-test--kinds buf)) nil)
+        (check "mention-is-logged" (claude-test--kinds buf) '(note))
+        ;; `pending' is the truth: the model has not been handed it.
+        (check "mention-logged-as-pending"
+               (plist-get (car claude-client--events) :pending) t))
+    (kill-buffer buf)))
+
+;; Queued, so the next prompt carries it -- that is what makes a mention
+;; reach the model at all.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (agent-backend-mention (claude-client-backend :buffer buf) "@a.el:1")
+        (check "mention-rides-next-prompt"
+               (claude-client--prompt-with-notes "what is this?")
+               "what is this?\n\nNotes from the human:\n- @a.el:1"))
+    (kill-buffer buf)))
+
+;; Mentioning the same lines twice before the model has seen either says
+;; nothing new, and costs context.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (let ((backend (claude-client-backend :buffer buf)))
+          (agent-backend-mention backend "@a.el:1")
+          (agent-backend-mention backend "@a.el:1")
+          (agent-backend-mention backend "@b.el:2"))
+        (check "mention-coalesces-repeat"
+               claude-client--pending-notes '("@a.el:1" "@b.el:2")))
+    (kill-buffer buf)))
+
+;; A mention mid-turn must not interrupt: pointing at code is not the
+;; human changing direction, which is what a note is for.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (setq claude-client--turn-active t)
+        (agent-backend-mention (claude-client-backend :buffer buf) "@a.el:1")
+        (check "mention-mid-turn-does-not-interrupt"
+               (memq 'interrupted (claude-test--kinds buf)) nil)
+        (check "mention-mid-turn-still-queued"
+               claude-client--pending-notes '("@a.el:1")))
+    (kill-buffer buf)))
+
+;; Empty or whitespace-only text is not a mention.
+(let ((buf (claude-test--buffer)))
+  (unwind-protect
+      (with-current-buffer buf
+        (agent-backend-mention (claude-client-backend :buffer buf) "   ")
+        (check "empty-mention-ignored" claude-client--pending-notes nil)
+        (check "empty-mention-not-logged" (claude-test--kinds buf) nil))
+    (kill-buffer buf)))
+
 ;; TAB is bound in the mode map, and re-registered for evil -- motion
 ;; state claims it as `evil-jump-forward', so without that it is dead.
 (check "tab-bound"


### PR DESCRIPTION
Sending the region — or a reference to it — to the current conversation is one of the most-used verbs, and it lived only in the eat runner. Neither `agent-backend`, `claude-client` nor `opencode-client` had an equivalent, so the verb was missing from the first-class path and the deprecated runner couldn't be deleted.

This adds `agent-backend-mention` to the protocol and `agent-backend-mention-selection` as the code-buffer command, with the reference builder generalised into `agent-backend-selection-reference`. The runner's helper now delegates to it, so there's one implementation instead of two that drift — its own reference tests pass untouched against it.

Resolving a target was the new work. Every existing command runs *inside* a conversation buffer, where `agent-backend--instance` is buffer-local; this runs in a code buffer with no instance. So the runner's tiering (same-project-visible → same-project-hidden → any-visible → any-hidden) is generalised over buffers that hold an instance — a scan rather than a registry, matching what the session overview already does.

The interesting part: a mention must not be a turn. The default routes through `agent-backend-add-note`, which already means "deliver with the next turn". But Claude's note does two things a mention must not — mid-turn it abandons the turn in flight, and with nothing running it drains *immediately*, submitting the mention as a turn of its own. I found that by running the command, not by reading it. Claude therefore overrides `agent-backend-mention` to queue and log without delivering, and your next prompt carries it along.

**Scope:** only the mention half of #56. `explain-selection` still depends on the runner's headless-query and markdown-popup machinery, which has no backend equivalent — that's a separate piece of work, so the issue stays open.

Refs #56