### PR TITLE
Make explain-selection work for any backend

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -328,12 +328,12 @@ transcript work regardless of which backend is driving the session.
 **The interface.** The base class declares a `cl-defgeneric` lifecycle
 interface — `agent-backend-connect`, `-quit`, `-send`, `-interrupt`,
 `-add-note`, `-note-policy`, `-reply-permission`, `-reply-question`,
-`-list-sessions`, `-resume`, `-seed-history`, `-project-root`, `-render`, and
-`-mention`. The optional capabilities (permission/question replies, sessions,
-resume, history seeding, project root, render, mention) have no-op,
-`user-error` or delegating defaults on the base class, so a minimal backend
-implements only connect, quit, send, interrupt, add-note, and note-policy and
-compiles without stubs.
+`-list-sessions`, `-resume`, `-seed-history`, `-project-root`, `-render`,
+`-mention`, and `-query`. The optional capabilities (permission/question
+replies, sessions, resume, history seeding, project root, render, mention,
+query) have no-op, `user-error` or delegating defaults on the base class, so a
+minimal backend implements only connect, quit, send, interrupt, add-note, and
+note-policy and compiles without stubs.
 
 **Sharing what you are looking at.** `M-x agent-backend-mention-selection`, run
 from a *code* buffer, hands the active region (or the line at point) to
@@ -356,6 +356,34 @@ note paths are wrong here: mid-turn a note abandons the turn in flight, and
 with nothing running a note drains *immediately* — which would submit the
 mention as a turn of its own. So Claude queues the mention and logs it as
 pending, and the next prompt you send carries it along.
+
+**Explaining a selection.** `M-x agent-backend-explain-selection` asks about
+the region (or line at point), with `agent-backend-explain-route` deciding
+where:
+
+| Route | Behaviour |
+|---|---|
+| `session-first` (default) | Ask in a conversation that is on screen; fall back to a one-shot query when none is |
+| `one-shot` | Always ask outside any session, even with a conversation open |
+| `session-only` | Ask in a visible conversation, refuse otherwise |
+
+The default prefers a session because "explain this" is usually part of the
+work already in that context — the model has it loaded, and the answer belongs
+in the log with everything else, where you can follow up on it. Switch to
+`one-shot` if explaining asides turns out to pollute the conversation: a dozen
+questions about unrelated code push the actual work out of the model's context.
+One-shot answers render in the popup output window near your code, and touch no
+session state. `agent-backend-explain-prompt` (default `"explain %s"`) is the
+template.
+
+Answering without a session is `agent-backend-query`, and how a backend manages
+it differs: Claude shells out to its one-shot CLI mode (`claude -p`), while
+opencode — session-only over HTTP — opens a session, asks, and deletes it, so
+the effect is one-shot even though the transport is not. Its prompt endpoint
+only acknowledges the request, so the answer is polled from the message list
+until the turn reports finished (`opencode-client-query-timeout`, default 120s);
+the throwaway session is deleted even on failure or timeout. Backends that can
+do neither inherit a default that refuses by name rather than pretending.
 
 **The event vocabulary.** Every conversation event is published as a plist with
 a `:kind` symbol on the abnormal hook `agent-backend-event-functions`, run with

--- a/elisp/agent-backend.el
+++ b/elisp/agent-backend.el
@@ -130,6 +130,19 @@ routes it through `agent-backend-add-note', which is exactly the
 existing \"human said something, deliver it with the next turn\"
 channel.")
 
+(cl-defgeneric agent-backend-query (backend prompt callback)
+  "Answer PROMPT once, outside any session, and call CALLBACK with the text.
+For asking a question when no conversation is live -- the answer goes
+wherever the caller puts it, not into a conversation log, and no session
+state is created.
+
+How a backend manages that is its own business: `claude' shells out to
+its one-shot CLI mode (`claude -p'), while opencode -- session-only over
+HTTP -- opens a session, asks, and deletes it, so the effect is one-shot
+even though the transport is not.  The default refuses, naming the
+backend, so a backend that can do neither says so rather than pretending
+\(issue #56).  CALLBACK is called with the answer text, on success only.")
+
 ;;;; Default implementations
 
 (cl-defmethod agent-backend-note-policy ((backend agent-backend))
@@ -172,6 +185,12 @@ channel.")
   "No-op default: BACKEND renders by other means, or not at all."
   (ignore backend)
   nil)
+
+(cl-defmethod agent-backend-query ((backend agent-backend) prompt callback)
+  "Default query: refuse, since BACKEND has no session-less mode."
+  (ignore prompt callback)
+  (user-error "%s cannot answer without a live session"
+              (or (eieio-object-class-name backend) "This agent backend")))
 
 (cl-defmethod agent-backend-mention ((backend agent-backend) text)
   "Default mention: hand TEXT to BACKEND as a human note.
@@ -328,6 +347,94 @@ runner (issue #56)."
       (agent-backend-mention agent-backend--instance reference))
     (message "Shared %s with %s" reference (buffer-name buffer))))
 
+(defun agent-backend--visible-conversation ()
+  "Return a conversation buffer shown in some window, or nil.
+Unlike `agent-backend--resolve-conversation' this never signals and never
+prompts: callers that have a fallback need to *ask* whether a
+conversation is on screen, not to be stopped when none is.  Same-project
+first, since that is what the code in front of you is about."
+  (let* ((root (agent-backend--current-project-root))
+         (shown (seq-filter (lambda (buffer) (get-buffer-window buffer t))
+                            (agent-backend--conversation-buffers)))
+         (same (seq-filter
+                (lambda (buffer)
+                  (equal (expand-file-name
+                          (buffer-local-value 'default-directory buffer))
+                         root))
+                shown)))
+    (or (car same) (car shown))))
+
+(defcustom agent-backend-explain-prompt "explain %s"
+  "Prompt template for `agent-backend-explain-selection'.
+The `%s' is replaced with the selection reference.  A template because
+what you want explained about a span of code is a matter of taste, and
+the reference is the only part that has to be there."
+  :type 'string
+  :group 'agent-backend)
+
+(defcustom agent-backend-explain-route 'session-first
+  "Where `agent-backend-explain-selection' sends its request.
+
+`session-first' asks in a conversation that is on screen, and falls back
+to a one-shot query when none is.  The default because \"explain this\"
+usually *is* part of the current work -- the model already has the
+context, and the answer belongs in the log with everything else.
+
+`one-shot' always asks outside any session, even with a conversation
+open.  Choose this when explaining things turns out to pollute the
+conversation: a dozen asides about unrelated code push the actual work
+out of the model's context and clutter the transcript.
+
+`session-only' asks in a visible conversation and refuses otherwise,
+for never spending a separate call."
+  :type '(choice (const :tag "Ask in a visible session, else one-shot" session-first)
+                 (const :tag "Always ask outside a session" one-shot)
+                 (const :tag "Only ask in a visible session" session-only))
+  :group 'agent-backend)
+
+;;;###autoload
+(defun agent-backend-explain-selection ()
+  "Explain the active region (or the line at point).
+Where the request goes is `agent-backend-explain-route': by default a
+conversation that is on screen, since \"explain this\" is usually part of
+the work already in that context, falling back to a one-shot query when
+none is visible.  Asked in a session the answer lands in the log and can
+be followed up on; asked one-shot it is rendered in the popup output
+window near the code, and no session state is touched.
+
+Generalised from `mcp-emacs-explain-selection-in-current-session' (issue
+#56), which routed this way but only ever over the eat runner."
+  (interactive)
+  (let* ((reference (agent-backend-selection-reference))
+         (prompt (format agent-backend-explain-prompt reference))
+         (visible (and (memq agent-backend-explain-route
+                             '(session-first session-only))
+                       (agent-backend--visible-conversation))))
+    (cond
+     (visible
+      (with-current-buffer visible
+        (agent-backend-send agent-backend--instance prompt)
+        (message "Explaining %s in %s" reference (buffer-name visible))))
+     ((eq agent-backend-explain-route 'session-only)
+      (user-error "No visible conversation to explain in (see `agent-backend-explain-route')"))
+     (t
+      (require 'mcp-emacs-run)
+      (mcp-emacs-popup-show "Working…" "explain")
+      (agent-backend-query
+       (agent-backend--query-backend) prompt
+       (lambda (output) (mcp-emacs-popup-show output "explain")))))))
+
+(defun agent-backend--query-backend ()
+  "Return a backend instance to answer a session-less query.
+Built from `agent-backend-preference' rather than taken from a
+conversation, because the no-conversation case is exactly when there is
+none to take it from."
+  (if (agent-backend-prefer-opencode-p)
+      (progn (require 'opencode-client nil t)
+             (make-instance 'opencode-client-backend))
+    (require 'claude-client nil t)
+    (make-instance 'claude-client-backend)))
+
 ;;;; Major mode
 
 (defun agent-backend-send-command (prompt)
@@ -386,6 +493,7 @@ The backend instance lives in the buffer-local `agent-backend--instance'."
 ;; shared core still byte-compiles standalone (the clients require
 ;; this file, so agent-backend cannot require them back at load).
 (declare-function opencode-client--health "opencode-client" ())
+(declare-function mcp-emacs-popup-show "mcp-emacs-run" (content &optional kind))
 (declare-function opencode-client-create-session "opencode-client" (&optional title))
 (declare-function claude-client-start "claude-client" (prompt &optional resume-id))
 

--- a/elisp/claude-client.el
+++ b/elisp/claude-client.el
@@ -1306,6 +1306,43 @@ carried text to the next prompt -- see
             (claude-client--push-event
              buffer (list :kind 'note :text mention :pending t))))))))
 
+(cl-defmethod agent-backend-query ((_backend claude-client-backend) prompt callback)
+  "Answer PROMPT with a one-shot `claude -p', passing stdout to CALLBACK.
+No session, no conversation buffer, no event log: the CLI is invoked
+once from the project root and its stdout handed over.  Asynchronous, so
+Emacs stays responsive while the model thinks.
+
+On a non-zero exit the user is told and CALLBACK is *not* called, so a
+caller cannot mistake an error message for an answer.  Moved here from
+`mcp-emacs-run--query-headless' (issue #56): the capability is Claude's,
+not the eat terminal's, and the runner is on its way out."
+  (let* ((default-directory
+          (file-name-as-directory (agent-backend--current-project-root)))
+         (out (generate-new-buffer " *claude-query-out*"))
+         (err (generate-new-buffer " *claude-query-err*")))
+    (make-process
+     :name "claude-query"
+     :buffer out
+     :stderr err
+     :noquery t
+     :command (list claude-client-executable
+                    "-p" prompt "--output-format" "text")
+     :sentinel
+     (lambda (proc _event)
+       (when (memq (process-status proc) '(exit signal))
+         (let ((code (process-exit-status proc))
+               (output (with-current-buffer out (buffer-string)))
+               (errtext (with-current-buffer err (buffer-string))))
+           (unwind-protect
+               (if (and (eq (process-status proc) 'exit) (zerop code))
+                   (funcall callback output)
+                 (message "claude query failed (exit %s): %s"
+                          code (string-trim (if (string-empty-p errtext)
+                                                output
+                                              errtext))))
+             (when (buffer-live-p out) (kill-buffer out))
+             (when (buffer-live-p err) (kill-buffer err)))))))))
+
 (cl-defmethod agent-backend-note-policy ((_backend claude-client-backend))
   "Return Claude's note delivery policy.
 `:interrupt' when `claude-client-note-interrupts' is on (a note

--- a/elisp/mcp-emacs-run.el
+++ b/elisp/mcp-emacs-run.el
@@ -417,7 +417,15 @@ auto-hiding side window).  The window is reused if already shown."
 Invokes the configured executable with `-p PROMPT --output-format text'
 from the current project root, collecting stdout asynchronously.  On a
 zero exit, CALLBACK is called with the collected string.  On failure the
-user is informed and CALLBACK is not called."
+user is informed and CALLBACK is not called.
+
+`agent-backend-query' on a Claude backend now does the same thing for
+the backend clients (issue #56).  This is deliberately *not* delegated
+to it: this one honours `mcp-emacs-run-executable' and
+`mcp-emacs-run--project-root', and folding it into the backend method
+would silently switch a user who configured only the runner's paths onto
+`claude-client-executable'.  Two short call sites beat changing
+behaviour under a deprecated surface; both go when the runner does."
   (let* ((default-directory (file-name-as-directory (mcp-emacs-run--project-root)))
          (out (generate-new-buffer " *mcp-emacs-query-out*"))
          (err (generate-new-buffer " *mcp-emacs-query-err*")))
@@ -649,7 +657,14 @@ project's runner session buffer is visible in a window, the explain
 request is sent to and submitted in that live session.  Otherwise —
 whether the project has a hidden session or no session at all — the
 explanation is fetched with a one-shot headless query and rendered in
-the popup output window.  Does not require or launch a TUI session."
+the popup output window.  Does not require or launch a TUI session.
+
+Superseded by `agent-backend-explain-selection', which routes the same
+way over whichever backend is live and takes
+`agent-backend-explain-route' for whether to prefer a session at all
+\(issue #56).  This stays while the runner does: its target is an eat
+terminal, which is not an `agent-backend' and cannot be resolved as
+one."
   (interactive)
   (let* ((root (mcp-emacs-run--project-root))
          (prompt (concat "explain " (mcp-emacs-run--selection-reference))))

--- a/elisp/opencode-client.el
+++ b/elisp/opencode-client.el
@@ -675,6 +675,88 @@ Use `opencode-client-switch-session' to pick a past session instead."
       (with-current-buffer buffer
         (opencode-client--render)))))
 
+(defcustom opencode-client-query-timeout 120
+  "Seconds to wait for a one-shot `agent-backend-query' answer.
+Polling stops after this and the user is told, so a wedged or very slow
+model cannot leave the caller waiting forever."
+  :type 'integer
+  :group 'opencode-client)
+
+(defcustom opencode-client-query-poll-interval 1.0
+  "Seconds between polls while waiting for a one-shot query's answer.
+opencode's prompt endpoint only acknowledges the request -- the answer
+arrives later -- so the reply has to be collected by asking again."
+  :type 'number
+  :group 'opencode-client)
+
+(defun opencode-client--completed-answer (session backend)
+  "Return the assistant answer for SESSION on BACKEND, or nil if not ready.
+nil means \"not finished yet\", so a caller can keep polling; a finished
+turn that failed signals instead, since waiting longer will not help.
+
+Shape verified against a live server: `GET /api/session/ID/message'
+returns messages newest-first, each with a `type' (\"assistant\" or
+\"user\"), a `content' list of parts, and -- once the turn is over -- a
+`finish' field, which is \"error\" plus an `error' object on failure."
+  (let* ((messages (opencode-client--request
+                    'get (format "/api/session/%s/message" session) nil backend))
+         (reply (seq-find (lambda (m) (equal (alist-get 'type m) "assistant"))
+                          (if (listp messages) messages nil))))
+    (when-let* ((finish (and reply (alist-get 'finish reply))))
+      (when (equal finish "error")
+        (user-error "opencode query failed: %s"
+                    (or (alist-get 'message (alist-get 'error reply))
+                        "unknown error")))
+      ;; Finished cleanly: join the text parts, skipping tool calls and
+      ;; other non-prose content.
+      (mapconcat (lambda (part) (or (alist-get 'text part) ""))
+                 (seq-filter (lambda (part) (equal (alist-get 'type part) "text"))
+                             (alist-get 'content reply))
+                 ""))))
+
+(cl-defmethod agent-backend-query ((backend opencode-client-backend) prompt callback)
+  "Answer PROMPT in a throwaway opencode session, passing text to CALLBACK.
+opencode has no one-shot mode -- it is session-only over HTTP -- so the
+one-shot *effect* is built: open a session, ask, collect the answer,
+delete the session.  Nothing is left behind and no conversation buffer
+is involved.
+
+The answer cannot be read from the prompt response, which only
+acknowledges the request (verified against a live server: it returns
+`admittedSeq' and a message id, no content).  So the reply is polled
+from the message list until the assistant's turn reports `finish', then
+the session is deleted -- including on failure or timeout, so a
+throwaway session is never orphaned."
+  (let* ((backend (or (and (oref backend port) backend)
+                      ;; Called with a bare instance -- e.g. from
+                      ;; `agent-backend--query-backend', which builds one
+                      ;; from the preference with no server attached yet.
+                      (opencode-client--ensure-server)))
+         (session (alist-get 'id (opencode-client--request
+                                  'post "/api/session" nil backend)))
+         (deadline (+ (float-time) opencode-client-query-timeout))
+         (done nil))
+    (unless session
+      (user-error "opencode: could not create a session for the query"))
+    (unwind-protect
+        (progn
+          (opencode-client--request
+           'post (format "/api/session/%s/prompt" session)
+           `((prompt . ((text . ,prompt))))
+           backend)
+          (while (and (not done) (< (float-time) deadline))
+            ;; `sit-for' rather than `sleep-for': this runs from a
+            ;; command, and input should still get through while waiting.
+            (sit-for opencode-client-query-poll-interval)
+            (setq done (opencode-client--completed-answer session backend)))
+          (if done
+              (funcall callback done)
+            (message "opencode query timed out after %ss"
+                     opencode-client-query-timeout)))
+      (ignore-errors
+        (opencode-client--request
+         'delete (format "/api/session/%s" session) nil backend)))))
+
 ;;;; Prompting and interaction
 
 (defun opencode-client--transient-backend ()

--- a/test/agent-backend-test.el
+++ b/test/agent-backend-test.el
@@ -141,3 +141,113 @@
              (lambda (_backend text) (setq noted text))))
     (agent-backend-mention (make-instance 'agent-backend) "@foo.el:1")
     (check "default-mention-uses-add-note" noted "@foo.el:1")))
+
+;;;; Explaining a selection (issue #56)
+
+;; Not every backend can answer without a session, so the base class
+;; refuses rather than pretending.
+(check "default-query-refuses"
+       (condition-case nil
+           (progn (agent-backend-query (make-instance 'agent-backend) "hi" #'ignore)
+                  'no-error)
+         (user-error 'user-error))
+       'user-error)
+
+;; The default route prefers a visible conversation: "explain this" is
+;; usually part of the work already in that context.
+(check "default-explain-route" agent-backend-explain-route 'session-first)
+
+;; `--visible-conversation' answers the question the fallback needs --
+;; "is one on screen?" -- without signalling the way
+;; `--resolve-conversation' does, since a nil answer is actionable here.
+(check "no-visible-conversation-is-nil" (agent-backend--visible-conversation) nil)
+
+(let ((conv (get-buffer-create "*conv-visible*")))
+  (unwind-protect
+      (progn
+        (with-current-buffer conv
+          (setq-local agent-backend--instance (make-instance 'agent-backend)))
+        ;; Live but not displayed: still nil, which is what routes an
+        ;; explain to the one-shot path.
+        (check "hidden-conversation-is-not-visible"
+               (agent-backend--visible-conversation) nil)
+        (set-window-buffer (selected-window) conv)
+        (check "shown-conversation-is-visible"
+               (agent-backend--visible-conversation) conv))
+    (set-window-buffer (selected-window) (get-buffer-create "*scratch*"))
+    (kill-buffer conv)))
+
+;; Routing.  Each mode is checked for what it does *and* what it must not
+;; do: the point of `one-shot' is that it skips a session even when one
+;; is right there, so asserting only "it queried" would pass a
+;; still-broken implementation.
+(let ((conv (get-buffer-create "*conv-route*"))
+      queried sent)
+  (unwind-protect
+      (cl-letf (((symbol-function 'agent-backend-send)
+                 (lambda (_b prompt) (setq sent prompt)))
+                ((symbol-function 'agent-backend-query)
+                 (lambda (_b prompt _cb) (setq queried prompt)))
+                ((symbol-function 'agent-backend--query-backend)
+                 (lambda () (make-instance 'agent-backend)))
+                ;; The popup needs markdown-mode, absent in batch.  The
+                ;; command requires mcp-emacs-run, which would reinstate
+                ;; the real definitions over a stub set before it loads --
+                ;; so load it here first, then stub both the renderer and
+                ;; the guard that refuses without markdown-mode.
+                ((symbol-function 'mcp-emacs-popup-show)
+                 (progn (require 'mcp-emacs-run)
+                        (lambda (content &optional _kind) content)))
+                ((symbol-function 'mcp-emacs-run--ensure-markdown) #'ignore))
+        (with-current-buffer conv
+          (setq-local agent-backend--instance (make-instance 'agent-backend)))
+
+        ;; Nothing visible: session-first falls back to a one-shot query.
+        (setq queried nil sent nil)
+        (let ((agent-backend-explain-route 'session-first))
+          (with-temp-buffer
+            (insert "some code\n")
+            (goto-char (point-min))
+            (agent-backend-explain-selection)))
+        (check "session-first-without-session-queries" (and queried t) t)
+        (check "session-first-without-session-sends-no-turn" sent nil)
+
+        ;; Visible: session-first sends a real turn instead.
+        (set-window-buffer (selected-window) conv)
+        (setq queried nil sent nil)
+        (let ((agent-backend-explain-route 'session-first))
+          (with-temp-buffer
+            (insert "some code\n")
+            (goto-char (point-min))
+            (agent-backend-explain-selection)))
+        (check "session-first-with-session-sends-turn" (and sent t) t)
+        (check "session-first-with-session-does-not-query" queried nil)
+
+        ;; one-shot ignores the visible conversation entirely.
+        (setq queried nil sent nil)
+        (let ((agent-backend-explain-route 'one-shot))
+          (with-temp-buffer
+            (insert "some code\n")
+            (goto-char (point-min))
+            (agent-backend-explain-selection)))
+        (check "one-shot-queries-despite-session" (and queried t) t)
+        (check "one-shot-sends-no-turn" sent nil)
+
+        ;; The prompt is the template applied to the reference.
+        (check "explain-prompt-uses-template" queried "explain some code")
+
+        ;; session-only refuses instead of spending a separate call.
+        (set-window-buffer (selected-window) (get-buffer-create "*scratch*"))
+        (setq queried nil sent nil)
+        (check "session-only-without-session-refuses"
+               (let ((agent-backend-explain-route 'session-only))
+                 (with-temp-buffer
+                   (insert "some code\n")
+                   (goto-char (point-min))
+                   (condition-case nil
+                       (progn (agent-backend-explain-selection) 'no-error)
+                     (user-error 'user-error))))
+               'user-error)
+        (check "session-only-refusal-queries-nothing" queried nil))
+    (set-window-buffer (selected-window) (get-buffer-create "*scratch*"))
+    (kill-buffer conv)))


### PR DESCRIPTION
The other half of #56. `mcp-emacs-explain-selection-in-current-session` routed by session visibility — visible session gets a turn, otherwise a one-shot query into the popup — but only ever over the eat runner, so the verb was missing from the first-class path.

`agent-backend-explain-selection` adds it, with the routing behind `agent-backend-explain-route`: `session-first` (default) asks in a visible conversation and falls back to one-shot, `one-shot` always asks outside a session, `session-only` refuses rather than spending a separate call. Configurable because "explain this" usually *is* part of the current work — the model already has the context and the answer belongs in the log — but a dozen asides about unrelated code would push the real work out of that context, and where that line sits is a matter of taste.

Answering without a session is the new `agent-backend-query`. Claude shells out to `claude -p`. opencode has no one-shot mode at all, so it builds the effect: create a session, ask, collect, delete — deleting even on failure or timeout so nothing is orphaned. Its prompt endpoint only *acknowledges* the request, which I verified against a live server (it returns `admittedSeq` and a message id, no content), so the answer is polled from the message list until the assistant's turn reports `finish`. Backends that can do neither inherit a default that refuses by name instead of pretending.

Two notes on the seams. Resolution needed a non-signalling variant — `--resolve-conversation` errors when nothing is live, which is right for mention but wrong here, where "nothing visible" is a route rather than a failure. And `mcp-emacs-run--query-headless` is deliberately **not** delegated to the new method, unlike the reference builder was: it honours `mcp-emacs-run-executable` and the runner's own project root, so folding it in would silently move anyone who configured only those onto `claude-client-executable`.

Closes #56