### PR TITLE
Run tests in a separate Emacs, with a test report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,48 +19,16 @@ jobs:
         with:
           version: '29.4'
 
+      # Everything below runs through bin/test-emacs.sh, the same entry point
+      # used locally.  CI and the local loop drifting apart is how a suite ends
+      # up green in one and broken in the other; the script owns dependency
+      # install, the isolated init directory, the glob and the pass/fail
+      # contract, so there is only one of each.
       - name: Install dependencies
-        run: |
-          emacs --batch \
-            --eval "(require 'package)" \
-            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\"))" \
-            --eval "(package-initialize)" \
-            --eval "(package-refresh-contents)" \
-            --eval "(package-install 'web-server)" \
-            --eval "(package-install 'websocket)"
+        run: bin/test-emacs.sh --deps
 
-      # Globbed rather than listed: the explicit lists silently fell behind as
-      # files were added, so claude-client.el, mcp-emacs-run.el and
-      # opencode-client.el were never compiled or tested here at all.
       - name: Byte-compile
-        run: |
-          emacs --batch \
-            --eval "(require 'package)" \
-            --eval "(package-initialize)" \
-            -L elisp \
-            -f batch-byte-compile \
-            elisp/*.el
+        run: bin/test-emacs.sh --compile
 
       - name: Run tests
-        run: |
-          status=0
-          for t in test/*.el; do
-            echo "== $t =="
-            # A suite that dies before printing anything used to pass, because
-            # the check only grepped for FAIL.  Require the run to exit clean
-            # AND to have produced at least one PASS.
-            if emacs --batch \
-                 --eval "(require 'package)" \
-                 --eval "(package-initialize)" \
-                 -L elisp -l "$t" 2>&1 | tee /tmp/out.txt; then
-              :
-            else
-              echo "ERRORED: $t"; status=1; continue
-            fi
-            if grep -q '^FAIL' /tmp/out.txt; then
-              echo "TESTS FAILED in $t"; status=1
-            elif ! grep -q '^PASS' /tmp/out.txt; then
-              echo "NO ASSERTIONS RAN in $t"; status=1
-            fi
-          done
-          exit $status
+        run: bin/test-emacs.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Byte-compile
         run: bin/test-emacs.sh --compile
 
+      # `--quiet': the per-suite report is the useful artefact in a log you
+      # only read when it is red, and a failing suite still gets its full
+      # output replayed.
       - name: Run tests
-        run: bin/test-emacs.sh
+        run: bin/test-emacs.sh --quiet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,12 @@ jobs:
       # output replayed.
       - name: Run tests
         run: bin/test-emacs.sh --quiet
+
+      # `always()': the report is most worth having on the run that failed.
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: .test-emacs/report.xml
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # Build artifacts (unrelated JS tooling may land in the repo root)
 dist/
 node_modules/
+
+# Packages and runtime state of the isolated test Emacs (bin/test-emacs.sh)
+.test-emacs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,40 @@ deliberately in a separate pass, so don't hand-edit it alongside code changes.
 
 ## Testing
 
-1. Start the MCP server in the running Emacs: `M-x mcp-emacs-server-start`, or
-   `emacsclient --eval '(mcp-emacs-server-ensure)'` (returns the endpoint URL).
-2. Exercise it with `curl`, e.g.
-   `curl -s -X POST http://localhost:8765/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`.
-3. Reload after edits via `emacsclient --eval` `load-file` +
-   `mcp-emacs-server-stop`/`-start`.
+**Never test in the working Emacs.** Fixtures pop windows, ediffs and
+`*claude-client*` buffers into whatever is being edited, and anything that
+wedges the instance takes the working session with it. Everything goes through
+`bin/test-emacs.sh`, which runs in an Emacs of its own — its own init directory
+(`test/init/`, no Doom, no user config), its own `emacsclient` socket
+(`mcp-emacs-test`), the MCP server on **8775** instead of 8765, and packages
+plus runtime state under the git-ignored `.test-emacs/`.
+
+```sh
+bin/test-emacs.sh                     # every suite, batch (what CI runs)
+bin/test-emacs.sh test/foo-test.el    # one or more suites
+bin/test-emacs.sh --compile           # byte-compile elisp/
+bin/test-emacs.sh --compile --strict  # ... warnings fatal
+bin/test-emacs.sh --daemon            # leave a test daemon up
+bin/test-emacs.sh --eval FORM         # eval in the test daemon
+bin/test-emacs.sh --gui               # windowed test instance
+bin/test-emacs.sh --stop
+```
+
+A suite passes only if it exits clean *and* prints at least one `PASS`; a suite
+that dies before asserting anything fails. CI calls the same script, so the
+local loop and CI cannot drift.
+
+For end-to-end pokes at the HTTP surface, start the server inside the test
+instance and curl its port:
+
+```sh
+bin/test-emacs.sh --eval '(progn (require (quote mcp-emacs-server)) (mcp-emacs-server-ensure))'
+curl -s -X POST http://localhost:8775/mcp -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+Reload after edits with `bin/test-emacs.sh --eval '(load-file "elisp/....el")'`,
+or just `--stop` and start fresh.
 
 ## Future Enhancements
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,8 @@ wedges the instance takes the working session with it. Everything goes through
 plus runtime state under the git-ignored `.test-emacs/`.
 
 ```sh
-bin/test-emacs.sh                     # every suite, batch (what CI runs)
+bin/test-emacs.sh                     # every suite, batch
+bin/test-emacs.sh --quiet             # per-suite report only (what CI runs)
 bin/test-emacs.sh test/foo-test.el    # one or more suites
 bin/test-emacs.sh --compile           # byte-compile elisp/
 bin/test-emacs.sh --compile --strict  # ... warnings fatal
@@ -74,9 +75,13 @@ bin/test-emacs.sh --gui               # windowed test instance
 bin/test-emacs.sh --stop
 ```
 
-A suite passes only if it exits clean *and* prints at least one `PASS`; a suite
-that dies before asserting anything fails. CI calls the same script, so the
-local loop and CI cannot drift.
+Every run ends with a per-suite report (`N pass`, `N fail`, verdict) and a
+totals line. A suite passes only if it exits clean *and* prints at least one
+`PASS`; one that dies before asserting anything is `ERRORED`/`NO ASSERTIONS`,
+not a pass. The suites don't use `ert-run-tests-batch` — each has its own
+`check` that princ's `PASS name`/`FAIL name`, and the script tallies those, so
+a new suite must keep that convention to be counted. CI calls the same script,
+so the local loop and CI cannot drift.
 
 For end-to-end pokes at the HTTP surface, start the server inside the test
 instance and curl its port:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,13 @@ it exits clean *and* prints at least one `PASS`; one that dies before asserting
 anything is `ERRORED`/`NO ASSERTIONS`, not a pass. CI calls the same script, so
 the local loop and CI cannot drift.
 
+What gets tested is the **current directory's git work tree**, not wherever the
+script lives, so running the main clone's copy from inside a worktree tests
+that worktree — it used to compile and test the main clone instead, silently,
+and still report green. A worktree run prints which tree it is testing and gets
+its own daemon socket and MCP port, derived from the path so they are stable
+across runs; packages stay shared with the main clone.
+
 ### Writing a suite
 
 These are batch scripts, not `ert` suites: loading the file runs it. The shared

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,14 +76,40 @@ bin/test-emacs.sh --stop
 ```
 
 Every run ends with a report: one line per suite (`N pass`, `N fail`, verdict)
-with every test name under it, a totals line, and the same results as JUnit XML
-in `.test-emacs/report.xml`. A suite passes only if it exits clean *and* prints
-at least one `PASS`; one that dies before asserting anything is
-`ERRORED`/`NO ASSERTIONS`, not a pass. The suites don't use
-`ert-run-tests-batch` — each has its own `check` that princ's `PASS name`/`FAIL
-name`, and the script tallies those, so a new suite must keep that convention
-to be listed and counted. CI calls the same script, so the local loop and CI
-cannot drift.
+with every expectation under it grouped by `describe`, a totals line, and the
+same results as JUnit XML in `.test-emacs/report.xml`. A suite passes only if
+it exits clean *and* prints at least one `PASS`; one that dies before asserting
+anything is `ERRORED`/`NO ASSERTIONS`, not a pass. CI calls the same script, so
+the local loop and CI cannot drift.
+
+### Writing a suite
+
+These are batch scripts, not `ert` suites: loading the file runs it. The shared
+vocabulary is `test/test-helper.el` — require it, don't write another local
+`check` (there were three drifted copies before it existed).
+
+```elisp
+(add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
+
+(describe "orgspec-agenda-install"
+  (it "keeps a single entry when installed twice"
+    (check (length org-agenda-custom-commands) 1)))
+```
+
+- `check` takes `(GOT WANT &optional LABEL)` and reports under the enclosing
+  `it`. Pass `LABEL` only when a loop emits several assertions, since one `it`
+  cannot name several results.
+- `check-that` for the `(check (and x t) t)` shape.
+- The `it` string completes "it …": state the behaviour being pinned down, not
+  the mechanics. It replaces the comment that used to sit above the assertion.
+- `describe`/`it` splice their body in place, so they go *inside* `let`,
+  `cl-letf` and `with-temp-buffer` fixtures — they group, they don't scope.
+- An error inside `it` fails that expectation instead of killing the suite.
+- End with `(test-helper-summary)`.
+- Report lines come from those `PASS`/`FAIL`/`DESCRIBE` prints, so a suite that
+  bypasses `check` isn't listed or counted.
 
 For end-to-end pokes at the HTTP surface, start the server inside the test
 instance and curl its port:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,13 +75,15 @@ bin/test-emacs.sh --gui               # windowed test instance
 bin/test-emacs.sh --stop
 ```
 
-Every run ends with a per-suite report (`N pass`, `N fail`, verdict) and a
-totals line. A suite passes only if it exits clean *and* prints at least one
-`PASS`; one that dies before asserting anything is `ERRORED`/`NO ASSERTIONS`,
-not a pass. The suites don't use `ert-run-tests-batch` — each has its own
-`check` that princ's `PASS name`/`FAIL name`, and the script tallies those, so
-a new suite must keep that convention to be counted. CI calls the same script,
-so the local loop and CI cannot drift.
+Every run ends with a report: one line per suite (`N pass`, `N fail`, verdict)
+with every test name under it, a totals line, and the same results as JUnit XML
+in `.test-emacs/report.xml`. A suite passes only if it exits clean *and* prints
+at least one `PASS`; one that dies before asserting anything is
+`ERRORED`/`NO ASSERTIONS`, not a pass. The suites don't use
+`ert-run-tests-batch` — each has its own `check` that princ's `PASS name`/`FAIL
+name`, and the script tallies those, so a new suite must keep that convention
+to be listed and counted. CI calls the same script, so the local loop and CI
+cannot drift.
 
 For end-to-end pokes at the HTTP surface, start the server inside the test
 instance and curl its port:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,10 @@ vocabulary is `test/test-helper.el` — require it, don't write another local
 - An error inside `it` fails that expectation instead of killing the suite.
 - End with `(test-helper-summary)`.
 - Report lines come from those `PASS`/`FAIL`/`DESCRIBE` prints, so a suite that
-  bypasses `check` isn't listed or counted.
+  bypasses `check` isn't listed or counted. Keep printing the words: the report
+  swaps in ✅/❌/📋 when rendering, and the counting, the exit status and CI's
+  verdict all read the words. `MCP_EMACS_TEST_ASCII=1` or `NO_COLOR` renders
+  them as text.
 
 For end-to-end pokes at the HTTP surface, start the server inside the test
 instance and curl its port:

--- a/README.md
+++ b/README.md
@@ -152,17 +152,20 @@ bin/test-emacs.sh --gui               # windowed test instance
 bin/test-emacs.sh --stop
 ```
 
-Every run ends with a report listing each suite and every test in it, so you
-can see what exists as well as what passed:
+Every run ends with a report listing each suite and every expectation in it, so
+you can see what exists as well as what passed:
 
 ```
 == report ==
 
 orgspec-agenda-test.el                     9 pass     0 fail  ok
-  PASS files-count
-  PASS files-active-only
-  PASS install-one
-  ...
+  orgspec-agenda-files
+    PASS collects one file per active change
+    PASS excludes changes under archive/
+  orgspec-agenda-install
+    PASS registers exactly one agenda command
+    PASS keeps a single entry when installed twice
+    ...
 
 claude-client-test.el                    224 pass     0 fail  ok
   ...
@@ -170,6 +173,18 @@ claude-client-test.el                    224 pass     0 fail  ok
 -- 19 suites, 700 assertions, 0 failed, 0 suites not ok
 -- JUnit XML: .test-emacs/report.xml
 ```
+
+The suites are batch scripts rather than `ert` suites — loading a file runs it —
+and they share one `describe`/`it` vocabulary from `test/test-helper.el`:
+
+```elisp
+(describe "orgspec-agenda-install"
+  (it "keeps a single entry when installed twice"
+    (check (length org-agenda-custom-commands) 1)))
+```
+
+so each report line states the behaviour being pinned down rather than naming a
+call site. [`AGENTS.md`](AGENTS.md) has the details for writing one.
 
 `--quiet` prints only the report, and replays the full output of any suite that
 is not `ok`. A suite counts as passing only if it exits clean *and* prints at

--- a/README.md
+++ b/README.md
@@ -152,20 +152,32 @@ bin/test-emacs.sh --gui               # windowed test instance
 bin/test-emacs.sh --stop
 ```
 
-Every run ends with a per-suite report:
+Every run ends with a report listing each suite and every test in it, so you
+can see what exists as well as what passed:
 
 ```
 == report ==
-agent-backend-test.el                       31 pass     0 fail  ok
-claude-client-test.el                      224 pass     0 fail  ok
-...
+
+orgspec-agenda-test.el                     9 pass     0 fail  ok
+  PASS files-count
+  PASS files-active-only
+  PASS install-one
+  ...
+
+claude-client-test.el                    224 pass     0 fail  ok
+  ...
+
 -- 19 suites, 700 assertions, 0 failed, 0 suites not ok
+-- JUnit XML: .test-emacs/report.xml
 ```
 
-`--quiet` prints only that, and replays the full output of any suite that is
-not `ok`. A suite counts as passing only if it exits clean *and* prints at
+`--quiet` prints only the report, and replays the full output of any suite that
+is not `ok`. A suite counts as passing only if it exits clean *and* prints at
 least one `PASS`, so one that dies before asserting anything is reported as
 `ERRORED` or `NO ASSERTIONS` rather than passing quietly.
+
+The same results are written as JUnit XML to `.test-emacs/report.xml`, which CI
+uploads as an artifact and any JUnit viewer can render per test.
 
 The first run installs `web-server`, `websocket` and `plz` into
 `.test-emacs/`; later runs skip the archive refresh.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ It started as an MCP server and grew into a small toolkit. See
 
 ## What's in here
 
-| Part | What it gives you | Docs |
-|---|---|---|
-| **MCP server** | 40+ tools letting any MCP client read and edit your live Emacs: buffers, selection, xref, tree-sitter, diagnostics, project, Org | [docs/tools.md](docs/tools.md) |
-| **Agent clients** | Run Claude Code or opencode *inside* Emacs — terminal-free in a normal buffer, or as a TUI — plus diff review of native edits | [docs/clients.md](docs/clients.md) |
-| **orgspec** | An org-native spec workflow: describe a change, implement it, fold it into an accumulating source of truth | [docs/orgspec.md](docs/orgspec.md) |
-| **Claude Code plugin** | Ships the MCP server, five skills, and a slash command as an installable plugin | [PLUGIN.md](PLUGIN.md) |
+| Part                   | What it gives you                                                                                                                | Docs                               |
+|------------------------|----------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| **MCP server**         | 40+ tools letting any MCP client read and edit your live Emacs: buffers, selection, xref, tree-sitter, diagnostics, project, Org | [docs/tools.md](docs/tools.md)     |
+| **Agent clients**      | Run Claude Code or opencode *inside* Emacs — terminal-free in a normal buffer, or as a TUI — plus diff review of native edits    | [docs/clients.md](docs/clients.md) |
+| **orgspec**            | An org-native spec workflow: describe a change, implement it, fold it into an accumulating source of truth                       | [docs/orgspec.md](docs/orgspec.md) |
+| **Claude Code plugin** | Ships the MCP server, five skills, and a slash command as an installable plugin                                                  | [PLUGIN.md](PLUGIN.md)             |
 
 The server runs **inside your live Emacs session** and speaks MCP over HTTP.
 There is no separate process and no `emacsclient` round-trip per call: tool calls
@@ -129,6 +129,47 @@ The source PlantUML definition lives in `docs/architecture.puml`. Re-render with
   (also as [PDF](docs/reference.pdf)), explaining the Elisp features it leans on.
 - [`docs/VISION.md`](docs/VISION.md) — why this exists and where it is going.
 - [`AGENTS.md`](AGENTS.md) — conventions and gotchas for changing the code.
+
+## Tests
+
+Everything runs in a separate Emacs, never in the one you are working in.
+Fixtures pop windows, ediffs and `*claude-client*` buffers, and a suite that
+wedges its instance should not cost you your session.
+`bin/test-emacs.sh` gives the tests their own init directory (`test/init/`, no
+personal config), their own `emacsclient` socket, the MCP server on port 8775
+instead of 8765, and packages plus runtime state under a git-ignored
+`.test-emacs/`.
+
+```sh
+bin/test-emacs.sh                     # every suite in batch
+bin/test-emacs.sh --quiet             # report only — what CI runs
+bin/test-emacs.sh test/foo-test.el    # one or more suites
+bin/test-emacs.sh --compile           # byte-compile elisp/
+bin/test-emacs.sh --compile --strict  # ... treating warnings as errors
+bin/test-emacs.sh --daemon            # leave a test daemon up
+bin/test-emacs.sh --eval FORM         # eval FORM in the test daemon
+bin/test-emacs.sh --gui               # windowed test instance
+bin/test-emacs.sh --stop
+```
+
+Every run ends with a per-suite report:
+
+```
+== report ==
+agent-backend-test.el                       31 pass     0 fail  ok
+claude-client-test.el                      224 pass     0 fail  ok
+...
+-- 19 suites, 700 assertions, 0 failed, 0 suites not ok
+```
+
+`--quiet` prints only that, and replays the full output of any suite that is
+not `ok`. A suite counts as passing only if it exits clean *and* prints at
+least one `PASS`, so one that dies before asserting anything is reported as
+`ERRORED` or `NO ASSERTIONS` rather than passing quietly.
+
+The first run installs `web-server`, `websocket` and `plz` into
+`.test-emacs/`; later runs skip the archive refresh.
+`bin/test-emacs.sh --help` lists everything.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -158,21 +158,27 @@ you can see what exists as well as what passed:
 ```
 == report ==
 
-orgspec-agenda-test.el                     9 pass     0 fail  ok
-  orgspec-agenda-files
-    PASS collects one file per active change
-    PASS excludes changes under archive/
-  orgspec-agenda-install
-    PASS registers exactly one agenda command
-    PASS keeps a single entry when installed twice
+orgspec-agenda-test.el                     9 pass     0 fail  ✅
+  📋 orgspec-agenda-files
+    ✅ collects one file per active change
+    ✅ excludes changes under archive/
+  📋 orgspec-agenda-install
+    ✅ registers exactly one agenda command
+    ✅ keeps a single entry when installed twice
     ...
 
-claude-client-test.el                    224 pass     0 fail  ok
+claude-client-test.el                    224 pass     0 fail  ✅
   ...
 
--- 19 suites, 700 assertions, 0 failed, 0 suites not ok
+✅ 19 suites, 700 assertions, 0 failed, 0 suites not ok
 -- JUnit XML: .test-emacs/report.xml
 ```
+
+A failure shows as `❌ <expectation>: got=… want=…`, and a suite that errored or
+asserted nothing keeps the louder `ERRORED` / `NO ASSERTIONS` wording. Set
+`MCP_EMACS_TEST_ASCII=1` (or `NO_COLOR`) for plain `PASS`/`FAIL` text. The
+JUnit XML is unaffected either way — the glyphs are applied when the report is
+rendered, not by the suites, so `PASS <name>` stays the format they print.
 
 The suites are batch scripts rather than `ert` suites — loading a file runs it —
 and they share one `describe`/`it` vocabulary from `test/test-helper.el`:

--- a/bin/test-emacs.sh
+++ b/bin/test-emacs.sh
@@ -88,6 +88,23 @@ ensure_deps() {
   }
 }
 
+# Test names are free text, and a `check' label containing & or < would
+# otherwise produce a JUnit file no parser accepts.
+#
+# The backslashes are load-bearing: since bash 5.2 an unescaped `&' in the
+# replacement half of ${var//pat/repl} means "the text that matched", so a
+# plain `&lt;' silently expanded to `<lt;' and produced invalid XML.
+# Ampersand is substituted first, or the `&' of each later entity would be
+# escaped again.
+xml_escape() {
+  local s="$1"
+  s="${s//&/\&amp;}"
+  s="${s//</\&lt;}"
+  s="${s//>/\&gt;}"
+  s="${s//\"/\&quot;}"
+  printf '%s' "$s"
+}
+
 # The suites do not use `ert-run-tests-batch'; each has its own `check' that
 # princ's "PASS name" / "FAIL name".  So the report is assembled here, from
 # those lines plus each run's exit status -- there is no ert summary to read.
@@ -105,7 +122,13 @@ run_suites() {
   report="$(mktemp)"
   trap 'rm -f "$out" "$report"' RETURN
 
-  local total_pass=0 total_fail=0 bad_suites=0
+  mkdir -p "$state_dir"
+  local junit="$state_dir/report.xml"
+  : >"$junit"
+
+  # xml_* totals count the synthetic errored/empty cases; the human totals
+  # deliberately do not, so "700 assertions" stays the number of real checks.
+  local total_pass=0 total_fail=0 bad_suites=0 xml_total=0 xml_total_fail=0
   for t in "${suites[@]}"; do
     [ "$quiet" = 1 ] || echo "== $t =="
     local exit_ok=1
@@ -145,15 +168,78 @@ run_suites() {
       [ "$quiet" = 1 ] && { echo "== $t ($verdict) =="; cat "$out"; }
     fi
 
-    printf '%-40s %5s pass %5s fail  %s\n' \
+    # Text report: the suite line, then every test name under it.  Listing
+    # the names is the point -- counts alone do not tell you which tests
+    # exist, so a test that silently stops being run looks like a pass.
+    local name
+    printf '\n%-38s %5s pass %5s fail  %s\n' \
            "$(basename "$t")" "$pass" "$fail" "$verdict" >>"$report"
+    while IFS= read -r line; do
+      printf '  %s\n' "$line" >>"$report"
+    done < <(grep -E '^(PASS|FAIL) ' "$out")
+    [ "$verdict" = ERRORED ] && printf '  (suite errored before finishing)\n' >>"$report"
+    [ "$verdict" = "NO ASSERTIONS" ] && printf '  (no tests ran)\n' >>"$report"
+
+    # JUnit: one testsuite per file, one testcase per check.  This is what
+    # lets CI and Emacs-side viewers render the per-test result natively
+    # instead of re-parsing the log.
+    # An errored or empty suite gets one synthetic testcase below, so it has
+    # to be counted here too -- a testsuite claiming tests="0" while holding
+    # a case renders as empty in viewers that trust the attribute.
+    local xml_tests=$((pass + fail)) xml_failures="$fail"
+    case "$verdict" in
+      ERRORED|"NO ASSERTIONS")
+        xml_tests=$((xml_tests + 1))
+        xml_failures=$((xml_failures + 1))
+        ;;
+    esac
+    xml_total=$((xml_total + xml_tests))
+    xml_total_fail=$((xml_total_fail + xml_failures))
+    {
+      printf '  <testsuite name="%s" tests="%d" failures="%d">\n' \
+             "$(xml_escape "$(basename "$t" .el)")" "$xml_tests" "$xml_failures"
+      while IFS= read -r line; do
+        name="$(xml_escape "${line#* }")"
+        if [ "${line%% *}" = PASS ]; then
+          printf '    <testcase name="%s"/>\n' "$name"
+        else
+          printf '    <testcase name="%s"><failure message="check failed"/></testcase>\n' "$name"
+        fi
+      done < <(grep -E '^(PASS|FAIL) ' "$out")
+      # An errored or empty suite has no testcases to report, so carry the
+      # verdict on the suite element instead -- otherwise it reads as green.
+      if [ "$verdict" = ERRORED ]; then
+        printf '    <testcase name="%s"><error message="suite errored"><![CDATA[\n' \
+               "$(xml_escape "$(basename "$t")")"
+        sed 's/]]>/]] >/g' "$out"
+        printf ']]></error></testcase>\n'
+      elif [ "$verdict" = "NO ASSERTIONS" ]; then
+        printf '    <testcase name="%s"><failure message="no assertions ran"/></testcase>\n' \
+               "$(xml_escape "$(basename "$t")")"
+      fi
+      printf '  </testsuite>\n'
+    } >>"$junit"
   done
+
+  # Written last: the totals belong on the root element, and they are not
+  # known until every suite has run.
+  local xml_body
+  xml_body="$(cat "$junit")"
+  {
+    printf '<?xml version="1.0" encoding="UTF-8"?>\n'
+    printf '<testsuites tests="%d" failures="%d">\n' \
+           "$xml_total" "$xml_total_fail"
+    printf '%s\n' "$xml_body"
+    printf '</testsuites>\n'
+  } >"$junit"
 
   echo
   echo "== report =="
   cat "$report"
+  echo
   printf -- '-- %d suites, %d assertions, %d failed, %d suites not ok\n' \
          "${#suites[@]}" "$((total_pass + total_fail))" "$total_fail" "$bad_suites"
+  printf -- '-- JUnit XML: %s\n' "${junit#"$root"/}"
   return $status
 }
 

--- a/bin/test-emacs.sh
+++ b/bin/test-emacs.sh
@@ -174,9 +174,15 @@ run_suites() {
     local name
     printf '\n%-38s %5s pass %5s fail  %s\n' \
            "$(basename "$t")" "$pass" "$fail" "$verdict" >>"$report"
+    # DESCRIBE lines are group headers from test-helper's `describe'; the
+    # expectations under one get indented beneath it.  A suite not yet
+    # converted emits no DESCRIBE at all and simply reads as a flat list.
     while IFS= read -r line; do
-      printf '  %s\n' "$line" >>"$report"
-    done < <(grep -E '^(PASS|FAIL) ' "$out")
+      case "$line" in
+        DESCRIBE\ *) printf '  %s\n' "${line#DESCRIBE }" >>"$report" ;;
+        *)           printf '    %s\n' "$line" >>"$report" ;;
+      esac
+    done < <(grep -E '^(PASS|FAIL|DESCRIBE) ' "$out")
     [ "$verdict" = ERRORED ] && printf '  (suite errored before finishing)\n' >>"$report"
     [ "$verdict" = "NO ASSERTIONS" ] && printf '  (no tests ran)\n' >>"$report"
 
@@ -198,14 +204,22 @@ run_suites() {
     {
       printf '  <testsuite name="%s" tests="%d" failures="%d">\n' \
              "$(xml_escape "$(basename "$t" .el)")" "$xml_tests" "$xml_failures"
+      # A `describe' becomes the testcase classname, which is how JUnit
+      # viewers show grouping -- the same nesting the text report indents.
+      local classname=""
       while IFS= read -r line; do
+        if [ "${line%% *}" = DESCRIBE ]; then
+          classname="$(xml_escape "${line#DESCRIBE }")"
+          continue
+        fi
         name="$(xml_escape "${line#* }")"
         if [ "${line%% *}" = PASS ]; then
-          printf '    <testcase name="%s"/>\n' "$name"
+          printf '    <testcase classname="%s" name="%s"/>\n' "$classname" "$name"
         else
-          printf '    <testcase name="%s"><failure message="check failed"/></testcase>\n' "$name"
+          printf '    <testcase classname="%s" name="%s"><failure message="check failed"/></testcase>\n' \
+                 "$classname" "$name"
         fi
-      done < <(grep -E '^(PASS|FAIL) ' "$out")
+      done < <(grep -E '^(PASS|FAIL|DESCRIBE) ' "$out")
       # An errored or empty suite has no testcases to report, so carry the
       # verdict on the suite element instead -- otherwise it reads as green.
       if [ "$verdict" = ERRORED ]; then

--- a/bin/test-emacs.sh
+++ b/bin/test-emacs.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Run the suites -- and interactive experiments -- in an Emacs of their own.
+#
+# Nothing here needs the working Emacs, and everything here is better off
+# without it: fixtures that pop windows, ediffs and *claude-client* buffers
+# stop landing in the middle of a real editing session, and a suite that
+# wedges or kills its instance costs nothing but that instance.
+#
+# Isolation is by state, not just by process.  A second Emacs sharing the
+# working one's MCP port or emacsclient socket is not isolated at all, so the
+# test instance gets:
+#
+#   - its own init directory (test/init/ -- no Doom, no user config)
+#   - its own emacsclient socket name (mcp-emacs-test)
+#   - the MCP HTTP server on 8775 rather than 8765
+#   - a package dir under .test-emacs/ shared across runs, so deps are
+#     installed once and ~/.emacs.d is never touched
+#
+# Modes:
+#   bin/test-emacs.sh                     run every suite in batch (like CI)
+#   bin/test-emacs.sh test/foo-test.el    run just these suites
+#   bin/test-emacs.sh --compile           byte-compile elisp/ (warnings shown)
+#   bin/test-emacs.sh --compile --strict  ... and treat warnings as errors
+#   bin/test-emacs.sh --daemon            start the test daemon and leave it up
+#   bin/test-emacs.sh --gui               start a windowed test Emacs
+#   bin/test-emacs.sh --eval FORM         eval FORM in the test daemon
+#   bin/test-emacs.sh --stop              kill the test daemon
+#   bin/test-emacs.sh --deps              install/refresh deps only
+
+set -uo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+EMACS="${EMACS:-emacs}"
+EMACSCLIENT="${EMACSCLIENT:-emacsclient}"
+
+server_name="mcp-emacs-test"
+state_dir="$root/.test-emacs"
+package_dir="$state_dir/package"
+home_dir="$state_dir/home"
+init_file="$root/test/init/init.el"
+
+export MCP_EMACS_TEST_REPO="$root"
+export MCP_EMACS_TEST_PACKAGE_DIR="$package_dir"
+export MCP_EMACS_TEST_PORT="${MCP_EMACS_TEST_PORT:-8775}"
+
+# plz is an optional runtime dependency of opencode-client, but installing it
+# here is what lets that file compile and be tested with plz present rather
+# than only through its soft-require fallback.
+deps=(web-server websocket plz)
+
+# `--init-directory' (Emacs 29+) is what keeps the personal config out; there
+# is no supported way to do this on 28 short of clobbering HOME.
+#
+# It points at the git-ignored state dir, not at test/init/ where init.el
+# actually lives, because `native-comp-eln-load-path' is derived from
+# `user-emacs-directory' at startup -- before any init file runs.  Pointing it
+# at the tracked directory made every daemon dump an eln-cache/ into the repo
+# no matter what init.el set afterwards.  So: state dir for the location,
+# explicit `-l' for the config.  `--batch' implies `-q' anyway, so the
+# explicit load is required there regardless.
+emacs_batch() {
+  mkdir -p "$home_dir"
+  "$EMACS" --batch --init-directory "$home_dir" -l "$init_file" "$@"
+}
+
+ensure_deps() {
+  local missing=()
+  for d in "${deps[@]}"; do
+    # Presence check only -- a versioned dir named after the package is enough
+    # to skip the (slow) MELPA refresh; package.el makes the real decision.
+    compgen -G "$package_dir/$d-*" >/dev/null || missing+=("$d")
+  done
+  if [ ${#missing[@]} -eq 0 ]; then
+    return 0
+  fi
+  mkdir -p "$package_dir"
+  echo "== installing deps: ${missing[*]}"
+  local forms=()
+  for d in "${missing[@]}"; do
+    forms+=(--eval "(unless (package-installed-p '$d) (package-install '$d))")
+  done
+  emacs_batch --eval '(package-refresh-contents)' "${forms[@]}" || {
+    echo "error: dependency install failed" >&2
+    exit 1
+  }
+}
+
+run_suites() {
+  local suites=("$@")
+  if [ ${#suites[@]} -eq 0 ]; then
+    # Globbed rather than listed for the same reason CI globs: an explicit
+    # list silently falls behind as suites are added.
+    suites=(test/*-test.el)
+  fi
+  local status=0 out
+  out="$(mktemp)"
+  trap 'rm -f "$out"' RETURN
+  for t in "${suites[@]}"; do
+    echo "== $t =="
+    if emacs_batch -l "$t" 2>&1 | tee "$out"; then
+      :
+    else
+      echo "ERRORED: $t"
+      status=1
+      continue
+    fi
+    # A suite that dies before printing anything must not pass, so require a
+    # clean exit AND at least one PASS -- same contract as CI.
+    if grep -q '^FAIL' "$out"; then
+      echo "TESTS FAILED in $t"
+      status=1
+    elif ! grep -q '^PASS' "$out"; then
+      echo "NO ASSERTIONS RAN in $t"
+      status=1
+    fi
+  done
+  return $status
+}
+
+daemon_running() {
+  "$EMACSCLIENT" -s "$server_name" --eval t >/dev/null 2>&1
+}
+
+start_daemon() {
+  if daemon_running; then
+    echo "test daemon already running (socket: $server_name)"
+    return 0
+  fi
+  ensure_deps
+  mkdir -p "$home_dir"
+  # `-l' rather than relying on the init directory to hold init.el: see
+  # `emacs_batch' for why the two are deliberately different places.
+  "$EMACS" --daemon="$server_name" \
+           --init-directory "$home_dir" -l "$init_file" || {
+    echo "error: test daemon failed to start" >&2
+    exit 1
+  }
+  echo "test daemon up: emacsclient -s $server_name"
+  echo "  MCP port would be $MCP_EMACS_TEST_PORT (start with --eval '(mcp-emacs-server-ensure)')"
+}
+
+case "${1:-}" in
+  --deps)
+    ensure_deps
+    ;;
+  --compile)
+    shift
+    ensure_deps
+    # Warnings stay non-fatal by default, matching CI: the tree carries
+    # pre-existing Emacs-31 obsoletions and over-80-column docstrings, so
+    # `-Werror' here would fail every run for reasons unrelated to the change
+    # under test.  `--compile --strict' opts in when cleaning those up.
+    strict=()
+    [ "${1:-}" = "--strict" ] && strict=(--eval '(setq byte-compile-error-on-warn t)')
+    emacs_batch "${strict[@]}" -f batch-byte-compile elisp/*.el
+    ;;
+  --daemon)
+    start_daemon
+    ;;
+  --gui)
+    ensure_deps
+    # Not exec'd through the daemon: a windowed instance is for watching a
+    # fixture misbehave, and killing the frame should end the instance.
+    mkdir -p "$home_dir"
+    "$EMACS" --init-directory "$home_dir" -l "$init_file" "${@:2}" &
+    echo "test GUI Emacs started (pid $!)"
+    ;;
+  --eval)
+    shift
+    [ $# -gt 0 ] || { echo "usage: bin/test-emacs.sh --eval FORM" >&2; exit 2; }
+    start_daemon >/dev/null
+    "$EMACSCLIENT" -s "$server_name" --eval "$*"
+    ;;
+  --stop)
+    if daemon_running; then
+      "$EMACSCLIENT" -s "$server_name" --eval '(kill-emacs)' >/dev/null 2>&1
+      echo "test daemon stopped"
+    else
+      echo "no test daemon running"
+    fi
+    ;;
+  -h|--help)
+    # Print the header comment: everything from line 2 up to the blank line
+    # that ends it, so adding a mode to the list keeps --help in sync.
+    sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+    ;;
+  --*)
+    echo "error: unknown option '$1'" >&2
+    exit 2
+    ;;
+  *)
+    ensure_deps
+    run_suites "$@"
+    ;;
+esac

--- a/bin/test-emacs.sh
+++ b/bin/test-emacs.sh
@@ -17,8 +17,9 @@
 #     installed once and ~/.emacs.d is never touched
 #
 # Modes:
-#   bin/test-emacs.sh                     run every suite in batch (like CI)
+#   bin/test-emacs.sh                     run every suite in batch
 #   bin/test-emacs.sh test/foo-test.el    run just these suites
+#   bin/test-emacs.sh --quiet [SUITE...]  report only, logs on failure (CI)
 #   bin/test-emacs.sh --compile           byte-compile elisp/ (warnings shown)
 #   bin/test-emacs.sh --compile --strict  ... and treat warnings as errors
 #   bin/test-emacs.sh --daemon            start the test daemon and leave it up
@@ -87,35 +88,72 @@ ensure_deps() {
   }
 }
 
+# The suites do not use `ert-run-tests-batch'; each has its own `check' that
+# princ's "PASS name" / "FAIL name".  So the report is assembled here, from
+# those lines plus each run's exit status -- there is no ert summary to read.
 run_suites() {
+  local quiet="$1"; shift
   local suites=("$@")
   if [ ${#suites[@]} -eq 0 ]; then
     # Globbed rather than listed for the same reason CI globs: an explicit
     # list silently falls behind as suites are added.
     suites=(test/*-test.el)
   fi
-  local status=0 out
+
+  local status=0 out report
   out="$(mktemp)"
-  trap 'rm -f "$out"' RETURN
+  report="$(mktemp)"
+  trap 'rm -f "$out" "$report"' RETURN
+
+  local total_pass=0 total_fail=0 bad_suites=0
   for t in "${suites[@]}"; do
-    echo "== $t =="
-    if emacs_batch -l "$t" 2>&1 | tee "$out"; then
-      :
+    [ "$quiet" = 1 ] || echo "== $t =="
+    local exit_ok=1
+    if [ "$quiet" = 1 ]; then
+      emacs_batch -l "$t" >"$out" 2>&1 || exit_ok=0
     else
-      echo "ERRORED: $t"
-      status=1
-      continue
+      emacs_batch -l "$t" 2>&1 | tee "$out"
+      # Careful: with the pipe, $? is tee's.  The suite's own status is the
+      # first element of PIPESTATUS.
+      [ "${PIPESTATUS[0]}" = 0 ] || exit_ok=0
     fi
+
+    local pass fail verdict
+    pass="$(grep -c '^PASS' "$out")"
+    fail="$(grep -c '^FAIL' "$out")"
+    total_pass=$((total_pass + pass))
+    total_fail=$((total_fail + fail))
+
     # A suite that dies before printing anything must not pass, so require a
-    # clean exit AND at least one PASS -- same contract as CI.
-    if grep -q '^FAIL' "$out"; then
-      echo "TESTS FAILED in $t"
-      status=1
-    elif ! grep -q '^PASS' "$out"; then
-      echo "NO ASSERTIONS RAN in $t"
-      status=1
+    # clean exit AND at least one PASS -- same contract CI has always had.
+    if [ "$exit_ok" = 0 ]; then
+      verdict="ERRORED"
+    elif [ "$fail" -gt 0 ]; then
+      verdict="FAILED"
+    elif [ "$pass" = 0 ]; then
+      verdict="NO ASSERTIONS"
+    else
+      verdict="ok"
     fi
+
+    if [ "$verdict" != ok ]; then
+      status=1
+      bad_suites=$((bad_suites + 1))
+      [ "$quiet" = 1 ] || echo "$verdict: $t"
+      # In quiet mode the per-assertion output was swallowed, so replay the
+      # failing suite's log -- a bare count is not something you can debug.
+      [ "$quiet" = 1 ] && { echo "== $t ($verdict) =="; cat "$out"; }
+    fi
+
+    printf '%-40s %5s pass %5s fail  %s\n' \
+           "$(basename "$t")" "$pass" "$fail" "$verdict" >>"$report"
   done
+
+  echo
+  echo "== report =="
+  cat "$report"
+  printf -- '-- %d suites, %d assertions, %d failed, %d suites not ok\n' \
+         "${#suites[@]}" "$((total_pass + total_fail))" "$total_fail" "$bad_suites"
   return $status
 }
 
@@ -186,12 +224,17 @@ case "${1:-}" in
     # that ends it, so adding a mode to the list keeps --help in sync.
     sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
     ;;
+  --quiet|-q)
+    shift
+    ensure_deps
+    run_suites 1 "$@"
+    ;;
   --*)
     echo "error: unknown option '$1'" >&2
     exit 2
     ;;
   *)
     ensure_deps
-    run_suites "$@"
+    run_suites 0 "$@"
     ;;
 esac

--- a/bin/test-emacs.sh
+++ b/bin/test-emacs.sh
@@ -16,6 +16,11 @@
 #   - a package dir under .test-emacs/ shared across runs, so deps are
 #     installed once and ~/.emacs.d is never touched
 #
+# What gets tested is the current directory's git work tree, so running this
+# from a worktree tests that worktree even when the script itself lives in the
+# main clone.  Such a run gets its own socket and port, derived from the path
+# so they are stable across runs; packages stay shared with the main clone.
+#
 # Modes:
 #   bin/test-emacs.sh                     run every suite in batch
 #   bin/test-emacs.sh test/foo-test.el    run just these suites
@@ -30,21 +35,67 @@
 
 set -uo pipefail
 
-root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Which checkout to test is the current directory's git work tree, not the one
+# this script happens to live in.  Deriving it from BASH_SOURCE meant running
+# the main clone's copy from inside a worktree silently compiled and tested the
+# main clone -- the worktree contributed nothing, and the run still reported
+# green, so the wrong checkout looked verified.
+#
+# Falling back to the script's own tree keeps `bin/test-emacs.sh' working from
+# outside any repo (a bare PATH invocation), which is how CI calls it.
+root="$(git rev-parse --show-toplevel 2>/dev/null || printf '%s' "$script_root")"
+
+# Guard on the init file rather than on the script: it is what a run actually
+# loads, so this also catches a checkout old enough to predate test/init/.
+# Better to say which tree is unusable than to fall back to the script's own
+# and quietly test something else.
+if [ ! -f "$root/test/init/init.el" ]; then
+  echo "error: $root/test/init/init.el is missing; not a testable mcp-emacs checkout" >&2
+  exit 1
+fi
+
+# Say so when the two differ, so a worktree run cannot be mistaken for a main
+# one in a scrollback.
+if [ "$root" != "$script_root" ]; then
+  echo "== testing $root (script from $script_root)"
+fi
+
 cd "$root"
 
 EMACS="${EMACS:-emacs}"
 EMACSCLIENT="${EMACSCLIENT:-emacsclient}"
 
-server_name="mcp-emacs-test"
 state_dir="$root/.test-emacs"
-package_dir="$state_dir/package"
 home_dir="$state_dir/home"
 init_file="$root/test/init/init.el"
 
+# Packages are shared with the main clone rather than kept per-worktree: they
+# depend on the Emacs version, not on the checkout, so a worktree would
+# otherwise spend a MELPA refresh re-downloading the same three every time.
+package_dir="$script_root/.test-emacs/package"
+
+# The daemon socket and the MCP port are per-checkout, or two worktrees would
+# fight over one daemon and one listening port -- and `--eval' would silently
+# reach whichever started first.  The main clone keeps the documented names so
+# the common case stays predictable.
+if [ "$root" = "$script_root" ]; then
+  server_name="mcp-emacs-test"
+  default_port=8775
+else
+  # cksum of the path, not $RANDOM: the same worktree must resolve to the same
+  # socket and port across runs, or --daemon and a later --eval would not meet.
+  # cksum is POSIX, unlike md5/md5sum which differ across macOS and Linux.
+  worktree_hash="$(printf '%s' "$root" | cksum | cut -d' ' -f1)"
+  server_name="mcp-emacs-test-$worktree_hash"
+  # A range above the documented 8775, well below 65535.
+  default_port=$((8800 + worktree_hash % 1000))
+fi
+
 export MCP_EMACS_TEST_REPO="$root"
 export MCP_EMACS_TEST_PACKAGE_DIR="$package_dir"
-export MCP_EMACS_TEST_PORT="${MCP_EMACS_TEST_PORT:-8775}"
+export MCP_EMACS_TEST_PORT="${MCP_EMACS_TEST_PORT:-$default_port}"
 
 # plz is an optional runtime dependency of opencode-client, but installing it
 # here is what lets that file compile and be tested with plz present rather

--- a/bin/test-emacs.sh
+++ b/bin/test-emacs.sh
@@ -97,6 +97,34 @@ export MCP_EMACS_TEST_REPO="$root"
 export MCP_EMACS_TEST_PACKAGE_DIR="$package_dir"
 export MCP_EMACS_TEST_PORT="${MCP_EMACS_TEST_PORT:-$default_port}"
 
+# Glyphs for the rendered report.  A pass is the line you skim past and a
+# failure is the one you stop at, so the two want to differ at a glance rather
+# than by a word that is four characters long either way.
+#
+# These are emoji on purpose, including in CI, whose logs render UTF-8 fine.
+# They are double-width, so they go before the description rather than inside
+# the aligned count columns, where they would shift the layout.
+#
+# NO_COLOR is the closest thing to a standard opt-out for terminal decoration,
+# and MCP_EMACS_TEST_ASCII is the explicit one; either falls back to the words.
+if [ -n "${MCP_EMACS_TEST_ASCII:-}" ] || [ -n "${NO_COLOR:-}" ]; then
+  GLYPH_PASS="PASS"
+  GLYPH_FAIL="FAIL"
+  GLYPH_GROUP="--"
+  GLYPH_OK="ok"
+  # The totals line reads as prose, so "-- 19 suites" beats "PASS 19 suites"
+  # when there is no glyph to carry the verdict.
+  GLYPH_TOTAL_OK="--"
+  GLYPH_TOTAL_BAD="--"
+else
+  GLYPH_PASS="✅"
+  GLYPH_FAIL="❌"
+  GLYPH_GROUP="📋"
+  GLYPH_OK="✅"
+  GLYPH_TOTAL_OK="✅"
+  GLYPH_TOTAL_BAD="❌"
+fi
+
 # plz is an optional runtime dependency of opencode-client, but installing it
 # here is what lets that file compile and be tested with plz present rather
 # than only through its soft-require fallback.
@@ -222,15 +250,25 @@ run_suites() {
     # Text report: the suite line, then every test name under it.  Listing
     # the names is the point -- counts alone do not tell you which tests
     # exist, so a test that silently stops being run looks like a pass.
-    local name
+    # Only the printed verdict becomes a glyph; `$verdict' itself stays a word
+    # because the exit status and the JUnit shape below both branch on it.
+    local name shown_verdict="$verdict"
+    [ "$verdict" = ok ] && shown_verdict="$GLYPH_OK"
     printf '\n%-38s %5s pass %5s fail  %s\n' \
-           "$(basename "$t")" "$pass" "$fail" "$verdict" >>"$report"
+           "$(basename "$t")" "$pass" "$fail" "$shown_verdict" >>"$report"
     # DESCRIBE lines are group headers from test-helper's `describe'; the
     # expectations under one get indented beneath it.  A suite not yet
     # converted emits no DESCRIBE at all and simply reads as a flat list.
+    #
+    # The words become glyphs here rather than in the suites, because
+    # "PASS name" is the wire format the counting above and CI's verdict both
+    # read.  Substituting at render time keeps that contract in words while
+    # every line a human reads is a symbol.
     while IFS= read -r line; do
       case "$line" in
-        DESCRIBE\ *) printf '  %s\n' "${line#DESCRIBE }" >>"$report" ;;
+        DESCRIBE\ *) printf '  %s %s\n' "$GLYPH_GROUP" "${line#DESCRIBE }" >>"$report" ;;
+        PASS\ *)     printf '    %s %s\n' "$GLYPH_PASS" "${line#PASS }" >>"$report" ;;
+        FAIL\ *)     printf '    %s %s\n' "$GLYPH_FAIL" "${line#FAIL }" >>"$report" ;;
         *)           printf '    %s\n' "$line" >>"$report" ;;
       esac
     done < <(grep -E '^(PASS|FAIL|DESCRIBE) ' "$out")
@@ -302,7 +340,10 @@ run_suites() {
   echo "== report =="
   cat "$report"
   echo
-  printf -- '-- %d suites, %d assertions, %d failed, %d suites not ok\n' \
+  # The whole-run verdict leads the totals line: it is the one thing worth
+  # seeing without reading, and the counts stay right behind it.
+  printf -- '%s %d suites, %d assertions, %d failed, %d suites not ok\n' \
+         "$([ "$status" = 0 ] && printf '%s' "$GLYPH_TOTAL_OK" || printf '%s' "$GLYPH_TOTAL_BAD")" \
          "${#suites[@]}" "$((total_pass + total_fail))" "$total_fail" "$bad_suites"
   printf -- '-- JUnit XML: %s\n' "${junit#"$root"/}"
   return $status

--- a/elisp/agent-session-overview.el
+++ b/elisp/agent-session-overview.el
@@ -241,12 +241,17 @@ call stack, so a rendering failure here must not reach that session."
   (pop-to-buffer (agent-session-overview--live-buffer-at-point)))
 
 (defun agent-session-overview-quit-session ()
-  "Shut down the session on the current line, without confirming.
-Deliberately unconfirmed, including mid-turn: the overview is the place
-you go to stop things."
+  "Shut down the session on the current line, after confirming.
+The overview is the place you go to stop things, so this stays a
+single key -- but it is bound to `k', which is also evil's
+`evil-previous-line', so moving the cursor up a list of sessions used to
+end one silently and unrecoverably.  A prompt is the cheapest fix that
+keeps the binding where the muscle memory expects it."
   (interactive)
   (let* ((entry (agent-session-overview--entry-at-point))
          (buffer (agent-session-overview--live-buffer-at-point)))
+    (unless (yes-or-no-p (format "Quit session %s? " (buffer-name buffer)))
+      (user-error "Session left running"))
     (pcase (plist-get entry :backend)
       ('claude-client
        (with-current-buffer buffer (claude-client-quit)))
@@ -275,7 +280,7 @@ you go to stop things."
 
 (defconst agent-session-overview--help
   '(("RET" "visit the session")
-    ("k"   "quit it, no confirmation")
+    ("k"   "quit it (asks first)")
     ("i"   "interrupt its turn")
     ("g"   "refresh")
     ("?"   "this help")

--- a/elisp/claude-client.el
+++ b/elisp/claude-client.el
@@ -553,12 +553,12 @@ subscribers on either name see every event."
 ;;
 ;; Delivery is deliberately conservative in this slice: the note is logged
 ;; and visible *immediately*, but it is only handed to the model when the
-;; current turn ends.  Nothing is aborted mid tool-call.  That is not a
-;; claim that queueing is the right interruption rule -- it is the honest
-;; behaviour for a one-shot runner that has no way to steer a turn in
-;; flight (no multi-turn stdin, no `--resume').  Deciding finish/abort/
-;; re-plan is still the open question in #39, and it needs a runner that
-;; can act on the answer.
+;; current turn ends.  Nothing is aborted mid tool-call.  That is a choice
+;; about the interruption rule, not a limit of the runner: this runner does
+;; have multi-turn stdin (`--input-format stream-json', so the process
+;; survives `finished' and serves further turns) and `--resume'.  Whether a
+;; note should finish, abort, or re-plan the turn in flight is still the
+;; open question in #39.
 
 ;;;###autoload
 (defun claude-client-add-note (text)
@@ -1050,7 +1050,14 @@ with the one being answered."
    (claude-client--turn-active
     (user-error "A turn is already running; add a note with `n' instead"))
    ((not (process-live-p claude-client--process))
-    (user-error "No live Claude process; start one with `g'"))
+    ;; A killed process leaves the session id behind, and the transcript is
+    ;; on disk, so the conversation can be picked up where it stopped --
+    ;; point at `r' rather than `g', which would start a fresh session and
+    ;; erase this log.
+    (if claude-client--session-id
+        (user-error
+         "No live Claude process; `r' resumes this conversation (`g' starts a new one)")
+      (user-error "No live Claude process; start one with `g'")))
    (t
     (let ((text (claude-client--prompt-with-notes prompt)))
       (claude-client--push-event (current-buffer)
@@ -1384,6 +1391,56 @@ turn to end)."
       (with-current-buffer buffer
         (claude-client--render)))))
 
+;;;; Help
+
+(defconst claude-client--help-buffer-name "*claude-client help*"
+  "Name of the buffer `claude-client-help' writes to.")
+
+(defconst claude-client--help
+  '(("s"       "send the next turn")
+    ("n"       "add a note (queued until the turn ends)")
+    ("i"       "interrupt the turn, keeping the session")
+    ("r"       "resume a past session here")
+    ("TAB"     "expand or collapse the tool result at point")
+    ("?"       "this help")
+    ("C-c C-q" "kill the CLI process for this buffer")
+    ("C-c C-r" "resume, by session id")
+    ("q"       "bury the conversation"))
+  "The bindings, as (KEY DESCRIPTION).
+The destructive pair is spelled `C-c'-prefixed on purpose: `k' and `g'
+stay evil motions here, see `claude-client--evil-keys'.")
+
+(defun claude-client--display-help (buffer _alist)
+  "Display help BUFFER in a plain window split from the conversation.
+Returns the new window, as a `display-buffer' action function must.
+Mirrors `agent-session-overview--display-help', and for the same reason:
+under a popup framework `q' in the help window would otherwise tear down
+the conversation's popup along with the help."
+  (let* ((base (or (get-buffer-window (current-buffer))
+                   (selected-window)))
+         (window (split-window base nil 'below)))
+    (set-window-buffer window buffer)
+    window))
+
+;;;###autoload
+(defun claude-client-help ()
+  "Describe what you can do from a Claude conversation buffer."
+  (interactive)
+  (let ((display-buffer-alist
+         (cons `(,(regexp-quote claude-client--help-buffer-name)
+                 (claude-client--display-help))
+               display-buffer-alist)))
+    (with-help-window claude-client--help-buffer-name
+      (princ "Claude conversation\n\n")
+      (dolist (binding claude-client--help)
+        (princ (format "  %-8s %s\n" (car binding) (cadr binding))))
+      (princ "\nOne process per conversation, kept alive across turns, so `s'\n")
+      (princ "continues the same session with its context.  If the process is\n")
+      (princ "gone, `r' picks the session up where it stopped; `g' would start\n")
+      (princ "a new one and erase this log.\n"))
+    (when-let* ((window (get-buffer-window claude-client--help-buffer-name)))
+      (fit-window-to-buffer window))))
+
 ;;;; Major mode
 
 (defvar claude-client-mode-map
@@ -1394,6 +1451,7 @@ turn to end)."
     (define-key map (kbd "s") #'claude-client-send)
     (define-key map (kbd "r") #'claude-client-resume)
     (define-key map (kbd "i") #'claude-client-interrupt)
+    (define-key map (kbd "?") #'claude-client-help)
     (define-key map (kbd "TAB") #'claude-client-toggle-tool-result)
     map)
   "Keymap for `claude-client-mode'.
@@ -1403,18 +1461,23 @@ re-registers them.  The evil-safe `C-c'-prefixed vocabulary lives in
 `agent-backend-mode-map' and works either way.")
 
 (defconst claude-client--evil-keys
-  '(("g" . claude-client-start)
-    ("k" . claude-client-quit)
-    ("n" . claude-client-add-note)
+  '(("n" . claude-client-add-note)
     ("s" . claude-client-send)
     ("r" . claude-client-resume)
     ("i" . claude-client-interrupt)
+    ("?" . claude-client-help)
     ;; Not single-letter, but evil's motion state does claim TAB
     ;; (`evil-jump-forward'), so it needs re-registering the same way.
     ("TAB" . claude-client-toggle-tool-result))
   "The single-letter bindings to re-register with evil.
-Mirrors `claude-client-mode-map'; kept as data so both paths bind the
-same set.")
+Deliberately a subset of `claude-client-mode-map': `k' and `g' are left
+to evil.  Both are vim motions (`evil-previous-line', the `gg' prefix)
+and both had destructive commands behind them here -- `k' killed the CLI
+process and `g' erased the log and started a new session -- so moving the
+cursor up in a conversation silently ended it, and `gg' was dead because
+`g' consumed the prefix.  Under evil they stay motions; the commands are
+still reachable as `C-c C-q' and `C-c C-r' (see `agent-backend-mode-map')
+and are listed by `?'.")
 
 (declare-function evil-define-key* "evil-core"
                   (state keymap key def &rest bindings))

--- a/test/agent-backend-test.el
+++ b/test/agent-backend-test.el
@@ -6,22 +6,25 @@
 ;; subscription), so the signal is the defcustom, not a runtime probe.
 
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'cl-lib)
 (require 'agent-backend)
-(defun check (l g w) (princ (format "%s %s: got=%S want=%S
-" (if (equal g w) "PASS" "FAIL") l g w)))
 
-;; Explicit preference wins regardless of server state.
-(cl-letf (((symbol-function 'opencode-client--health) (lambda () t)))
-  (let ((agent-backend-preference 'opencode))
-    (check "forced-opencode" (agent-backend-prefer-opencode-p) t)))
+(describe "agent-backend-prefer-opencode-p with an explicit preference"
+  (cl-letf (((symbol-function 'opencode-client--health) (lambda () t)))
+    (let ((agent-backend-preference 'opencode))
+      (it "prefers opencode when it is forced"
+        (check (agent-backend-prefer-opencode-p) t))))
 
-(cl-letf (((symbol-function 'opencode-client--health) (lambda () nil)))
-  (let ((agent-backend-preference 'opencode))
-    (check "forced-opencode-despite-unhealthy" (agent-backend-prefer-opencode-p) t)))
+  (cl-letf (((symbol-function 'opencode-client--health) (lambda () nil)))
+    (let ((agent-backend-preference 'opencode))
+      (it "prefers opencode even when the server is unhealthy"
+        (check (agent-backend-prefer-opencode-p) t))))
 
-(let ((agent-backend-preference 'claude))
-  (check "forced-claude" (agent-backend-prefer-opencode-p) nil))
+  (let ((agent-backend-preference 'claude))
+    (it "declines opencode when claude is forced"
+      (check (agent-backend-prefer-opencode-p) nil))))
 
 ;; auto consults the server only for opencode.  Provide a stub
 ;; opencode-client feature first so the require inside
@@ -32,222 +35,239 @@
 (unless (featurep 'opencode-client)
   (fset 'opencode-client--health (lambda () nil))
   (provide 'opencode-client))
-(cl-letf (((symbol-function 'opencode-client--health) (lambda () t)))
-  (let ((agent-backend-preference 'auto))
-    (check "auto-healthy-opencode" (agent-backend-prefer-opencode-p) t)))
-(cl-letf (((symbol-function 'opencode-client--health) (lambda () nil)))
-  (let ((agent-backend-preference 'auto))
-    (check "auto-unhealthy-falls-to-claude" (agent-backend-prefer-opencode-p) nil)))
 
-;; Default is auto.
-(check "default-preference" agent-backend-preference 'auto)
+(describe "agent-backend-prefer-opencode-p on auto"
+  (cl-letf (((symbol-function 'opencode-client--health) (lambda () t)))
+    (let ((agent-backend-preference 'auto))
+      (it "picks opencode when the server is healthy"
+        (check (agent-backend-prefer-opencode-p) t))))
+  (cl-letf (((symbol-function 'opencode-client--health) (lambda () nil)))
+    (let ((agent-backend-preference 'auto))
+      (it "falls back to claude when the server is unhealthy"
+        (check (agent-backend-prefer-opencode-p) nil)))))
 
-;; The class dispatches note-policy from the slot.
-(let ((b (make-instance 'agent-backend)))
-  (check "default-note-policy" (agent-backend-note-policy b) :steer)
-  (oset b note-policy :queue)
-  (check "oset-note-policy" (agent-backend-note-policy b) :queue))
+(describe "agent-backend-preference"
+  (it "defaults to auto"
+    (check agent-backend-preference 'auto)))
+
+(describe "agent-backend note-policy"
+  (let ((b (make-instance 'agent-backend)))
+    (it "reads :steer from the class default"
+      (check (agent-backend-note-policy b) :steer))
+    (oset b note-policy :queue)
+    (it "dispatches the value set on the slot"
+      (check (agent-backend-note-policy b) :queue))))
 
 ;;;; Sharing a selection (issue #56)
 
 (require 'project)
 
-;; The reference is a project-relative pointer, not the text itself: the
-;; agent can read the file for itself, and a pointer stays right as the
-;; file moves on.
-(let ((buf (find-file-noselect
-            (expand-file-name "elisp/agent-backend.el"))))
-  (with-current-buffer buf
-    (goto-char (point-min))
-    (forward-line 11)
-    (let ((beg (point)))
-      (forward-line 3)
-      (let ((transient-mark-mode t))
-        (set-mark beg)
-        (activate-mark)
-        ;; 12-14, not 12-15: the region ends at column 0 of line 15, so
-        ;; it covers up to the previous line -- selecting three whole
-        ;; lines should not claim a fourth.
-        (check "ref-region-is-project-relative"
-               (agent-backend-selection-reference)
-               "@elisp/agent-backend.el:12-14")
-        (deactivate-mark))
-      ;; No region: the single line at point.
+(describe "agent-backend-selection-reference"
+  ;; The reference is a project-relative pointer, not the text itself: the
+  ;; agent can read the file for itself, and a pointer stays right as the
+  ;; file moves on.
+  (let ((buf (find-file-noselect
+              (expand-file-name "elisp/agent-backend.el"))))
+    (with-current-buffer buf
       (goto-char (point-min))
-      (forward-line 4)
-      (check "ref-no-region-is-one-line"
-             (agent-backend-selection-reference)
-             "@elisp/agent-backend.el:5")))
-  (kill-buffer buf))
+      (forward-line 11)
+      (let ((beg (point)))
+        (forward-line 3)
+        (let ((transient-mark-mode t))
+          (set-mark beg)
+          (activate-mark)
+          ;; 12-14, not 12-15: the region ends at column 0 of line 15, so
+          ;; it covers up to the previous line -- selecting three whole
+          ;; lines should not claim a fourth.
+          (it "points at the project-relative path and the selected lines only"
+            (check (agent-backend-selection-reference)
+                   "@elisp/agent-backend.el:12-14"))
+          (deactivate-mark))
+        (goto-char (point-min))
+        (forward-line 4)
+        (it "points at the single line at point when there is no region"
+          (check (agent-backend-selection-reference)
+                 "@elisp/agent-backend.el:5"))))
+    (kill-buffer buf))
 
-;; With no file to point at there is no path, so the text itself is the
-;; only useful reference.
-(with-temp-buffer
-  (insert "alpha\nbeta\n")
-  (goto-char (point-min))
-  (check "ref-nonfile-no-region" (agent-backend-selection-reference) "alpha"))
+  ;; With no file to point at there is no path, so the text itself is the
+  ;; only useful reference.
+  (with-temp-buffer
+    (insert "alpha\nbeta\n")
+    (goto-char (point-min))
+    (it "falls back to the line's text in a buffer with no file"
+      (check (agent-backend-selection-reference) "alpha"))))
 
-;; Resolution finds any buffer holding an instance -- no registry, so a
-;; new client is found for free.
-(let ((conv (get-buffer-create "*fake-conversation*")))
-  (unwind-protect
-      (progn
-        (with-current-buffer conv
-          (setq-local agent-backend--instance (make-instance 'agent-backend)))
-        (check "conversation-found"
-               (memq conv (agent-backend--conversation-buffers))
-               (list conv))
-        (check "resolves-the-only-one"
-               (agent-backend--resolve-conversation) conv))
-    (kill-buffer conv)))
+(describe "agent-backend--conversation-buffers"
+  ;; Resolution finds any buffer holding an instance -- no registry, so a
+  ;; new client is found for free.
+  (let ((conv (get-buffer-create "*fake-conversation*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer conv
+            (setq-local agent-backend--instance (make-instance 'agent-backend)))
+          (it "finds any buffer holding an instance, with no registry to enrol in"
+            (check (memq conv (agent-backend--conversation-buffers))
+                   (list conv)))
+          (it "resolves the only conversation there is"
+            (check (agent-backend--resolve-conversation) conv)))
+      (kill-buffer conv)))
 
-;; A buffer without an instance is not a conversation.
-(let ((plain (get-buffer-create "*not-a-conversation*")))
-  (unwind-protect
-      (check "plain-buffer-ignored"
-             (memq plain (agent-backend--conversation-buffers)) nil)
-    (kill-buffer plain)))
+  (let ((plain (get-buffer-create "*not-a-conversation*")))
+    (unwind-protect
+        (it "ignores a buffer without an instance"
+          (check (memq plain (agent-backend--conversation-buffers)) nil))
+      (kill-buffer plain))))
 
-;; Refuses rather than silently doing nothing when nothing is live.
-(check "no-conversation-errors"
-       (condition-case nil
-           (progn (agent-backend--resolve-conversation) 'no-error)
-         (user-error 'user-error))
-       'user-error)
+(describe "agent-backend--resolve-conversation"
+  (it "refuses rather than silently doing nothing when nothing is live"
+    (check (condition-case nil
+               (progn (agent-backend--resolve-conversation) 'no-error)
+             (user-error 'user-error))
+           'user-error))
 
-;; Same project beats another project, and visible beats hidden -- the
-;; selection is about the project you are in, and an on-screen
-;; conversation is the one being worked with.
-(let* ((here (expand-file-name default-directory))
-       (mine (get-buffer-create "*conv-same-project*"))
-       (other (get-buffer-create "*conv-other-project*")))
-  (unwind-protect
-      (progn
-        (with-current-buffer mine
-          (setq-local default-directory here)
-          (setq-local agent-backend--instance (make-instance 'agent-backend)))
-        (with-current-buffer other
-          (setq-local default-directory "/tmp/somewhere-else/")
-          (setq-local agent-backend--instance (make-instance 'agent-backend)))
-        (check "same-project-wins"
-               (agent-backend--resolve-conversation) mine))
-    (kill-buffer mine)
-    (kill-buffer other)))
+  ;; Same project beats another project, and visible beats hidden -- the
+  ;; selection is about the project you are in, and an on-screen
+  ;; conversation is the one being worked with.
+  (let* ((here (expand-file-name default-directory))
+         (mine (get-buffer-create "*conv-same-project*"))
+         (other (get-buffer-create "*conv-other-project*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer mine
+            (setq-local default-directory here)
+            (setq-local agent-backend--instance (make-instance 'agent-backend)))
+          (with-current-buffer other
+            (setq-local default-directory "/tmp/somewhere-else/")
+            (setq-local agent-backend--instance (make-instance 'agent-backend)))
+          (it "prefers the conversation in the current project"
+            (check (agent-backend--resolve-conversation) mine)))
+      (kill-buffer mine)
+      (kill-buffer other))))
 
-;; The default mention routes through add-note, so a backend that
-;; implements only the required verbs still gets a working mention.
-(let ((noted nil))
-  (cl-letf (((symbol-function 'agent-backend-add-note)
-             (lambda (_backend text) (setq noted text))))
-    (agent-backend-mention (make-instance 'agent-backend) "@foo.el:1")
-    (check "default-mention-uses-add-note" noted "@foo.el:1")))
+(describe "agent-backend-mention"
+  ;; The default mention routes through add-note, so a backend that
+  ;; implements only the required verbs still gets a working mention.
+  (let ((noted nil))
+    (cl-letf (((symbol-function 'agent-backend-add-note)
+               (lambda (_backend text) (setq noted text))))
+      (agent-backend-mention (make-instance 'agent-backend) "@foo.el:1")
+      (it "routes through add-note so a minimal backend still gets a mention"
+        (check noted "@foo.el:1")))))
 
 ;;;; Explaining a selection (issue #56)
 
-;; Not every backend can answer without a session, so the base class
-;; refuses rather than pretending.
-(check "default-query-refuses"
-       (condition-case nil
-           (progn (agent-backend-query (make-instance 'agent-backend) "hi" #'ignore)
-                  'no-error)
-         (user-error 'user-error))
-       'user-error)
+(describe "agent-backend-query"
+  (it "refuses on the base class rather than pretending it can answer without a session"
+    (check (condition-case nil
+               (progn (agent-backend-query (make-instance 'agent-backend) "hi" #'ignore)
+                      'no-error)
+             (user-error 'user-error))
+           'user-error)))
 
-;; The default route prefers a visible conversation: "explain this" is
-;; usually part of the work already in that context.
-(check "default-explain-route" agent-backend-explain-route 'session-first)
+(describe "agent-backend-explain-route"
+  (it "defaults to session-first, since explaining is usually part of the work in context"
+    (check agent-backend-explain-route 'session-first)))
 
 ;; `--visible-conversation' answers the question the fallback needs --
 ;; "is one on screen?" -- without signalling the way
 ;; `--resolve-conversation' does, since a nil answer is actionable here.
-(check "no-visible-conversation-is-nil" (agent-backend--visible-conversation) nil)
+(describe "agent-backend--visible-conversation"
+  (it "returns nil rather than signalling when there is no conversation at all"
+    (check (agent-backend--visible-conversation) nil))
 
-(let ((conv (get-buffer-create "*conv-visible*")))
-  (unwind-protect
-      (progn
-        (with-current-buffer conv
-          (setq-local agent-backend--instance (make-instance 'agent-backend)))
-        ;; Live but not displayed: still nil, which is what routes an
-        ;; explain to the one-shot path.
-        (check "hidden-conversation-is-not-visible"
-               (agent-backend--visible-conversation) nil)
-        (set-window-buffer (selected-window) conv)
-        (check "shown-conversation-is-visible"
-               (agent-backend--visible-conversation) conv))
-    (set-window-buffer (selected-window) (get-buffer-create "*scratch*"))
-    (kill-buffer conv)))
+  (let ((conv (get-buffer-create "*conv-visible*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer conv
+            (setq-local agent-backend--instance (make-instance 'agent-backend)))
+          (it "returns nil for a live conversation that is not displayed"
+            (check (agent-backend--visible-conversation) nil))
+          (set-window-buffer (selected-window) conv)
+          (it "returns the conversation once it is shown in a window"
+            (check (agent-backend--visible-conversation) conv)))
+      (set-window-buffer (selected-window) (get-buffer-create "*scratch*"))
+      (kill-buffer conv))))
 
 ;; Routing.  Each mode is checked for what it does *and* what it must not
 ;; do: the point of `one-shot' is that it skips a session even when one
 ;; is right there, so asserting only "it queried" would pass a
 ;; still-broken implementation.
-(let ((conv (get-buffer-create "*conv-route*"))
-      queried sent)
-  (unwind-protect
-      (cl-letf (((symbol-function 'agent-backend-send)
-                 (lambda (_b prompt) (setq sent prompt)))
-                ((symbol-function 'agent-backend-query)
-                 (lambda (_b prompt _cb) (setq queried prompt)))
-                ((symbol-function 'agent-backend--query-backend)
-                 (lambda () (make-instance 'agent-backend)))
-                ;; The popup needs markdown-mode, absent in batch.  The
-                ;; command requires mcp-emacs-run, which would reinstate
-                ;; the real definitions over a stub set before it loads --
-                ;; so load it here first, then stub both the renderer and
-                ;; the guard that refuses without markdown-mode.
-                ((symbol-function 'mcp-emacs-popup-show)
-                 (progn (require 'mcp-emacs-run)
-                        (lambda (content &optional _kind) content)))
-                ((symbol-function 'mcp-emacs-run--ensure-markdown) #'ignore))
-        (with-current-buffer conv
-          (setq-local agent-backend--instance (make-instance 'agent-backend)))
+(describe "agent-backend-explain-selection"
+  (let ((conv (get-buffer-create "*conv-route*"))
+        queried sent)
+    (unwind-protect
+        (cl-letf (((symbol-function 'agent-backend-send)
+                   (lambda (_b prompt) (setq sent prompt)))
+                  ((symbol-function 'agent-backend-query)
+                   (lambda (_b prompt _cb) (setq queried prompt)))
+                  ((symbol-function 'agent-backend--query-backend)
+                   (lambda () (make-instance 'agent-backend)))
+                  ;; The popup needs markdown-mode, absent in batch.  The
+                  ;; command requires mcp-emacs-run, which would reinstate
+                  ;; the real definitions over a stub set before it loads --
+                  ;; so load it here first, then stub both the renderer and
+                  ;; the guard that refuses without markdown-mode.
+                  ((symbol-function 'mcp-emacs-popup-show)
+                   (progn (require 'mcp-emacs-run)
+                          (lambda (content &optional _kind) content)))
+                  ((symbol-function 'mcp-emacs-run--ensure-markdown) #'ignore))
+          (with-current-buffer conv
+            (setq-local agent-backend--instance (make-instance 'agent-backend)))
 
-        ;; Nothing visible: session-first falls back to a one-shot query.
-        (setq queried nil sent nil)
-        (let ((agent-backend-explain-route 'session-first))
-          (with-temp-buffer
-            (insert "some code\n")
-            (goto-char (point-min))
-            (agent-backend-explain-selection)))
-        (check "session-first-without-session-queries" (and queried t) t)
-        (check "session-first-without-session-sends-no-turn" sent nil)
+          (setq queried nil sent nil)
+          (let ((agent-backend-explain-route 'session-first))
+            (with-temp-buffer
+              (insert "some code\n")
+              (goto-char (point-min))
+              (agent-backend-explain-selection)))
+          (it "falls back to a one-shot query under session-first when nothing is visible"
+            (check-that queried))
+          (it "sends no turn under session-first when nothing is visible"
+            (check sent nil))
 
-        ;; Visible: session-first sends a real turn instead.
-        (set-window-buffer (selected-window) conv)
-        (setq queried nil sent nil)
-        (let ((agent-backend-explain-route 'session-first))
-          (with-temp-buffer
-            (insert "some code\n")
-            (goto-char (point-min))
-            (agent-backend-explain-selection)))
-        (check "session-first-with-session-sends-turn" (and sent t) t)
-        (check "session-first-with-session-does-not-query" queried nil)
+          (set-window-buffer (selected-window) conv)
+          (setq queried nil sent nil)
+          (let ((agent-backend-explain-route 'session-first))
+            (with-temp-buffer
+              (insert "some code\n")
+              (goto-char (point-min))
+              (agent-backend-explain-selection)))
+          (it "sends a real turn under session-first when a conversation is visible"
+            (check-that sent))
+          (it "does not spend a separate query when it sent a turn"
+            (check queried nil))
 
-        ;; one-shot ignores the visible conversation entirely.
-        (setq queried nil sent nil)
-        (let ((agent-backend-explain-route 'one-shot))
-          (with-temp-buffer
-            (insert "some code\n")
-            (goto-char (point-min))
-            (agent-backend-explain-selection)))
-        (check "one-shot-queries-despite-session" (and queried t) t)
-        (check "one-shot-sends-no-turn" sent nil)
+          (setq queried nil sent nil)
+          (let ((agent-backend-explain-route 'one-shot))
+            (with-temp-buffer
+              (insert "some code\n")
+              (goto-char (point-min))
+              (agent-backend-explain-selection)))
+          (it "queries under one-shot even though a conversation is right there"
+            (check-that queried))
+          (it "sends no turn under one-shot"
+            (check sent nil))
 
-        ;; The prompt is the template applied to the reference.
-        (check "explain-prompt-uses-template" queried "explain some code")
+          (it "builds the prompt by applying the template to the reference"
+            (check queried "explain some code"))
 
-        ;; session-only refuses instead of spending a separate call.
-        (set-window-buffer (selected-window) (get-buffer-create "*scratch*"))
-        (setq queried nil sent nil)
-        (check "session-only-without-session-refuses"
-               (let ((agent-backend-explain-route 'session-only))
-                 (with-temp-buffer
-                   (insert "some code\n")
-                   (goto-char (point-min))
-                   (condition-case nil
-                       (progn (agent-backend-explain-selection) 'no-error)
-                     (user-error 'user-error))))
-               'user-error)
-        (check "session-only-refusal-queries-nothing" queried nil))
-    (set-window-buffer (selected-window) (get-buffer-create "*scratch*"))
-    (kill-buffer conv)))
+          (set-window-buffer (selected-window) (get-buffer-create "*scratch*"))
+          (setq queried nil sent nil)
+          (it "refuses under session-only when there is no session, instead of spending a separate call"
+            (check (let ((agent-backend-explain-route 'session-only))
+                     (with-temp-buffer
+                       (insert "some code\n")
+                       (goto-char (point-min))
+                       (condition-case nil
+                           (progn (agent-backend-explain-selection) 'no-error)
+                         (user-error 'user-error))))
+                   'user-error))
+          (it "queries nothing when session-only refuses"
+            (check queried nil)))
+      (set-window-buffer (selected-window) (get-buffer-create "*scratch*"))
+      (kill-buffer conv))))
+
+(test-helper-summary)
+
+;;; agent-backend-test.el ends here

--- a/test/agent-session-overview-test.el
+++ b/test/agent-session-overview-test.el
@@ -8,13 +8,10 @@
 ;; state, so they test without a live CLI or server.
 
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'cl-lib)
 (require 'agent-session-overview)
-
-(defvar failures 0)
-(defun check (l g w)
-  (unless (equal g w) (setq failures (1+ failures)))
-  (princ (format "%s %s: got=%S want=%S\n" (if (equal g w) "PASS" "FAIL") l g w)))
 
 (defmacro with-session-buffers (names &rest body)
   "Create buffers NAMES, run BODY, then kill them."
@@ -30,156 +27,175 @@
 
 ;;;; Enumeration
 
-;; All three naming schemes are recognised, and each row knows its backend.
-(with-session-buffers '("*claude-client:mcp-emacs:1*"
-                        "*claude:rdm-core:1*"
-                        "*opencode:some-title*")
-  (check "claude-client recognised"
-         (plist-get (entry-for "*claude-client:mcp-emacs:1*") :label) "claude")
-  (check "eat recognised"
-         (plist-get (entry-for "*claude:rdm-core:1*") :label) "eat")
-  (check "opencode recognised"
-         (plist-get (entry-for "*opencode:some-title*") :label) "opencode")
-  (check "all three listed together"
-         (length (agent-session-overview--sessions)) 3))
+(describe "agent-session-overview--sessions across naming schemes"
+  (with-session-buffers '("*claude-client:mcp-emacs:1*"
+                          "*claude:rdm-core:1*"
+                          "*opencode:some-title*")
+    (it "recognises a claude-client buffer as the claude backend"
+      (check (plist-get (entry-for "*claude-client:mcp-emacs:1*") :label) "claude"))
+    (it "recognises an eat runner buffer as the eat backend"
+      (check (plist-get (entry-for "*claude:rdm-core:1*") :label) "eat"))
+    (it "recognises an opencode buffer as the opencode backend"
+      (check (plist-get (entry-for "*opencode:some-title*") :label) "opencode"))
+    (it "lists all three naming schemes together"
+      (check (length (agent-session-overview--sessions)) 3))))
 
-;; Project and session identity come out of the buffer name where it
-;; carries them.
-(with-session-buffers '("*claude-client:mcp-emacs:2*")
-  (let ((e (entry-for "*claude-client:mcp-emacs:2*")))
-    (check "project from name" (plist-get e :project) "mcp-emacs")
-    (check "session from name" (plist-get e :session) "mcp-emacs:2")))
+(describe "agent-session-overview--sessions identity from the buffer name"
+  (with-session-buffers '("*claude-client:mcp-emacs:2*")
+    (let ((e (entry-for "*claude-client:mcp-emacs:2*")))
+      (it "takes the project out of the buffer name"
+        (check (plist-get e :project) "mcp-emacs"))
+      (it "takes the session out of the buffer name"
+        (check (plist-get e :session) "mcp-emacs:2"))))
 
-;; Two conversations in one project stay distinguishable -- the session
-;; number is what separates them.
-(with-session-buffers '("*claude-client:mcp-emacs:1*" "*claude-client:mcp-emacs:2*")
-  (let ((sessions (mapcar (lambda (e) (plist-get e :session))
-                          (agent-session-overview--sessions))))
-    (check "two rows in one project" (length sessions) 2)
-    (check "sessions distinguishable" (equal (nth 0 sessions) (nth 1 sessions)) nil)))
+  ;; Two conversations in one project stay distinguishable -- the session
+  ;; number is what separates them.
+  (with-session-buffers '("*claude-client:mcp-emacs:1*" "*claude-client:mcp-emacs:2*")
+    (let ((sessions (mapcar (lambda (e) (plist-get e :session))
+                            (agent-session-overview--sessions))))
+      (it "lists two rows for two conversations in one project"
+        (check (length sessions) 2))
+      (it "keeps the two sessions in one project distinguishable by number"
+        (check (equal (nth 0 sessions) (nth 1 sessions)) nil))))
 
-;; Opencode names buffers by title, so its project falls back to the
-;; buffer's own directory rather than being parsed out of the name.
-(with-session-buffers '("*opencode:my-chat*")
-  (with-current-buffer "*opencode:my-chat*"
-    (setq-local default-directory "/tmp/some-project/"))
-  (let ((e (entry-for "*opencode:my-chat*")))
-    (check "opencode project from directory" (plist-get e :project) "some-project")
-    (check "opencode session is its title" (plist-get e :session) "my-chat")))
+  ;; Opencode names buffers by title, so its project falls back to the
+  ;; buffer's own directory rather than being parsed out of the name.
+  (with-session-buffers '("*opencode:my-chat*")
+    (with-current-buffer "*opencode:my-chat*"
+      (setq-local default-directory "/tmp/some-project/"))
+    (let ((e (entry-for "*opencode:my-chat*")))
+      (it "falls back to the buffer's directory for an opencode project"
+        (check (plist-get e :project) "some-project"))
+      (it "uses the title as the session for opencode"
+        (check (plist-get e :session) "my-chat")))))
 
-;; Unrelated buffers are not sessions.
-(with-session-buffers '("*scratch-not-a-session*" "*claude-ish*")
-  (check "no false positives" (length (agent-session-overview--sessions)) 0))
+(describe "agent-session-overview--sessions rejecting non-sessions"
+  (with-session-buffers '("*scratch-not-a-session*" "*claude-ish*")
+    (it "does not mistake a similarly named buffer for a session"
+      (check (length (agent-session-overview--sessions)) 0)))
+
+  ;; Mode matching must not drag in a buffer that merely sets some
+  ;; claude-client variable without being a conversation.
+  (with-session-buffers '("*not-a-conversation*")
+    (with-current-buffer "*not-a-conversation*"
+      (setq-local claude-client--turn-active t))
+    (it "needs the major mode, not just a claude-client variable"
+      (check (entry-for "*not-a-conversation*") nil)))
+
+  (it "returns nothing when no session is live"
+    (check (agent-session-overview--sessions) nil)))
 
 ;; A session buffer whose name predates the `:<project>:<n>' scheme --
 ;; plain `*claude-client*' -- is still a live session and must be listed.
 ;; Found in a real Emacs, where exactly such a buffer was being missed.
-(with-session-buffers '("*claude-client*")
-  (with-current-buffer "*claude-client*"
-    (setq major-mode 'claude-client-mode)
-    (setq-local claude-client--turn-active nil)
-    (setq-local claude-client--process nil))
-  ;; The mode only has to be fbound for `--mode-match-p' to consult it, and
-  ;; the stub must be a lambda rather than a symbol like #'ignore: Emacs
-  ;; 29's `provided-mode-derived-p' treats a symbol-valued function as an
-  ;; alias and follows it, so `derived-mode-p' would compare against
-  ;; `ignore' and the buffer would not match.  Emacs 30 dropped that branch,
-  ;; which is why #'ignore passed locally and failed on CI's 29.4.
-  (cl-letf (((symbol-function 'claude-client-mode) (lambda () nil)))
-    (let ((e (entry-for "*claude-client*")))
-      (check "unnumbered session is listed" (and e t) t)
-      (check "unnumbered session backend" (plist-get e :label) "claude")
-      (check "unnumbered session identity" (plist-get e :session) "*claude-client*")
-      (check "unnumbered session state" (plist-get e :state) 'finished))))
-
-;; Mode matching must not drag in a buffer that merely sets some
-;; claude-client variable without being a conversation.
-(with-session-buffers '("*not-a-conversation*")
-  (with-current-buffer "*not-a-conversation*"
-    (setq-local claude-client--turn-active t))
-  (check "mode match needs the mode" (entry-for "*not-a-conversation*") nil))
-
-;; Nothing live at all.
-(check "no sessions when none exist" (agent-session-overview--sessions) nil)
+(describe "agent-session-overview--sessions with an unnumbered buffer name"
+  (with-session-buffers '("*claude-client*")
+    (with-current-buffer "*claude-client*"
+      (setq major-mode 'claude-client-mode)
+      (setq-local claude-client--turn-active nil)
+      (setq-local claude-client--process nil))
+    ;; The mode only has to be fbound for `--mode-match-p' to consult it, and
+    ;; the stub must be a lambda rather than a symbol like #'ignore: Emacs
+    ;; 29's `provided-mode-derived-p' treats a symbol-valued function as an
+    ;; alias and follows it, so `derived-mode-p' would compare against
+    ;; `ignore' and the buffer would not match.  Emacs 30 dropped that branch,
+    ;; which is why #'ignore passed locally and failed on CI's 29.4.
+    (cl-letf (((symbol-function 'claude-client-mode) (lambda () nil)))
+      (let ((e (entry-for "*claude-client*")))
+        (it "lists a session whose name predates the numbering scheme"
+          (check-that e))
+        (it "still identifies its backend"
+          (check (plist-get e :label) "claude"))
+        (it "uses the whole buffer name as the session"
+          (check (plist-get e :session) "*claude-client*"))
+        (it "still classifies its state"
+          (check (plist-get e :state) 'finished))))))
 
 ;;;; State classification
 
-;; claude-client reports working / idle / finished from its own state.
-(with-session-buffers '("*claude-client:p:1*")
-  (with-current-buffer "*claude-client:p:1*"
-    (setq-local claude-client--turn-active t)
-    (setq-local claude-client--process nil))
-  (check "mid-turn is working"
-         (plist-get (entry-for "*claude-client:p:1*") :state) 'working))
+(describe "agent-session-overview state for claude-client"
+  (with-session-buffers '("*claude-client:p:1*")
+    (with-current-buffer "*claude-client:p:1*"
+      (setq-local claude-client--turn-active t)
+      (setq-local claude-client--process nil))
+    (it "reports working while a turn is running"
+      (check (plist-get (entry-for "*claude-client:p:1*") :state) 'working)))
 
-(with-session-buffers '("*claude-client:p:1*")
-  (with-current-buffer "*claude-client:p:1*"
-    (setq-local claude-client--turn-active nil)
-    (setq-local claude-client--process nil))
-  (check "exited is finished"
-         (plist-get (entry-for "*claude-client:p:1*") :state) 'finished))
+  (with-session-buffers '("*claude-client:p:1*")
+    (with-current-buffer "*claude-client:p:1*"
+      (setq-local claude-client--turn-active nil)
+      (setq-local claude-client--process nil))
+    (it "reports finished once the process is gone"
+      (check (plist-get (entry-for "*claude-client:p:1*") :state) 'finished)))
 
-;; A live process with no turn running is idle, not finished.  The
-;; process here is a real one so `process-live-p' has something true to
-;; say without a CLI.
-(with-session-buffers '("*claude-client:p:1*")
-  (let ((proc (start-process "overview-test-idle" nil "sleep" "30")))
-    (unwind-protect
-        (progn
-          (with-current-buffer "*claude-client:p:1*"
-            (setq-local claude-client--turn-active nil)
-            (setq-local claude-client--process proc))
-          (check "live process between turns is idle"
-                 (plist-get (entry-for "*claude-client:p:1*") :state) 'idle))
-      (delete-process proc))))
+  ;; The process here is a real one so `process-live-p' has something true
+  ;; to say without a CLI.
+  (with-session-buffers '("*claude-client:p:1*")
+    (let ((proc (start-process "overview-test-idle" nil "sleep" "30")))
+      (unwind-protect
+          (progn
+            (with-current-buffer "*claude-client:p:1*"
+              (setq-local claude-client--turn-active nil)
+              (setq-local claude-client--process proc))
+            (it "reports idle, not finished, for a live process between turns"
+              (check (plist-get (entry-for "*claude-client:p:1*") :state) 'idle)))
+        (delete-process proc)))))
 
 ;; The eat runner and opencode report liveness only -- never a turn
 ;; state, because neither publishes one.
-(with-session-buffers '("*claude:p:1*" "*opencode:t*")
-  (check "eat with no process is dead"
-         (plist-get (entry-for "*claude:p:1*") :state) 'dead)
-  (check "opencode with no process is dead"
-         (plist-get (entry-for "*opencode:t*") :state) 'dead)
-  (check "eat never reports working"
-         (memq (plist-get (entry-for "*claude:p:1*") :state) '(working idle)) nil)
-  (check "opencode never reports working"
-         (memq (plist-get (entry-for "*opencode:t*") :state) '(working idle)) nil))
+(describe "agent-session-overview state for liveness-only backends"
+  (with-session-buffers '("*claude:p:1*" "*opencode:t*")
+    (it "reports an eat session with no process as dead"
+      (check (plist-get (entry-for "*claude:p:1*") :state) 'dead))
+    (it "reports an opencode session with no process as dead"
+      (check (plist-get (entry-for "*opencode:t*") :state) 'dead))
+    (it "never reports a turn state for eat"
+      (check (memq (plist-get (entry-for "*claude:p:1*") :state) '(working idle)) nil))
+    (it "never reports a turn state for opencode"
+      (check (memq (plist-get (entry-for "*opencode:t*") :state) '(working idle)) nil)))
 
-;; A turn-active flag left in an eat buffer must not promote it: eat's
-;; classifier reads the process, not stray buffer-local state.
-(with-session-buffers '("*claude:p:1*")
-  (with-current-buffer "*claude:p:1*"
-    (setq-local claude-client--turn-active t))
-  (check "eat ignores a turn flag"
-         (plist-get (entry-for "*claude:p:1*") :state) 'dead))
+  ;; A turn-active flag left in an eat buffer must not promote it: eat's
+  ;; classifier reads the process, not stray buffer-local state.
+  (with-session-buffers '("*claude:p:1*")
+    (with-current-buffer "*claude:p:1*"
+      (setq-local claude-client--turn-active t))
+    (it "ignores a stray turn flag in an eat buffer"
+      (check (plist-get (entry-for "*claude:p:1*") :state) 'dead))))
 
 ;;;; Rendering and the event subscriber
 
-;; Rows render as the four displayed columns.
-(with-session-buffers '("*claude-client:mcp-emacs:1*")
-  (let ((row (cadr (car (agent-session-overview--entries)))))
-    (check "row is 4 columns" (length row) 4)
-    (check "row backend column" (aref row 0) "claude")
-    (check "row state column" (aref row 3) "finished")))
+(describe "agent-session-overview--entries"
+  (with-session-buffers '("*claude-client:mcp-emacs:1*")
+    (let ((row (cadr (car (agent-session-overview--entries)))))
+      (it "renders a row as the four displayed columns"
+        (check (length row) 4))
+      (it "puts the backend in the first column"
+        (check (aref row 0) "claude"))
+      (it "puts the state in the last column"
+        (check (aref row 3) "finished")))))
 
-;; The subscriber must not let a render failure escape into the session
-;; that published the event.
-(cl-letf (((symbol-function 'agent-session-overview--render)
-           (lambda () (error "boom"))))
-  (check "render error is contained"
-         (progn (agent-session-overview--on-event nil '(:kind started)) 'survived)
-         'survived))
-
-;; Irrelevant kinds do not trigger a render at all.
-(let ((rendered 0))
+(describe "agent-session-overview--on-event"
+  ;; The subscriber must not let a render failure escape into the session
+  ;; that published the event.
   (cl-letf (((symbol-function 'agent-session-overview--render)
-             (lambda () (setq rendered (1+ rendered)))))
-    (agent-session-overview--on-event nil '(:kind text))
-    (check "text does not re-render" rendered 0)
-    (agent-session-overview--on-event nil '(:kind finished))
-    (check "finished re-renders" rendered 1)
-    (agent-session-overview--on-event nil '(:kind some-future-kind))
-    (check "unknown kind ignored" rendered 1)))
+             (lambda () (error "boom"))))
+    (it "contains a render error instead of raising it into the publisher"
+      (check (progn (agent-session-overview--on-event nil '(:kind started)) 'survived)
+             'survived)))
+
+  ;; Irrelevant kinds do not trigger a render at all.
+  (let ((rendered 0))
+    (cl-letf (((symbol-function 'agent-session-overview--render)
+               (lambda () (setq rendered (1+ rendered)))))
+      (agent-session-overview--on-event nil '(:kind text))
+      (it "does not re-render on a text event"
+        (check rendered 0))
+      (agent-session-overview--on-event nil '(:kind finished))
+      (it "re-renders on a finished event"
+        (check rendered 1))
+      (agent-session-overview--on-event nil '(:kind some-future-kind))
+      (it "ignores an unknown event kind"
+        (check rendered 1)))))
 
 ;;;; Actions
 
@@ -195,71 +211,102 @@ which is what the compiled and uncompiled paths both read."
      (goto-char (point-min))
      ,@body))
 
-;; Interrupting a session that is not mid-turn is refused rather than
-;; attempted.
-(with-session-buffers '("*claude-client:p:1*")
-  (with-current-buffer "*claude-client:p:1*"
-    (setq-local claude-client--turn-active nil)
-    (setq-local claude-client--process nil))
-  (let ((entry (entry-for "*claude-client:p:1*")))
-    (with-row-at-point entry
-      (check "interrupt refuses when idle"
-             (condition-case err
-                 (progn (agent-session-overview-interrupt-session) 'no-error)
-               (user-error (error-message-string err)))
-             "No turn is running for this session"))))
+(describe "agent-session-overview-interrupt-session"
+  (with-session-buffers '("*claude-client:p:1*")
+    (with-current-buffer "*claude-client:p:1*"
+      (setq-local claude-client--turn-active nil)
+      (setq-local claude-client--process nil))
+    (let ((entry (entry-for "*claude-client:p:1*")))
+      (with-row-at-point entry
+        (it "refuses rather than attempting when no turn is running"
+          (check (condition-case err
+                     (progn (agent-session-overview-interrupt-session) 'no-error)
+                   (user-error (error-message-string err)))
+                 "No turn is running for this session"))))))
 
-;; A row whose buffer has been killed is reported, not chased.
-(let ((entry (list :buffer (generate-new-buffer "*overview-dead*")
-                   :backend 'claude-client :state 'idle)))
-  (kill-buffer (plist-get entry :buffer))
-  (with-row-at-point entry
-    ;; `user-error' curls the apostrophe, so match on substance not glyph.
-    (check "dead buffer is reported"
-           (condition-case err
-               (progn (agent-session-overview-visit) 'no-error)
-             (user-error (and (string-match-p "buffer is gone"
-                                             (error-message-string err))
-                              'reported)))
-           'reported)))
+;; `k' is evil's `evil-previous-line', so an unconfirmed kill here ended
+;; sessions the human was only scrolling past.
+(describe "agent-session-overview-quit-session"
+  (with-session-buffers '("*claude-client:p:2*")
+    (with-current-buffer "*claude-client:p:2*"
+      (setq-local claude-client--turn-active nil)
+      (setq-local claude-client--process nil))
+    (let ((entry (entry-for "*claude-client:p:2*")))
+      (with-row-at-point entry
+        (it "leaves the process alone when the confirmation is declined"
+          (check (cl-letf (((symbol-function 'yes-or-no-p) (lambda (&rest _) nil))
+                           ((symbol-function 'claude-client-quit)
+                            (lambda (&rest _) (error "should not be reached"))))
+                   (condition-case err
+                       (progn (agent-session-overview-quit-session) 'no-error)
+                     (user-error (error-message-string err))))
+                 "Session left running"))
+        (it "still quits the session when the confirmation is accepted"
+          (check (let ((quit nil))
+                   (cl-letf (((symbol-function 'yes-or-no-p) (lambda (&rest _) t))
+                             ((symbol-function 'claude-client-quit)
+                              (lambda (&rest _) (setq quit t)))
+                             ((symbol-function 'agent-session-overview--render)
+                              #'ignore))
+                     (agent-session-overview-quit-session)
+                     quit))
+                 t))))))
+
+(describe "agent-session-overview-visit"
+  (let ((entry (list :buffer (generate-new-buffer "*overview-dead*")
+                     :backend 'claude-client :state 'idle)))
+    (kill-buffer (plist-get entry :buffer))
+    (with-row-at-point entry
+      ;; `user-error' curls the apostrophe, so match on substance not glyph.
+      (it "reports a killed buffer rather than chasing it"
+        (check (condition-case err
+                   (progn (agent-session-overview-visit) 'no-error)
+                 (user-error (and (string-match-p "buffer is gone"
+                                                  (error-message-string err))
+                                  'reported)))
+               'reported)))))
 
 ;;;; Help
 
 ;; The key hint names every binding, so the list stays the one source of
 ;; truth for what the buffer can do.
-(let ((terse (agent-session-overview--key-hint))
-      (verbose (agent-session-overview--key-hint t)))
-  (dolist (binding agent-session-overview--help)
-    (check (format "hint names %s" (car binding))
-           (and (string-match-p (regexp-quote (car binding)) terse) t) t)
-    (check (format "verbose hint describes %s" (car binding))
-           (and (string-match-p (regexp-quote (cadr binding)) verbose) t) t)))
+(describe "agent-session-overview--key-hint"
+  (let ((terse (agent-session-overview--key-hint))
+        (verbose (agent-session-overview--key-hint t)))
+    (dolist (binding agent-session-overview--help)
+      (it "names every documented key in the terse hint"
+        (check-that (string-match-p (regexp-quote (car binding)) terse)
+                    (format "names %s in the terse hint" (car binding))))
+      (it "describes every documented key in the verbose hint"
+        (check-that (string-match-p (regexp-quote (cadr binding)) verbose)
+                    (format "describes %s in the verbose hint" (car binding)))))))
 
 ;; Every documented key is actually bound -- documenting an action that
 ;; does nothing is worse than not documenting it.  `g' and `q' come from
 ;; the parent mode, so look them up through the real keymap.
-(with-temp-buffer
-  (agent-session-overview-mode)
-  (dolist (binding agent-session-overview--help)
-    (let ((key (car binding)))
-      (check (format "%s is bound" key)
-             (and (commandp (key-binding (kbd key))) t)
-             t))))
+(describe "agent-session-overview-mode keymap"
+  (with-temp-buffer
+    (agent-session-overview-mode)
+    (dolist (binding agent-session-overview--help)
+      (let ((key (car binding)))
+        (it "actually binds every key the help documents"
+          (check-that (commandp (key-binding (kbd key)))
+                      (format "binds %s" key)))))))
 
-;; `?' opens a help buffer rather than signalling.
-(check "help renders"
-       (progn (agent-session-overview-help)
-              (and (get-buffer "*ai-sessions help*") t))
-       t)
+(describe "agent-session-overview-help"
+  (it "opens a help buffer rather than signalling"
+    (check (progn (agent-session-overview-help)
+                  (and (get-buffer "*ai-sessions help*") t))
+           t))
 
-;; The help text explains the per-backend state precision, which is the
-;; one thing about this buffer that surprises people.
-(with-current-buffer "*ai-sessions help*"
-  (let ((text (buffer-substring-no-properties (point-min) (point-max))))
-    (check "help explains claude states"
-           (and (string-match-p "working / idle / finished" text) t) t)
-    (check "help explains liveness-only backends"
-           (and (string-match-p "live / dead" text) t) t)))
+  ;; The help text explains the per-backend state precision, which is the
+  ;; one thing about this buffer that surprises people.
+  (with-current-buffer "*ai-sessions help*"
+    (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+      (it "explains which states claude-client can report"
+        (check-that (string-match-p "working / idle / finished" text)))
+      (it "explains that other backends report liveness only"
+        (check-that (string-match-p "live / dead" text))))))
 (kill-buffer "*ai-sessions help*")
 
 ;; Issue #59: reading the help used to dismiss the overview behind it,
@@ -277,53 +324,56 @@ which is what the compiled and uncompiled paths both read."
 ;; must beat a matching `display-buffer-alist' entry, since that is how
 ;; the framework imposes a side window.  So stand in for the framework
 ;; with a rule that would force one, and require it to lose.
-(let ((overview (get-buffer-create agent-session-overview-buffer-name)))
-  (unwind-protect
-      (let ((display-buffer-alist
-             `((,(regexp-quote agent-session-overview--help-buffer-name)
-                (display-buffer-in-side-window)
-                (side . bottom)))))
-        (delete-other-windows)
-        (switch-to-buffer overview)
-        (let ((overview-window (selected-window)))
-          (agent-session-overview-help)
-          (let ((help-window (get-buffer-window
-                              agent-session-overview--help-buffer-name)))
-            (check "help gets its own window"
-                   (and (window-live-p help-window) t) t)
-            ;; The assertion that fails without the fix: a side window is
-            ;; the popup failure mode, and a plain split is what keeps `q'
-            ;; from taking the overview with it.
-            (check "help placement beats a side-window rule"
-                   (window-parameter help-window 'window-side) nil)
-            (check "help is split from the overview, not replacing it"
-                   (and (window-live-p overview-window)
-                        (eq (window-buffer overview-window) overview))
-                   t)
-            ;; The point of the issue: closing the help returns you to the
-            ;; list instead of taking it down too.
-            (quit-window nil help-window)
-            (check "quitting the help keeps the overview"
-                   (and (window-live-p (get-buffer-window overview)) t) t))))
-    (when (get-buffer agent-session-overview--help-buffer-name)
-      (kill-buffer agent-session-overview--help-buffer-name))
-    (kill-buffer overview)
-    (delete-other-windows)))
+(describe "agent-session-overview-help window placement"
+  (let ((overview (get-buffer-create agent-session-overview-buffer-name)))
+    (unwind-protect
+        (let ((display-buffer-alist
+               `((,(regexp-quote agent-session-overview--help-buffer-name)
+                  (display-buffer-in-side-window)
+                  (side . bottom)))))
+          (delete-other-windows)
+          (switch-to-buffer overview)
+          (let ((overview-window (selected-window)))
+            (agent-session-overview-help)
+            (let ((help-window (get-buffer-window
+                                agent-session-overview--help-buffer-name)))
+              (it "gives the help its own live window"
+                (check-that (window-live-p help-window)))
+              ;; The assertion that fails without the fix: a side window is
+              ;; the popup failure mode, and a plain split is what keeps `q'
+              ;; from taking the overview with it.
+              (it "wins over a display-buffer rule forcing a side window"
+                (check (window-parameter help-window 'window-side) nil))
+              (it "splits off the overview's window instead of replacing it"
+                (check (and (window-live-p overview-window)
+                            (eq (window-buffer overview-window) overview))
+                       t))
+              ;; The point of the issue: closing the help returns you to the
+              ;; list instead of taking it down too.
+              (quit-window nil help-window)
+              (it "leaves the overview standing when the help is quit"
+                (check-that (window-live-p (get-buffer-window overview)))))))
+      (when (get-buffer agent-session-overview--help-buffer-name)
+        (kill-buffer agent-session-overview--help-buffer-name))
+      (kill-buffer overview)
+      (delete-other-windows))))
 
 ;; The column headers keep the header-line, since only tabulated-list
 ;; aligns them with the data; the hint lives in the mode line and must
 ;; actually render there.
-(with-temp-buffer
-  (agent-session-overview-mode)
-  (check "columns keep the header-line" tabulated-list-use-header-line t)
-  ;; `format-mode-line' renders to "" in batch (there is no window), so
-  ;; assert the construct is installed and that it produces the keys.
-  (check "mode line carries the hint"
-         (and (member '(:eval (agent-session-overview--key-hint)) mode-line-format) t)
-         t)
-  (let ((hint (substring-no-properties (agent-session-overview--key-hint))))
-    (check "hint renders the keys"
-           (and (string-match-p "RET" hint) (string-match-p "\\?" hint) t) t)))
+(describe "agent-session-overview-mode display"
+  (with-temp-buffer
+    (agent-session-overview-mode)
+    (it "keeps the header-line so tabulated-list aligns the columns"
+      (check tabulated-list-use-header-line t))
+    ;; `format-mode-line' renders to "" in batch (there is no window), so
+    ;; assert the construct is installed and that it produces the keys.
+    (it "installs the key hint in the mode line"
+      (check (and (member '(:eval (agent-session-overview--key-hint)) mode-line-format) t)
+             t))
+    (let ((hint (substring-no-properties (agent-session-overview--key-hint))))
+      (it "renders the keys into the hint text"
+        (check (and (string-match-p "RET" hint) (string-match-p "\\?" hint) t) t)))))
 
 ;;;; Evil integration
 
@@ -331,30 +381,37 @@ which is what the compiled and uncompiled paths both read."
 ;; keys must be re-registered per state or they are all dead in a
 ;; Doom-style config.  Evil is absent in batch, so record what the setup
 ;; would bind by capturing `evil-define-key*' calls.
-(let (registered)
-  (cl-letf (((symbol-function 'evil-define-key*)
-             (lambda (states _map key def &rest _)
-               (push (list states (key-description key) def) registered))))
-    (agent-session-overview--setup-evil)
-    (let ((keys (mapcar #'cadr registered)))
-      (check "evil gets RET" (and (member "RET" keys) t) t)
-      (check "evil gets k" (and (member "k" keys) t) t)
-      (check "evil gets i" (and (member "i" keys) t) t)
-      (check "evil gets ?" (and (member "?" keys) t) t)
-      ;; `g' is already an evil prefix whose `g r' reverts, and `q'
-      ;; quits the window -- taking either would break a convention.
-      (check "evil keeps g" (member "g" keys) nil)
-      (check "evil keeps q" (member "q" keys) nil))
-    (check "evil bindings target normal and motion"
-           (seq-every-p (lambda (r) (equal (car r) '(normal motion))) registered) t)
-    (check "evil bindings are commands"
-           (seq-every-p (lambda (r) (commandp (nth 2 r))) registered) t)))
+(describe "agent-session-overview--setup-evil"
+  (let (registered)
+    (cl-letf (((symbol-function 'evil-define-key*)
+               (lambda (states _map key def &rest _)
+                 (push (list states (key-description key) def) registered))))
+      (agent-session-overview--setup-evil)
+      (let ((keys (mapcar #'cadr registered)))
+        (it "re-registers RET for evil"
+          (check (and (member "RET" keys) t) t))
+        (it "re-registers k for evil"
+          (check (and (member "k" keys) t) t))
+        (it "re-registers i for evil"
+          (check (and (member "i" keys) t) t))
+        (it "re-registers ? for evil"
+          (check (and (member "?" keys) t) t))
+        ;; `g' is already an evil prefix whose `g r' reverts, and `q'
+        ;; quits the window -- taking either would break a convention.
+        (it "leaves g to evil's own prefix"
+          (check (member "g" keys) nil))
+        (it "leaves q to evil's window quit"
+          (check (member "q" keys) nil)))
+      (it "registers every binding for the normal and motion states"
+        (check (seq-every-p (lambda (r) (equal (car r) '(normal motion))) registered) t))
+      (it "binds only commands"
+        (check (seq-every-p (lambda (r) (commandp (nth 2 r))) registered) t))))
 
-;; Absent evil, setup must be a silent no-op rather than an error.
-(cl-letf (((symbol-function 'fboundp) (lambda (s) (not (eq s 'evil-define-key*)))))
-  (check "no-op without evil"
-         (progn (agent-session-overview--setup-evil) 'survived) 'survived))
+  ;; Absent evil, setup must be a silent no-op rather than an error.
+  (cl-letf (((symbol-function 'fboundp) (lambda (s) (not (eq s 'evil-define-key*)))))
+    (it "is a silent no-op when evil is absent"
+      (check (progn (agent-session-overview--setup-evil) 'survived) 'survived))))
 
-(princ (format "\n%s\n" (if (zerop failures) "ALL PASS" (format "%d FAILURE(S)" failures))))
-(kill-emacs (if (zerop failures) 0 1))
+(test-helper-summary)
+
 ;;; agent-session-overview-test.el ends here

--- a/test/claude-client-test.el
+++ b/test/claude-client-test.el
@@ -6,11 +6,11 @@
 ;; `claude --print --output-format stream-json' output.
 
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'cl-lib)
 (require 'json)
 (require 'claude-client)
-
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
 
 (defun claude-test--buffer ()
   "Return a fresh conversation buffer in `claude-client-mode'."
@@ -62,206 +62,239 @@ records."
 ;; tools must be off and the MCP config on, or Claude edits files directly
 ;; and never reaches the ediff gate.
 
-(let ((cmd (claude-client--command)))
-  (check "cmd-print" (and (member "--print" cmd) t) t)
-  (check "cmd-stream-json-out"
-         (equal (cadr (member "--output-format" cmd)) "stream-json") t)
-  (check "cmd-stream-json-in"
-         (equal (cadr (member "--input-format" cmd)) "stream-json") t)
-  (check "cmd-strict-mcp" (and (member "--strict-mcp-config" cmd) t) t)
-  (check "cmd-has-mcp-config" (and (member "--mcp-config" cmd) t) t)
-  (check "cmd-has-settings" (and (member "--settings" cmd) t) t)
-  ;; Edit and MultiEdit both: MultiEdit alone can batch writes past the gate.
-  (check "cmd-disallows-write" (and (member "Write" cmd) t) t)
-  (check "cmd-disallows-edit" (and (member "Edit" cmd) t) t)
-  (check "cmd-disallows-multiedit" (and (member "MultiEdit" cmd) t) t))
+(describe "claude-client--command"
+  (let ((cmd (claude-client--command)))
+    (it "runs the CLI in non-interactive print mode"
+      (check-that (member "--print" cmd)))
+    (it "asks for stream-json on stdout"
+      (check-that (equal (cadr (member "--output-format" cmd)) "stream-json")))
+    (it "asks for stream-json on stdin"
+      (check-that (equal (cadr (member "--input-format" cmd)) "stream-json")))
+    (it "confines the CLI to the generated MCP config"
+      (check-that (member "--strict-mcp-config" cmd)))
+    (it "passes the generated MCP config"
+      (check-that (member "--mcp-config" cmd)))
+    (it "passes the generated settings file"
+      (check-that (member "--settings" cmd)))
+    (it "disallows Write so edits cannot bypass the ediff gate"
+      (check-that (member "Write" cmd)))
+    (it "disallows Edit so edits cannot bypass the ediff gate"
+      (check-that (member "Edit" cmd)))
+    ;; Edit and MultiEdit both: MultiEdit alone can batch writes past the gate.
+    (it "disallows MultiEdit, which alone could batch writes past the gate"
+      (check-that (member "MultiEdit" cmd)))))
 
-;; The generated MCP config points at the mcp-emacs HTTP endpoint.
-(let* ((file (claude-client--mcp-config-file))
-       (parsed (with-temp-buffer
-                 (insert-file-contents file)
-                 (json-parse-string (buffer-string)
-                                    :object-type 'alist :array-type 'list))))
-  (let* ((servers (alist-get 'mcpServers parsed))
-         (emacs (alist-get 'emacs servers)))
-    (check "mcp-config-type" (alist-get 'type emacs) "http")
-    (check "mcp-config-url-mcp-path"
-           (and (string-suffix-p "/mcp" (alist-get 'url emacs)) t) t))
-  (delete-file file))
+(describe "claude-client--mcp-config-file"
+  (let* ((file (claude-client--mcp-config-file))
+         (parsed (with-temp-buffer
+                   (insert-file-contents file)
+                   (json-parse-string (buffer-string)
+                                      :object-type 'alist :array-type 'list))))
+    (let* ((servers (alist-get 'mcpServers parsed))
+           (emacs (alist-get 'emacs servers)))
+      (it "declares the emacs server as an HTTP transport"
+        (check (alist-get 'type emacs) "http"))
+      (it "points at the mcp-emacs /mcp endpoint"
+        (check-that (string-suffix-p "/mcp" (alist-get 'url emacs)))))
+    (delete-file file)))
 
-;; apply_diff must be allowlisted: proxied MCP tools are denied by default,
-;; so without this every edit is refused before the human sees an ediff.
-(let* ((file (claude-client--settings-file))
-       (parsed (with-temp-buffer
-                 (insert-file-contents file)
-                 (json-parse-string (buffer-string)
-                                    :object-type 'alist :array-type 'list))))
-  (let ((allow (alist-get 'allow (alist-get 'permissions parsed))))
-    (check "settings-allows-apply-diff"
-           (and (member "mcp__emacs__apply_diff" allow) t) t))
-  (delete-file file))
+(describe "claude-client--settings-file"
+  (let* ((file (claude-client--settings-file))
+         (parsed (with-temp-buffer
+                   (insert-file-contents file)
+                   (json-parse-string (buffer-string)
+                                      :object-type 'alist :array-type 'list))))
+    ;; apply_diff must be allowlisted: proxied MCP tools are denied by default,
+    ;; so without this every edit is refused before the human sees an ediff.
+    (let ((allow (alist-get 'allow (alist-get 'permissions parsed))))
+      (it "allowlists apply_diff, which is denied by default as a proxied MCP tool"
+        (check-that (member "mcp__emacs__apply_diff" allow))))
+    (delete-file file)))
 
 ;;;; Stream framing
 ;;
 ;; stream-json is NDJSON: one object per line.  The filter must tolerate a
 ;; chunk boundary landing mid-line, since the pipe splits wherever it likes.
 
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf (concat claude-test--init "\n"))
-        (check "frame-single-line" (claude-test--kinds buf) '(started)))
-    (kill-buffer buf)))
+(describe "claude-client--filter framing"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf (concat claude-test--init "\n"))
+          (it "dispatches a single complete line"
+            (check (claude-test--kinds buf) '(started))))
+      (kill-buffer buf)))
 
-;; A line split across two chunks is buffered until its newline arrives.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (let* ((whole (concat claude-test--init "\n"))
-             (cut (/ (length whole) 2)))
-        (claude-test--feed buf (substring whole 0 cut))
-        (check "frame-partial-not-yet" (claude-test--kinds buf) nil)
-        (claude-test--feed buf (substring whole cut))
-        (check "frame-partial-completed" (claude-test--kinds buf) '(started)))
-    (kill-buffer buf)))
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (let* ((whole (concat claude-test--init "\n"))
+               (cut (/ (length whole) 2)))
+          (claude-test--feed buf (substring whole 0 cut))
+          (it "holds a line split across chunks until its newline arrives"
+            (check (claude-test--kinds buf) nil))
+          (claude-test--feed buf (substring whole cut))
+          (it "dispatches the split line once the newline arrives"
+            (check (claude-test--kinds buf) '(started))))
+      (kill-buffer buf)))
 
-;; Several objects arriving in one chunk all get dispatched.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed
-         buf (concat claude-test--init "\n" claude-test--text-msg "\n"))
-        (check "frame-multiple-in-chunk"
-               (claude-test--kinds buf) '(started text)))
-    (kill-buffer buf)))
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed
+           buf (concat claude-test--init "\n" claude-test--text-msg "\n"))
+          (it "dispatches every object arriving in one chunk"
+            (check (claude-test--kinds buf) '(started text))))
+      (kill-buffer buf)))
 
-;; Garbage lines are skipped rather than aborting the stream.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf "not json at all\n"
-                           (concat claude-test--init "\n"))
-        (check "frame-skips-garbage" (claude-test--kinds buf) '(started)))
-    (kill-buffer buf)))
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf "not json at all\n"
+                             (concat claude-test--init "\n"))
+          (it "skips a garbage line rather than aborting the stream"
+            (check (claude-test--kinds buf) '(started))))
+      (kill-buffer buf))))
 
 ;;;; Event mapping
 
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf (concat claude-test--init "\n"))
-        (with-current-buffer buf
-          (check "init-records-session" claude-client--session-id "abc-123")
-          (let ((e (car claude-client--events)))
-            (check "init-kind" (plist-get e :kind) 'started)
-            (check "init-model" (plist-get e :model) "claude-opus-5"))))
-    (kill-buffer buf)))
+(describe "system init events"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf (concat claude-test--init "\n"))
+          (with-current-buffer buf
+            (it "records the session id for later resumes"
+              (check claude-client--session-id "abc-123"))
+            (let ((e (car claude-client--events)))
+              (it "maps init to a started event"
+                (check (plist-get e :kind) 'started))
+              (it "carries the model the CLI announced"
+                (check (plist-get e :model) "claude-opus-5")))))
+      (kill-buffer buf))))
 
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf (concat claude-test--text-msg "\n"))
-        (with-current-buffer buf
-          (let ((e (car claude-client--events)))
-            (check "text-kind" (plist-get e :kind) 'text)
-            (check "text-content" (plist-get e :text) "I'll write the file."))))
-    (kill-buffer buf)))
+(describe "assistant text events"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf (concat claude-test--text-msg "\n"))
+          (with-current-buffer buf
+            (let ((e (car claude-client--events)))
+              (it "maps an assistant text block to a text event"
+                (check (plist-get e :kind) 'text))
+              (it "carries the model's prose verbatim"
+                (check (plist-get e :text) "I'll write the file.")))))
+      (kill-buffer buf))))
 
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf (concat claude-test--tool-use "\n"))
-        (with-current-buffer buf
-          (let ((e (car claude-client--events)))
-            (check "tool-use-kind" (plist-get e :kind) 'tool-use)
-            (check "tool-use-name"
-                   (plist-get e :name) "mcp__emacs__apply_diff"))))
-    (kill-buffer buf)))
+(describe "assistant tool_use events"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf (concat claude-test--tool-use "\n"))
+          (with-current-buffer buf
+            (let ((e (car claude-client--events)))
+              (it "maps a tool_use block to a tool-use event"
+                (check (plist-get e :kind) 'tool-use))
+              (it "carries the name of the tool being called"
+                (check (plist-get e :name) "mcp__emacs__apply_diff")))))
+      (kill-buffer buf))))
 
 ;; tool_result content is a plain string in practice; the list form is also
 ;; accepted, so both shapes must land as text.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf (concat claude-test--tool-result "\n"))
-        (with-current-buffer buf
-          (let ((e (car claude-client--events)))
-            (check "tool-result-kind" (plist-get e :kind) 'tool-result)
-            (check "tool-result-text"
-                   (plist-get e :text) "Status: applied\nnew\n"))))
-    (kill-buffer buf)))
+(describe "tool_result events"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf (concat claude-test--tool-result "\n"))
+          (with-current-buffer buf
+            (let ((e (car claude-client--events)))
+              (it "maps a tool_result block to a tool-result event"
+                (check (plist-get e :kind) 'tool-result))
+              (it "carries string content as the event text"
+                (check (plist-get e :text) "Status: applied\nnew\n")))))
+      (kill-buffer buf)))
 
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed
-         buf (concat "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"content\":[{\"type\":\"text\",\"text\":\"from list\"}]}]}}" "\n"))
-        (with-current-buffer buf
-          (check "tool-result-list-form"
-                 (plist-get (car claude-client--events) :text) "from list")))
-    (kill-buffer buf)))
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed
+           buf (concat "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"content\":[{\"type\":\"text\",\"text\":\"from list\"}]}]}}" "\n"))
+          (with-current-buffer buf
+            (it "accepts the list content shape as well as a plain string"
+              (check (plist-get (car claude-client--events) :text) "from list"))))
+      (kill-buffer buf))))
 
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf (concat claude-test--result "\n"))
-        (with-current-buffer buf
-          (let ((e (car claude-client--events)))
-            (check "result-kind" (plist-get e :kind) 'finished)
-            (check "result-subtype" (plist-get e :subtype) "success"))))
-    (kill-buffer buf)))
+(describe "result events"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf (concat claude-test--result "\n"))
+          (with-current-buffer buf
+            (let ((e (car claude-client--events)))
+              (it "maps result to a finished event"
+                (check (plist-get e :kind) 'finished))
+              (it "carries the subtype saying how the turn ended"
+                (check (plist-get e :subtype) "success")))))
+      (kill-buffer buf))))
 
-;; Unknown top-level types are ignored, not turned into stray events.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf "{\"type\":\"rate_limit_event\"}\n")
-        (check "ignores-unknown-type" (claude-test--kinds buf) nil))
-    (kill-buffer buf)))
+(describe "events the runner has no mapping for"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf "{\"type\":\"rate_limit_event\"}\n")
+          (it "ignores an unknown top-level type instead of logging a stray event"
+            (check (claude-test--kinds buf) nil)))
+      (kill-buffer buf)))
 
-;; Empty assistant text blocks produce no event (the CLI emits these while
-;; streaming partial messages).
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed
-         buf "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"   \"}]}}\n")
-        (check "skips-empty-text" (claude-test--kinds buf) nil))
-    (kill-buffer buf)))
+  ;; Empty assistant text blocks produce no event (the CLI emits these while
+  ;; streaming partial messages).
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed
+           buf "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"   \"}]}}\n")
+          (it "logs nothing for the blank text blocks the CLI emits while streaming"
+            (check (claude-test--kinds buf) nil)))
+      (kill-buffer buf))))
 
 ;;;; Event ordering and the subscriber hook
 
-;; The log is append-only and in arrival order -- this is what issue #39
-;; subscribes to, so ordering is a contract, not an implementation detail.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf
-                           (concat claude-test--init "\n")
-                           (concat claude-test--text-msg "\n")
-                           (concat claude-test--tool-use "\n")
-                           (concat claude-test--tool-result "\n")
-                           (concat claude-test--result "\n"))
-        (check "event-order"
-               (claude-test--kinds buf)
-               '(started text tool-use tool-result finished)))
-    (kill-buffer buf)))
+(describe "the event log"
+  ;; The log is append-only and in arrival order -- this is what issue #39
+  ;; subscribes to, so ordering is a contract, not an implementation detail.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf
+                             (concat claude-test--init "\n")
+                             (concat claude-test--text-msg "\n")
+                             (concat claude-test--tool-use "\n")
+                             (concat claude-test--tool-result "\n")
+                             (concat claude-test--result "\n"))
+          (it "keeps events in arrival order, which subscribers rely on"
+            (check (claude-test--kinds buf)
+                   '(started text tool-use tool-result finished))))
+      (kill-buffer buf))))
 
 ;; Every event is announced to `claude-client-event-functions' with its
 ;; buffer -- the seam that lets #39 attach an Org transcript subscriber
 ;; without touching the renderer.
-(let* ((buf (claude-test--buffer))
-       (seen nil)
-       (claude-client-event-functions
-        (list (lambda (b e) (push (cons b (plist-get e :kind)) seen)))))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf
-                           (concat claude-test--init "\n")
-                           (concat claude-test--result "\n"))
-        (check "hook-called-per-event" (length seen) 2)
-        (check "hook-receives-buffer" (car (car seen)) buf)
-        (check "hook-order" (mapcar #'cdr (reverse seen)) '(started finished)))
-    (kill-buffer buf)))
+(describe "claude-client-event-functions"
+  (let* ((buf (claude-test--buffer))
+         (seen nil)
+         (claude-client-event-functions
+          (list (lambda (b e) (push (cons b (plist-get e :kind)) seen)))))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf
+                             (concat claude-test--init "\n")
+                             (concat claude-test--result "\n"))
+          (it "is called once per event"
+            (check (length seen) 2))
+          (it "tells the subscriber which conversation the event came from"
+            (check (car (car seen)) buf))
+          (it "announces events in the order they arrived"
+            (check (mapcar #'cdr (reverse seen)) '(started finished))))
+      (kill-buffer buf))))
 
 ;;;; The process dying
 
@@ -270,86 +303,94 @@ records."
 ;; the transcript ending on whatever the model was mid-way through --
 ;; typically a `tool-use' with no result, indistinguishable from a turn
 ;; still running.  Observed in a real session (issue #62).
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf
-                           (concat claude-test--init "\n")
-                           (concat claude-test--tool-use "\n"))
-        (with-current-buffer buf (setq claude-client--turn-active t))
-        (claude-client--sentinel buf (claude-test--dead-process "false")
-                                 "exited abnormally with code 1\n")
-        (check "death-mid-turn-logged"
-               (claude-test--kinds buf) '(started tool-use died))
-        (check "death-mid-turn-rendered"
-               (and (string-match-p "died mid-turn" (claude-test--text buf)) t) t)
-        ;; The cause is recorded, not guessed: the sentinel's own account of
-        ;; how the process ended, plus a status code to branch on.  Without
-        ;; these the banner asserts a death it cannot evidence (issue #62).
-        (let ((e (car (last (with-current-buffer buf claude-client--events)))))
-          (check "death-records-reason"
-                 (plist-get e :reason) "exited abnormally with code 1")
-          (check "death-records-status" (plist-get e :status) 1))
-        (check "death-reason-rendered"
-               (and (string-match-p "died mid-turn: exited abnormally with code 1"
-                                    (claude-test--text buf))
-                    t)
-               t)
-        (with-current-buffer buf
-          (check "death-clears-process" claude-client--process nil)
-          ;; Left set, the buffer could never start another turn.
-          (check "death-clears-turn-flag" claude-client--turn-active nil)))
-    (kill-buffer buf)))
+(describe "claude-client--sentinel on a turn cut short"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf
+                             (concat claude-test--init "\n")
+                             (concat claude-test--tool-use "\n"))
+          (with-current-buffer buf (setq claude-client--turn-active t))
+          (claude-client--sentinel buf (claude-test--dead-process "false")
+                                   "exited abnormally with code 1\n")
+          (it "appends a died event so the transcript does not end mid-tool-call"
+            (check (claude-test--kinds buf) '(started tool-use died)))
+          (it "renders a banner saying the turn died"
+            (check-that (string-match-p "died mid-turn" (claude-test--text buf))))
+          ;; The cause is recorded, not guessed: the sentinel's own account of
+          ;; how the process ended, plus a status code to branch on.  Without
+          ;; these the banner asserts a death it cannot evidence (issue #62).
+          (let ((e (car (last (with-current-buffer buf claude-client--events)))))
+            (it "records the sentinel's own account of how the process ended"
+              (check (plist-get e :reason) "exited abnormally with code 1"))
+            (it "records the exit status so callers can branch on it"
+              (check (plist-get e :status) 1)))
+          (it "names the cause in the banner rather than asserting a bare death"
+            (check-that (string-match-p "died mid-turn: exited abnormally with code 1"
+                                        (claude-test--text buf))))
+          (with-current-buffer buf
+            (it "forgets the dead process"
+              (check claude-client--process nil))
+            ;; Left set, the buffer could never start another turn.
+            (it "clears the in-flight flag so another turn can start"
+              (check claude-client--turn-active nil))))
+      (kill-buffer buf))))
 
 ;; A process exiting between turns is the normal way a conversation ends
 ;; (`claude --print' lingers on stdin, so this is the human quitting).
 ;; Nothing was cut short, so nothing is reported.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf
-                           (concat claude-test--init "\n")
-                           (concat claude-test--result "\n"))
-        (claude-client--sentinel buf (claude-test--dead-process) nil)
-        (check "clean-exit-silent"
-               (claude-test--kinds buf) '(started finished)))
-    (kill-buffer buf)))
+(describe "claude-client--sentinel on a clean exit"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf
+                             (concat claude-test--init "\n")
+                             (concat claude-test--result "\n"))
+          (claude-client--sentinel buf (claude-test--dead-process) nil)
+          (it "reports nothing when the process exits between turns"
+            (check (claude-test--kinds buf) '(started finished))))
+      (kill-buffer buf))))
 
 ;; The sentinel outliving its buffer must not signal -- it fires from a
 ;; process filter, where an error is swallowed and leaves the log wedged.
-(let ((buf (claude-test--buffer)))
-  (kill-buffer buf)
-  (check "death-after-buffer-killed"
-         (progn (claude-client--sentinel buf (claude-test--dead-process) nil)
-                'survived)
-         'survived))
+(describe "claude-client--sentinel outliving its buffer"
+  (let ((buf (claude-test--buffer)))
+    (kill-buffer buf)
+    (it "returns rather than signalling, since an error here wedges the log"
+      (check (progn (claude-client--sentinel buf (claude-test--dead-process) nil)
+                    'survived)
+             'survived))))
 
 ;;;; Rendering
 
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf
-                           (concat claude-test--init "\n")
-                           (concat claude-test--text-msg "\n")
-                           (concat claude-test--tool-use "\n")
-                           (concat claude-test--result "\n"))
-        (let ((text (claude-test--text buf)))
-          (check "render-has-text"
-                 (and (string-match-p "I'll write the file\\." text) t) t)
-          (check "render-has-tool"
-                 (and (string-match-p "mcp__emacs__apply_diff" text) t) t)
-          (check "render-has-banner"
-                 (and (string-match-p "claude-opus-5" text) t) t)))
-    (kill-buffer buf)))
+(describe "rendering a whole turn"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf
+                             (concat claude-test--init "\n")
+                             (concat claude-test--text-msg "\n")
+                             (concat claude-test--tool-use "\n")
+                             (concat claude-test--result "\n"))
+          (let ((text (claude-test--text buf)))
+            (it "shows the model's prose"
+              (check-that (string-match-p "I'll write the file\\." text)))
+            (it "shows the tool that was called"
+              (check-that (string-match-p "mcp__emacs__apply_diff" text)))
+            (it "shows the model name in the opening banner"
+              (check-that (string-match-p "claude-opus-5" text)))))
+      (kill-buffer buf))))
 
 ;; The buffer is read-only for the human but still writable by the renderer.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (check "mode-is-special" (derived-mode-p 'special-mode) 'special-mode)
-        (check "buffer-read-only" buffer-read-only t))
-    (kill-buffer buf)))
+(describe "claude-client-mode"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (it "derives from `special-mode'"
+            (check (derived-mode-p 'special-mode) 'special-mode))
+          (it "leaves the conversation read-only for the human"
+            (check buffer-read-only t)))
+      (kill-buffer buf))))
 
 ;;;; Prettified rendering
 ;;
@@ -362,78 +403,90 @@ records."
   "Return the `face' property of STRING at INDEX."
   (get-text-property index 'face string))
 
-(let ((cases '((started . claude-client-banner-face)
-               (finished . claude-client-banner-face)
-               (interrupted . claude-client-banner-face)
-               (prompt . claude-client-prompt-face)
-               (note . claude-client-note-face)
-               (error . claude-client-error-face)
-               ;; `died' is faced as an error rather than a banner: the two
-               ;; deliberate endings are chrome, this one is a failure.
-               (died . claude-client-error-face))))
-  (dolist (c cases)
-    (let* ((kind (car c))
-           (s (claude-client--render-event
-               (list :kind kind :text "x" :model "m" :subtype "success"
-                     :session "s")))
-           ;; `prompt' opens with a newline that carries no face.
-           (i (if (eq kind 'prompt) 1 0)))
-      (check (format "face-%s" kind) (claude-test--face-at s i) (cdr c)))))
+(describe "faces on rendered events"
+  (let ((cases '((started . claude-client-banner-face)
+                 (finished . claude-client-banner-face)
+                 (interrupted . claude-client-banner-face)
+                 (prompt . claude-client-prompt-face)
+                 (note . claude-client-note-face)
+                 (error . claude-client-error-face)
+                 ;; `died' is faced as an error rather than a banner: the two
+                 ;; deliberate endings are chrome, this one is a failure.
+                 (died . claude-client-error-face))))
+    (dolist (c cases)
+      (let* ((kind (car c))
+             (s (claude-client--render-event
+                 (list :kind kind :text "x" :model "m" :subtype "success"
+                       :session "s")))
+             ;; `prompt' opens with a newline that carries no face.
+             (i (if (eq kind 'prompt) 1 0)))
+        (it (format "faces a %s event on the `face' property" kind)
+          (check (claude-test--face-at s i) (cdr c)
+                 (format "faces a %s event on the `face' property" kind)))))))
 
 ;; The banner reports what the sentinel observed, and no more: with a
 ;; reason it names the cause, without one it claims only that the turn
 ;; died.  An empty reason must not render as a dangling colon.
-(let ((s (claude-client--render-event
-          '(:kind died :reason "killed by signal 15" :status 15))))
-  (check "died-names-cause"
-         (substring-no-properties s) "── died mid-turn: killed by signal 15 ──"))
+(describe "rendering a died event"
+  (let ((s (claude-client--render-event
+            '(:kind died :reason "killed by signal 15" :status 15))))
+    (it "names the cause when the sentinel supplied a reason"
+      (check (substring-no-properties s)
+             "── died mid-turn: killed by signal 15 ──")))
 
-(dolist (event '((:kind died) (:kind died :reason "")))
-  (check "died-without-reason"
-         (substring-no-properties (claude-client--render-event event))
-         "── died mid-turn ──"))
+  (dolist (event '((:kind died) (:kind died :reason "")))
+    (it "claims only that the turn died when there is no reason, without a dangling colon"
+      (check (substring-no-properties (claude-client--render-event event))
+             "── died mid-turn ──"
+             (format "claims only that the turn died for %S, without a dangling colon"
+                     event)))))
 
-(let ((s (claude-client--render-event
-          '(:kind tool-use :name "apply_diff" :input ((path . "/tmp/x"))))))
-  (check "tool-name-faced" (claude-test--face-at s 2)
-         'claude-client-tool-face)
-  (check "tool-input-shown"
-         (and (string-match-p "/tmp/x" (substring-no-properties s)) t) t)
-  (check "tool-input-faced"
-         (claude-test--face-at s (1- (length s)))
-         'claude-client-tool-input-face))
+(describe "rendering a tool-use event"
+  (let ((s (claude-client--render-event
+            '(:kind tool-use :name "apply_diff" :input ((path . "/tmp/x"))))))
+    (it "faces the tool name"
+      (check (claude-test--face-at s 2) 'claude-client-tool-face))
+    (it "shows the tool's input beside the call"
+      (check-that (string-match-p "/tmp/x" (substring-no-properties s))))
+    (it "faces the input apart from the name"
+      (check (claude-test--face-at s (1- (length s)))
+             'claude-client-tool-input-face)))
 
-;; A tool's input can be a whole file's contents; only a short summary of
-;; what was touched belongs beside the call.
-(let ((s (claude-client--render-event
-          `(:kind tool-use :name "write"
-            :input ((path . ,(concat (make-string 200 ?a) "\nsecond line")))))))
-  (check "tool-input-single-line"
-         (length (split-string (substring-no-properties s) "\n")) 1)
-  (check "tool-input-truncated"
-         (and (<= (length (substring-no-properties s)) 100) t) t))
+  ;; A tool's input can be a whole file's contents; only a short summary of
+  ;; what was touched belongs beside the call.
+  (let ((s (claude-client--render-event
+            `(:kind tool-use :name "write"
+              :input ((path . ,(concat (make-string 200 ?a) "\nsecond line")))))))
+    (it "keeps a multi-line input to a single rendered line"
+      (check (length (split-string (substring-no-properties s) "\n")) 1))
+    (it "truncates a long input to a short summary"
+      (check-that (<= (length (substring-no-properties s)) 100))))
 
-(let ((s (claude-client--render-event '(:kind tool-use :name "bare"))))
-  (check "tool-without-input" (substring-no-properties s) "  [tool: bare]"))
+  (let ((s (claude-client--render-event '(:kind tool-use :name "bare"))))
+    (it "renders a call with no input as just the tool name"
+      (check (substring-no-properties s) "  [tool: bare]"))))
 
 ;; A note not yet delivered is marked, and the marker is faced apart from
 ;; the note itself.
-(let ((s (claude-client--render-event '(:kind note :text "n" :pending t))))
-  (check "pending-marker-faced"
-         (claude-test--face-at s (1- (length s)))
-         'claude-client-pending-face))
+(describe "rendering a pending note"
+  (let ((s (claude-client--render-event '(:kind note :text "n" :pending t))))
+    (it "faces the not-yet-delivered marker apart from the note itself"
+      (check (claude-test--face-at s (1- (length s)))
+             'claude-client-pending-face))))
 
-;; Earlier this truncated to the first line, hiding the rest of a tool's
-;; answer.
-(let ((s (claude-client--render-event
-          '(:kind tool-result :text "Status: applied\n412 lines\n"))))
-  (check "tool-result-keeps-lines"
-         (substring-no-properties s) "  → Status: applied\n  → 412 lines")
-  (check "tool-result-faced" (claude-test--face-at s 2)
-         'claude-client-tool-result-face))
+(describe "rendering a tool-result event"
+  ;; Earlier this truncated to the first line, hiding the rest of a tool's
+  ;; answer.
+  (let ((s (claude-client--render-event
+            '(:kind tool-result :text "Status: applied\n412 lines\n"))))
+    (it "keeps every line rather than truncating to the first"
+      (check (substring-no-properties s) "  → Status: applied\n  → 412 lines"))
+    (it "faces the result text"
+      (check (claude-test--face-at s 2) 'claude-client-tool-result-face)))
 
-(let ((s (claude-client--render-event '(:kind tool-result :text "   "))))
-  (check "empty-tool-result-skipped" s nil))
+  (let ((s (claude-client--render-event '(:kind tool-result :text "   "))))
+    (it "renders nothing for a whitespace-only result"
+      (check s nil))))
 
 ;;;; Bounded tool results (issue #61)
 
@@ -441,152 +494,169 @@ records."
 ;; bury the prose.  Bounded now -- but *not* back to one line, which was
 ;; tried before and reverted (see `tool-result-keeps-lines' above): the
 ;; floor is a few lines plus a way to reach the rest.
-(let* ((long (mapconcat (lambda (i) (format "line %d" i))
-                        (number-sequence 1 20) "\n"))
-       (event (list :kind 'tool-result :text long))
-       (s (substring-no-properties (claude-client--render-event event 0)))
-       (lines (split-string s "\n")))
-  ;; Six shown plus the elision row.
-  (check "bounded-result-line-count" (length lines) 7)
-  (check "bounded-result-keeps-head" (car lines) "  → line 1")
-  (check "bounded-result-stops-at-limit" (nth 5 lines) "  → line 6")
-  (check "bounded-result-counts-remainder"
-         (nth 6 lines) "  → … 14 more lines (TAB to expand)")
-  ;; The elision is faced as pending, not as result text: it is chrome
-  ;; about the result rather than part of the answer.
-  (check "elision-faced"
-         (claude-test--face-at (claude-client--render-event event 0)
-                               (- (length s) 3))
-         'claude-client-pending-face))
+(describe "bounding a long tool result"
+  (let* ((long (mapconcat (lambda (i) (format "line %d" i))
+                          (number-sequence 1 20) "\n"))
+         (event (list :kind 'tool-result :text long))
+         (s (substring-no-properties (claude-client--render-event event 0)))
+         (lines (split-string s "\n")))
+    ;; Six shown plus the elision row.
+    (it "shows six lines plus an elision row"
+      (check (length lines) 7))
+    (it "keeps the head of the result"
+      (check (car lines) "  → line 1"))
+    (it "stops at the line limit"
+      (check (nth 5 lines) "  → line 6"))
+    (it "counts the elided remainder and offers a way to reach it"
+      (check (nth 6 lines) "  → … 14 more lines (TAB to expand)"))
+    ;; The elision is faced as pending, not as result text: it is chrome
+    ;; about the result rather than part of the answer.
+    (it "faces the elision as chrome rather than as part of the answer"
+      (check (claude-test--face-at (claude-client--render-event event 0)
+                                   (- (length s) 3))
+             'claude-client-pending-face)))
 
-;; Singular, because "1 more lines" reads as a bug.
-(let* ((seven (mapconcat #'number-to-string (number-sequence 1 7) "\n"))
-       (s (substring-no-properties
-           (claude-client--render-event (list :kind 'tool-result :text seven) 0))))
-  (check "bounded-result-singular"
-         (and (string-match-p "… 1 more line (TAB" s) t) t))
+  ;; Singular, because "1 more lines" reads as a bug.
+  (let* ((seven (mapconcat #'number-to-string (number-sequence 1 7) "\n"))
+         (s (substring-no-properties
+             (claude-client--render-event (list :kind 'tool-result :text seven) 0))))
+    (it "says \"1 more line\" rather than \"1 more lines\""
+      (check-that (string-match-p "… 1 more line (TAB" s))))
 
-;; Under the limit nothing is elided, and no affordance is advertised.
-(let ((s (substring-no-properties
-          (claude-client--render-event
-           '(:kind tool-result :text "one\ntwo\nthree") 0))))
-  (check "short-result-not-elided" (and (string-match-p "more line" s) t) nil)
-  (check "short-result-intact" s "  → one\n  → two\n  → three"))
+  ;; Under the limit nothing is elided, and no affordance is advertised.
+  (let ((s (substring-no-properties
+            (claude-client--render-event
+             '(:kind tool-result :text "one\ntwo\nthree") 0))))
+    (it "advertises no expansion affordance for a result under the limit"
+      (check (and (string-match-p "more line" s) t) nil))
+    (it "leaves a short result intact"
+      (check s "  → one\n  → two\n  → three"))))
 
 ;; Expansion is keyed by event index, so the *other* result stays bounded.
-(let* ((long (mapconcat (lambda (i) (format "l%d" i)) (number-sequence 1 20) "\n"))
-       (event (list :kind 'tool-result :text long))
-       (claude-client--expanded-results '(3)))
-  (check "expanded-index-shows-all"
-         (length (split-string
-                  (substring-no-properties (claude-client--render-event event 3))
-                  "\n"))
-         20)
-  (check "unexpanded-index-still-bounded"
-         (length (split-string
-                  (substring-no-properties (claude-client--render-event event 4))
-                  "\n"))
-         7))
+(describe "claude-client--expanded-results"
+  (let* ((long (mapconcat (lambda (i) (format "l%d" i)) (number-sequence 1 20) "\n"))
+         (event (list :kind 'tool-result :text long))
+         (claude-client--expanded-results '(3)))
+    (it "shows every line of the result whose index is expanded"
+      (check (length (split-string
+                      (substring-no-properties (claude-client--render-event event 3))
+                      "\n"))
+             20))
+    (it "leaves another result bounded, since expansion is keyed by index"
+      (check (length (split-string
+                      (substring-no-properties (claude-client--render-event event 4))
+                      "\n"))
+             7))))
 
 ;; nil is the documented escape hatch: show everything.
-(let* ((long (mapconcat (lambda (i) (format "l%d" i)) (number-sequence 1 20) "\n"))
-       (claude-client-tool-result-lines nil)
-       (s (substring-no-properties
-           (claude-client--render-event (list :kind 'tool-result :text long) 0))))
-  (check "unbounded-custom-shows-all" (length (split-string s "\n")) 20))
+(describe "claude-client-tool-result-lines"
+  (let* ((long (mapconcat (lambda (i) (format "l%d" i)) (number-sequence 1 20) "\n"))
+         (claude-client-tool-result-lines nil)
+         (s (substring-no-properties
+             (claude-client--render-event (list :kind 'tool-result :text long) 0))))
+    (it "bounds nothing when set to nil"
+      (check (length (split-string s "\n")) 20))))
 
-;; `gh issue view' answers with a dozen empty field labels; they are noise.
-(let ((s (substring-no-properties
-          (claude-client--render-event
-           '(:kind tool-result
-             :text "title: Fix it\nlabels:\nassignees:\nmilestone:\nbody: real")
-           0))))
-  (check "empty-fields-dropped" s "  → title: Fix it\n  → body: real"))
+(describe "empty field labels in a tool result"
+  ;; `gh issue view' answers with a dozen empty field labels; they are noise.
+  (let ((s (substring-no-properties
+            (claude-client--render-event
+             '(:kind tool-result
+               :text "title: Fix it\nlabels:\nassignees:\nmilestone:\nbody: real")
+             0))))
+    (it "drops the empty labels `gh issue view' pads its answer with"
+      (check s "  → title: Fix it\n  → body: real")))
 
-;; The pattern must not eat real content that happens to contain a colon.
-(let ((s (substring-no-properties
-          (claude-client--render-event
-           '(:kind tool-result :text "Status: applied\nlabels: bug\n  (let ((x 1))") 0))))
-  (check "populated-fields-kept"
-         s "  → Status: applied\n  → labels: bug\n  →   (let ((x 1))"))
+  ;; The pattern must not eat real content that happens to contain a colon.
+  (let ((s (substring-no-properties
+            (claude-client--render-event
+             '(:kind tool-result :text "Status: applied\nlabels: bug\n  (let ((x 1))") 0))))
+    (it "keeps real content that happens to contain a colon"
+      (check s "  → Status: applied\n  → labels: bug\n  →   (let ((x 1))")))
 
-;; A result that is nothing but empty labels earns no row at all.
-(let ((s (claude-client--render-event
-          '(:kind tool-result :text "labels:\nassignees:") 0)))
-  (check "all-empty-fields-skipped" s nil))
+  ;; A result that is nothing but empty labels earns no row at all.
+  (let ((s (claude-client--render-event
+            '(:kind tool-result :text "labels:\nassignees:") 0)))
+    (it "renders nothing when the result is nothing but empty labels"
+      (check s nil))))
 
 ;;;; Toggling a result (issue #61)
 
 ;; Round-trip through the real command in a real buffer: the rows carry
 ;; their event index, TAB expands, TAB again collapses, and the prose
 ;; after the result survives both.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (setq claude-client--events
-              (list '(:kind tool-use :name "Bash")
-                    (list :kind 'tool-result
-                          :text (mapconcat (lambda (i) (format "l%d" i))
-                                           (number-sequence 1 30) "\n"))
-                    '(:kind text :text "prose after")))
-        (claude-client--render)
-        (let ((collapsed (count-lines (point-min) (point-max))))
-          ;; Line 3 is the first result row (banner-less: tool-use, then
-          ;; six result rows).
-          (goto-char (point-min))
-          (forward-line 2)
-          (check "result-rows-carry-index" (claude-client--result-at-point) 1)
-          (claude-client-toggle-tool-result)
-          (check "toggle-expands"
-                 (> (count-lines (point-min) (point-max)) collapsed) t)
-          (check "expanded-shows-last-line"
-                 (and (string-match-p "→ l30" (buffer-string)) t) t)
-          (goto-char (point-min))
-          (forward-line 2)
-          (claude-client-toggle-tool-result)
-          (check "toggle-collapses-again"
-                 (count-lines (point-min) (point-max)) collapsed)
-          (check "prose-survives-toggling"
-                 (and (string-match-p "prose after" (buffer-string)) t) t)))
-    (kill-buffer buf)))
+(describe "claude-client-toggle-tool-result"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq claude-client--events
+                (list '(:kind tool-use :name "Bash")
+                      (list :kind 'tool-result
+                            :text (mapconcat (lambda (i) (format "l%d" i))
+                                             (number-sequence 1 30) "\n"))
+                      '(:kind text :text "prose after")))
+          (claude-client--render)
+          (let ((collapsed (count-lines (point-min) (point-max))))
+            ;; Line 3 is the first result row (banner-less: tool-use, then
+            ;; six result rows).
+            (goto-char (point-min))
+            (forward-line 2)
+            (it "finds the event index carried by a rendered result row"
+              (check (claude-client--result-at-point) 1))
+            (claude-client-toggle-tool-result)
+            (it "expands the result under point"
+              (check (> (count-lines (point-min) (point-max)) collapsed) t))
+            (it "shows the last line of the result once expanded"
+              (check-that (string-match-p "→ l30" (buffer-string))))
+            (goto-char (point-min))
+            (forward-line 2)
+            (claude-client-toggle-tool-result)
+            (it "collapses the result again on a second toggle"
+              (check (count-lines (point-min) (point-max)) collapsed))
+            (it "leaves the prose after the result untouched by either toggle"
+              (check-that (string-match-p "prose after" (buffer-string))))))
+      (kill-buffer buf)))
 
-;; Point sits at end of line often enough that looking only at
-;; `char-after' would make TAB fail there.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (setq claude-client--events
-              (list (list :kind 'tool-result :text "a\nb")))
-        (claude-client--render)
-        (goto-char (point-min))
-        (end-of-line)
-        (check "index-found-at-eol" (claude-client--result-at-point) 0))
-    (kill-buffer buf)))
+  ;; Point sits at end of line often enough that looking only at
+  ;; `char-after' would make TAB fail there.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq claude-client--events
+                (list (list :kind 'tool-result :text "a\nb")))
+          (claude-client--render)
+          (goto-char (point-min))
+          (end-of-line)
+          (it "still finds the index with point at end of line"
+            (check (claude-client--result-at-point) 0)))
+      (kill-buffer buf)))
 
-;; Off a result it refuses rather than toggling something arbitrary.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (setq claude-client--events '((:kind text :text "just prose")))
-        (claude-client--render)
-        (goto-char (point-min))
-        (check "toggle-off-result-errors"
-               (condition-case nil
-                   (progn (claude-client-toggle-tool-result) 'no-error)
-                 (user-error 'user-error))
-               'user-error))
-    (kill-buffer buf)))
+  ;; Off a result it refuses rather than toggling something arbitrary.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq claude-client--events '((:kind text :text "just prose")))
+          (claude-client--render)
+          (goto-char (point-min))
+          (it "refuses off a result rather than toggling something arbitrary"
+            (check (condition-case nil
+                       (progn (claude-client-toggle-tool-result) 'no-error)
+                     (user-error 'user-error))
+                   'user-error)))
+      (kill-buffer buf))))
 
 ;; Starting a conversation discards the log, so stale indices must not
 ;; survive to expand unrelated results in the new one.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (setq claude-client--expanded-results '(0 1 2))
-        (let ((claude-client-executable "definitely-not-a-real-binary"))
-          (ignore-errors (claude-client-start "hi")))
-        (check "start-clears-expansion" claude-client--expanded-results nil))
-    (kill-buffer buf)))
+(describe "claude-client-start and expansion state"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq claude-client--expanded-results '(0 1 2))
+          (let ((claude-client-executable "definitely-not-a-real-binary"))
+            (ignore-errors (claude-client-start "hi")))
+          (it "discards stale expansion indices along with the old log"
+            (check claude-client--expanded-results nil)))
+      (kill-buffer buf))))
 
 ;;;; Mentions (issue #56)
 
@@ -595,91 +665,101 @@ records."
 ;; running add-note drains immediately -- which would send the mention as
 ;; a turn of its own, the opposite of "without submitting".  Found by
 ;; running the command, not by reading the code.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (agent-backend-mention (claude-client-backend :buffer buf)
-                               "@elisp/foo.el:12-40")
-        (check "mention-is-queued"
-               claude-client--pending-notes '("@elisp/foo.el:12-40"))
-        (check "mention-delivers-nothing"
-               (memq 'notes-delivered (claude-test--kinds buf)) nil)
-        (check "mention-is-logged" (claude-test--kinds buf) '(note))
-        ;; `pending' is the truth: the model has not been handed it.
-        (check "mention-logged-as-pending"
-               (plist-get (car claude-client--events) :pending) t))
-    (kill-buffer buf)))
+(describe "agent-backend-mention on the claude backend"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (agent-backend-mention (claude-client-backend :buffer buf)
+                                 "@elisp/foo.el:12-40")
+          (it "queues the mention instead of delivering it"
+            (check claude-client--pending-notes '("@elisp/foo.el:12-40")))
+          (it "sends nothing, so a mention is not a turn of its own"
+            (check (memq 'notes-delivered (claude-test--kinds buf)) nil))
+          (it "records the mention in the log"
+            (check (claude-test--kinds buf) '(note)))
+          ;; `pending' is the truth: the model has not been handed it.
+          (it "marks the logged mention pending, since the model has not seen it"
+            (check (plist-get (car claude-client--events) :pending) t)))
+      (kill-buffer buf)))
 
-;; Queued, so the next prompt carries it -- that is what makes a mention
-;; reach the model at all.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (agent-backend-mention (claude-client-backend :buffer buf) "@a.el:1")
-        (check "mention-rides-next-prompt"
-               (claude-client--prompt-with-notes "what is this?")
-               "what is this?\n\nNotes from the human:\n- @a.el:1"))
-    (kill-buffer buf)))
+  ;; Queued, so the next prompt carries it -- that is what makes a mention
+  ;; reach the model at all.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (agent-backend-mention (claude-client-backend :buffer buf) "@a.el:1")
+          (it "rides out on the next prompt, which is how it reaches the model"
+            (check (claude-client--prompt-with-notes "what is this?")
+                   "what is this?\n\nNotes from the human:\n- @a.el:1")))
+      (kill-buffer buf)))
 
-;; Mentioning the same lines twice before the model has seen either says
-;; nothing new, and costs context.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (let ((backend (claude-client-backend :buffer buf)))
-          (agent-backend-mention backend "@a.el:1")
-          (agent-backend-mention backend "@a.el:1")
-          (agent-backend-mention backend "@b.el:2"))
-        (check "mention-coalesces-repeat"
-               claude-client--pending-notes '("@a.el:1" "@b.el:2")))
-    (kill-buffer buf)))
+  ;; Mentioning the same lines twice before the model has seen either says
+  ;; nothing new, and costs context.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((backend (claude-client-backend :buffer buf)))
+            (agent-backend-mention backend "@a.el:1")
+            (agent-backend-mention backend "@a.el:1")
+            (agent-backend-mention backend "@b.el:2"))
+          (it "coalesces a repeated mention, which says nothing new and costs context"
+            (check claude-client--pending-notes '("@a.el:1" "@b.el:2"))))
+      (kill-buffer buf)))
 
-;; A mention mid-turn must not interrupt: pointing at code is not the
-;; human changing direction, which is what a note is for.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (setq claude-client--turn-active t)
-        (agent-backend-mention (claude-client-backend :buffer buf) "@a.el:1")
-        (check "mention-mid-turn-does-not-interrupt"
-               (memq 'interrupted (claude-test--kinds buf)) nil)
-        (check "mention-mid-turn-still-queued"
-               claude-client--pending-notes '("@a.el:1")))
-    (kill-buffer buf)))
+  ;; A mention mid-turn must not interrupt: pointing at code is not the
+  ;; human changing direction, which is what a note is for.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq claude-client--turn-active t)
+          (agent-backend-mention (claude-client-backend :buffer buf) "@a.el:1")
+          (it "does not interrupt a running turn, since pointing at code is not a change of direction"
+            (check (memq 'interrupted (claude-test--kinds buf)) nil))
+          (it "still queues the mention while a turn runs"
+            (check claude-client--pending-notes '("@a.el:1"))))
+      (kill-buffer buf)))
 
-;; Empty or whitespace-only text is not a mention.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (agent-backend-mention (claude-client-backend :buffer buf) "   ")
-        (check "empty-mention-ignored" claude-client--pending-notes nil)
-        (check "empty-mention-not-logged" (claude-test--kinds buf) nil))
-    (kill-buffer buf)))
+  ;; Empty or whitespace-only text is not a mention.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (agent-backend-mention (claude-client-backend :buffer buf) "   ")
+          (it "queues nothing for whitespace-only text"
+            (check claude-client--pending-notes nil))
+          (it "logs nothing for whitespace-only text"
+            (check (claude-test--kinds buf) nil)))
+      (kill-buffer buf))))
 
 ;; TAB is bound in the mode map, and re-registered for evil -- motion
 ;; state claims it as `evil-jump-forward', so without that it is dead.
-(check "tab-bound"
-       (lookup-key claude-client-mode-map (kbd "TAB"))
-       #'claude-client-toggle-tool-result)
-(check "tab-in-evil-keys"
-       (cdr (assoc "TAB" claude-client--evil-keys))
-       'claude-client-toggle-tool-result)
+(describe "the TAB binding"
+  (it "toggles a tool result in the plain-Emacs map"
+    (check (lookup-key claude-client-mode-map (kbd "TAB"))
+           #'claude-client-toggle-tool-result))
+  (it "is re-registered for evil, which would otherwise claim it as a motion"
+    (check (cdr (assoc "TAB" claude-client--evil-keys))
+           'claude-client-toggle-tool-result)))
 
 ;; Prose keeps its exact text either way; only the properties differ.
-(let* ((prose "Use **bold** and `code`.\n")
-       (s (claude-client--render-event (list :kind 'text :text prose))))
-  (check "prose-text-unchanged" (substring-no-properties s) prose)
-  (if (fboundp 'gfm-view-mode)
-      (check "prose-fontified"
-             (and (text-properties-at 6 s) t) t)
-    ;; Without `markdown-mode' the client must still render, plain.
-    (check "prose-plain-without-markdown" (text-properties-at 6 s) nil)))
+(describe "rendering prose as markdown"
+  (let* ((prose "Use **bold** and `code`.\n")
+         (s (claude-client--render-event (list :kind 'text :text prose))))
+    (it "keeps the prose text exactly, changing only its properties"
+      (check (substring-no-properties s) prose))
+    (if (fboundp 'gfm-view-mode)
+        (it "fontifies the prose when markdown-mode is available"
+          (check (and (text-properties-at 6 s) t) t))
+      ;; Without `markdown-mode' the client must still render, plain.
+      (it "still renders, plain, without markdown-mode"
+        (check (text-properties-at 6 s) nil))))
 
-(let ((s (claude-client--render-event '(:kind text :text ""))))
-  (check "empty-prose-renders" s ""))
+  (let ((s (claude-client--render-event '(:kind text :text ""))))
+    (it "renders empty prose as the empty string rather than nothing"
+      (check s ""))))
 
-(check "unknown-kind-skipped"
-       (claude-client--render-event '(:kind :no-such-kind)) nil)
+(describe "claude-client--render-event on an unknown kind"
+  (it "renders nothing rather than guessing"
+    (check (claude-client--render-event '(:kind :no-such-kind)) nil)))
 
 ;;;; Human notes (issue #39, `NoteAdded')
 ;;
@@ -698,182 +778,199 @@ stays alive after `result', so process liveness cannot stand in for it."
   `(let ((claude-client--turn-active t))
      ,@body))
 
-;; The note lands in the log as soon as it is written, and waits while a
-;; turn is running.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (claude-test--with-running-turn
-         (claude-client-add-note "look at the error handling"))
-        (check "note-logged-immediately" (claude-test--kinds buf) '(note))
-        (check "note-text"
-               (plist-get (car claude-client--events) :text)
-               "look at the error handling")
-        (check "note-queued"
-               claude-client--pending-notes '("look at the error handling")))
-    (kill-buffer buf)))
+(describe "claude-client-add-note during a turn"
+  ;; The note lands in the log as soon as it is written, and waits while a
+  ;; turn is running.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (claude-test--with-running-turn
+           (claude-client-add-note "look at the error handling"))
+          (it "records the note as soon as it is written"
+            (check (claude-test--kinds buf) '(note)))
+          (it "logs the note's text verbatim"
+            (check (plist-get (car claude-client--events) :text)
+                   "look at the error handling"))
+          (it "queues the note to wait while a turn is running"
+            (check claude-client--pending-notes '("look at the error handling"))))
+      (kill-buffer buf))))
 
 ;; Turn state must not be inferred from the process.  `claude --print' stays
 ;; alive after emitting `result' (it waits on stdin), so a live process is
 ;; not evidence of a turn in flight -- reading it that way left notes queued
 ;; forever once a run had finished.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string) (lambda (&rest _) nil)))
-          ;; Process "alive", but the turn ended: the note must still drain.
-          (setq claude-client--process 'fake
-                claude-client--turn-active nil)
-          (claude-client-add-note "after the turn")
-          (check "live-process-is-not-an-active-turn"
-                 claude-client--pending-notes nil)))
-    (kill-buffer buf)))
+(describe "turn state versus process liveness"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string) (lambda (&rest _) nil)))
+            ;; Process "alive", but the turn ended: the note must still drain.
+            (setq claude-client--process 'fake
+                  claude-client--turn-active nil)
+            (claude-client-add-note "after the turn")
+            (it "drains a note against a live process whose turn has ended"
+              (check claude-client--pending-notes nil))))
+      (kill-buffer buf)))
 
-;; The stream is what starts and ends a turn.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (setq claude-client--turn-active t)
-        (claude-test--feed buf (concat claude-test--result "\n"))
-        (check "result-clears-turn-active" claude-client--turn-active nil))
-    (kill-buffer buf)))
+  ;; The stream is what starts and ends a turn.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq claude-client--turn-active t)
+          (claude-test--feed buf (concat claude-test--result "\n"))
+          (it "ends the turn when `result' arrives on the stream"
+            (check claude-client--turn-active nil)))
+      (kill-buffer buf))))
 
 ;; With no turn running the note has nothing to wait for, so it is delivered
 ;; straight away rather than sitting queued for a turn that may never come.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (claude-client-add-note "idle note")
-        (check "idle-note-drains-now" claude-client--pending-notes nil)
-        (check "idle-note-delivery-event"
-               (claude-test--kinds buf) '(note notes-delivered)))
-    (kill-buffer buf)))
+(describe "claude-client-add-note with nothing running"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (claude-client-add-note "idle note")
+          (it "drains at once rather than waiting for a turn that may never come"
+            (check claude-client--pending-notes nil))
+          (it "logs the delivery alongside the note"
+            (check (claude-test--kinds buf) '(note notes-delivered))))
+      (kill-buffer buf)))
 
-;; Empty and whitespace notes are rejected rather than logged as blanks.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (check "empty-note-errors"
-               (condition-case _ (progn (claude-client-add-note "   ") nil)
-                 (user-error t))
-               t)
-        (check "empty-note-not-logged" (claude-test--kinds buf) nil))
-    (kill-buffer buf)))
+  ;; Empty and whitespace notes are rejected rather than logged as blanks.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (it "rejects a whitespace-only note"
+            (check (condition-case _ (progn (claude-client-add-note "   ") nil)
+                     (user-error t))
+                   t))
+          (it "logs no blank event for a rejected note"
+            (check (claude-test--kinds buf) nil)))
+      (kill-buffer buf))))
 
-;; Notes keep their order and all of them are queued.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (claude-test--with-running-turn
-         (claude-client-add-note "first")
-         (claude-client-add-note "second"))
-        (check "notes-ordered" claude-client--pending-notes '("first" "second")))
-    (kill-buffer buf)))
+(describe "the pending-note queue"
+  ;; Notes keep their order and all of them are queued.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (claude-test--with-running-turn
+           (claude-client-add-note "first")
+           (claude-client-add-note "second"))
+          (it "keeps notes in the order they were written"
+            (check claude-client--pending-notes '("first" "second"))))
+      (kill-buffer buf))))
 
 ;; Notes are drained when the turn's `result' arrives -- after the
 ;; `finished' event, so the log reads in the order things happened.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (claude-test--feed buf (concat claude-test--init "\n"))
-        (claude-test--with-running-turn
-         (claude-client-add-note "mid-turn thought"))
-        (check "note-pending-during-turn"
-               claude-client--pending-notes '("mid-turn thought"))
-        (claude-test--feed buf (concat claude-test--result "\n"))
-        (check "notes-drained-at-turn-end" claude-client--pending-notes nil)
-        (check "drain-order"
-               (claude-test--kinds buf)
-               '(started note finished notes-delivered))
-        (check "delivered-carries-notes"
-               (plist-get (car (last claude-client--events)) :notes)
-               '("mid-turn thought")))
-    (kill-buffer buf)))
+(describe "draining notes at turn end"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (claude-test--feed buf (concat claude-test--init "\n"))
+          (claude-test--with-running-turn
+           (claude-client-add-note "mid-turn thought"))
+          (it "holds the note while the turn is still in flight"
+            (check claude-client--pending-notes '("mid-turn thought")))
+          (claude-test--feed buf (concat claude-test--result "\n"))
+          (it "empties the queue when the turn's `result' arrives"
+            (check claude-client--pending-notes nil))
+          (it "logs the delivery after `finished', so the log reads in order"
+            (check (claude-test--kinds buf)
+                   '(started note finished notes-delivered)))
+          (it "records which notes were delivered"
+            (check (plist-get (car (last claude-client--events)) :notes)
+                   '("mid-turn thought"))))
+      (kill-buffer buf)))
 
-;; A turn that ends with no notes produces no delivery event.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (progn
-        (claude-test--feed buf
-                           (concat claude-test--init "\n")
-                           (concat claude-test--result "\n"))
-        (check "no-notes-no-delivery-event"
-               (claude-test--kinds buf) '(started finished)))
-    (kill-buffer buf)))
+  ;; A turn that ends with no notes produces no delivery event.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (progn
+          (claude-test--feed buf
+                             (concat claude-test--init "\n")
+                             (concat claude-test--result "\n"))
+          (it "logs no delivery event for a turn that ends with no notes"
+            (check (claude-test--kinds buf) '(started finished))))
+      (kill-buffer buf))))
 
 ;; Notes are announced on the subscriber hook like any other event, so the
 ;; transcript sees the human's writes on the same channel as the runner's.
-(let* ((buf (claude-test--buffer))
-       (seen nil)
-       (claude-client-event-functions
-        (list (lambda (_b e) (push (plist-get e :kind) seen)))))
-  (unwind-protect
-      (with-current-buffer buf
-        (claude-test--with-running-turn
-         (claude-client-add-note "via hook"))
-        (check "note-reaches-subscribers" seen '(note)))
-    (kill-buffer buf)))
+(describe "notes on the subscriber hook"
+  (let* ((buf (claude-test--buffer))
+         (seen nil)
+         (claude-client-event-functions
+          (list (lambda (_b e) (push (plist-get e :kind) seen)))))
+    (unwind-protect
+        (with-current-buffer buf
+          (claude-test--with-running-turn
+           (claude-client-add-note "via hook"))
+          (it "announces a note on the same channel as the runner's own events"
+            (check seen '(note))))
+      (kill-buffer buf))))
 
 ;; Notes render, and a note added while a turn is running is marked pending.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (let ((claude-client-note-interrupts nil))
-          (claude-test--with-running-turn
-           (claude-client-add-note "rendered note")))
-        (check "note-rendered"
-               (and (string-match-p "> rendered note" (claude-test--text buf)) t) t)
-        ;; `pending' means the model has not seen it.  Only true when the
-        ;; note waits; an interrupting note is about to be delivered.
-        (check "note-pending-marked"
-               (plist-get (car claude-client--events) :pending) t))
-    (kill-buffer buf)))
+(describe "rendering a note in the conversation"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((claude-client-note-interrupts nil))
+            (claude-test--with-running-turn
+             (claude-client-add-note "rendered note")))
+          (it "shows the note in the conversation buffer"
+            (check-that (string-match-p "> rendered note" (claude-test--text buf))))
+          ;; `pending' means the model has not seen it.  Only true when the
+          ;; note waits; an interrupting note is about to be delivered.
+          (it "marks a waiting note pending, since the model has not seen it"
+            (check (plist-get (car claude-client--events) :pending) t)))
+      (kill-buffer buf))))
 
 ;; A note outside a conversation buffer is refused rather than silently lost.
-(with-temp-buffer
-  (check "note-outside-conversation-errors"
-         (condition-case _ (progn (claude-client-add-note "x") nil)
-           (user-error t))
-         t))
+(describe "claude-client-add-note outside a conversation"
+  (with-temp-buffer
+    (it "refuses rather than silently losing the human's words"
+      (check (condition-case _ (progn (claude-client-add-note "x") nil)
+               (user-error t))
+             t))))
 
 ;; Starting a run resets the event log, so a note queued beforehand has to be
 ;; carried into the outgoing prompt or the human's words are silently lost.
 ;; Stub the subprocess and capture what would be written to its stdin.
-(let ((sent nil))
-  (cl-letf (((symbol-function 'make-process) (lambda (&rest _) 'fake-proc))
-            ((symbol-function 'process-send-string)
-             (lambda (_p s) (setq sent s)))
-            ((symbol-function 'pop-to-buffer) #'ignore)
-            ;; Keep the real buffer out of the way of an interactive session.
-            ((symbol-function 'claude-client--mcp-config-file) (lambda () "/tmp/m.json"))
-            ((symbol-function 'claude-client--settings-file) (lambda () "/tmp/s.json"))
-            ((symbol-function 'claude-client--system-prompt-file) (lambda () "/tmp/p.txt")))
-    (let ((buf (get-buffer-create "*claude-client*")))
-      (unwind-protect
-          (progn
-            (with-current-buffer buf
-              (claude-client-mode)
-              (setq claude-client--process nil)
-              (claude-test--with-running-turn
-               (claude-client-add-note "remember the timeout")))
-            (with-current-buffer buf (claude-client-start "do the thing"))
-            (let ((text (alist-get
-                         'text
-                         (aref (alist-get
-                                'content
-                                (alist-get 'message
-                                           (json-parse-string
-                                            sent :object-type 'alist
-                                            :array-type 'array)))
-                               0))))
-              (check "restart-carries-note"
-                     (and (string-match-p "remember the timeout" text) t) t)
-              (check "restart-keeps-prompt"
-                     (and (string-match-p "do the thing" text) t) t))
-            (with-current-buffer buf
-              (check "restart-clears-queue" claude-client--pending-notes nil)))
-        (let ((kill-buffer-query-functions nil)) (kill-buffer buf))))))
+(describe "claude-client-start with a note already queued"
+  (let ((sent nil))
+    (cl-letf (((symbol-function 'make-process) (lambda (&rest _) 'fake-proc))
+              ((symbol-function 'process-send-string)
+               (lambda (_p s) (setq sent s)))
+              ((symbol-function 'pop-to-buffer) #'ignore)
+              ;; Keep the real buffer out of the way of an interactive session.
+              ((symbol-function 'claude-client--mcp-config-file) (lambda () "/tmp/m.json"))
+              ((symbol-function 'claude-client--settings-file) (lambda () "/tmp/s.json"))
+              ((symbol-function 'claude-client--system-prompt-file) (lambda () "/tmp/p.txt")))
+      (let ((buf (get-buffer-create "*claude-client*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (claude-client-mode)
+                (setq claude-client--process nil)
+                (claude-test--with-running-turn
+                 (claude-client-add-note "remember the timeout")))
+              (with-current-buffer buf (claude-client-start "do the thing"))
+              (let ((text (alist-get
+                           'text
+                           (aref (alist-get
+                                  'content
+                                  (alist-get 'message
+                                             (json-parse-string
+                                              sent :object-type 'alist
+                                              :array-type 'array)))
+                                 0))))
+                (it "carries the queued note into the outgoing prompt, not losing it with the log"
+                  (check-that (string-match-p "remember the timeout" text)))
+                (it "keeps the human's own prompt alongside the note"
+                  (check-that (string-match-p "do the thing" text))))
+              (with-current-buffer buf
+                (it "empties the queue once the note has gone out"
+                  (check claude-client--pending-notes nil))))
+          (let ((kill-buffer-query-functions nil)) (kill-buffer buf)))))))
 
 ;;;; Multi-turn stdin
 ;;
@@ -883,107 +980,117 @@ stays alive after `result', so process liveness cannot stand in for it."
 
 ;; `claude-client-send' writes a well-formed user turn and marks the turn
 ;; active, without respawning.
-(let ((buf (claude-test--buffer))
-      (sent nil))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string)
-                   (lambda (_p s) (setq sent s)))
-                  ;; A respawn here would be the bug: the point is reuse.
-                  ((symbol-function 'make-process)
-                   (lambda (&rest _) (error "must not spawn"))))
-          (setq claude-client--process 'fake claude-client--turn-active nil)
-          (claude-client-send "second turn")
-          (let ((msg (json-parse-string sent :object-type 'alist
-                                        :array-type 'array)))
-            (check "send-type-user" (alist-get 'type msg) "user")
-            (check "send-text"
-                   (alist-get 'text
-                              (aref (alist-get 'content
-                                               (alist-get 'message msg)) 0))
-                   "second turn"))
-          (check "send-marks-turn-active" claude-client--turn-active t)
-          (check "send-logs-prompt"
-                 (plist-get (car (last claude-client--events)) :kind) 'prompt)))
-    (kill-buffer buf)))
+(describe "claude-client-send"
+  (let ((buf (claude-test--buffer))
+        (sent nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string)
+                     (lambda (_p s) (setq sent s)))
+                    ;; A respawn here would be the bug: the point is reuse.
+                    ((symbol-function 'make-process)
+                     (lambda (&rest _) (error "must not spawn"))))
+            (setq claude-client--process 'fake claude-client--turn-active nil)
+            (claude-client-send "second turn")
+            (let ((msg (json-parse-string sent :object-type 'alist
+                                          :array-type 'array)))
+              (it "writes a user turn on the running CLI's stdin"
+                (check (alist-get 'type msg) "user"))
+              (it "carries the prompt text in the turn"
+                (check (alist-get 'text
+                                  (aref (alist-get 'content
+                                                   (alist-get 'message msg)) 0))
+                       "second turn")))
+            (it "marks the turn in flight"
+              (check claude-client--turn-active t))
+            (it "logs the prompt"
+              (check (plist-get (car (last claude-client--events)) :kind) 'prompt))))
+      (kill-buffer buf)))
 
-;; Sending while a turn is in flight is refused: the CLI reads one turn at a
-;; time, so a second write would interleave with the one being answered.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t)))
-          (setq claude-client--process 'fake claude-client--turn-active t)
-          (check "send-refused-mid-turn"
-                 (condition-case _ (progn (claude-client-send "x") nil)
-                   (user-error t))
-                 t)))
-    (kill-buffer buf)))
+  ;; Sending while a turn is in flight is refused: the CLI reads one turn at a
+  ;; time, so a second write would interleave with the one being answered.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t)))
+            (setq claude-client--process 'fake claude-client--turn-active t)
+            (it "refuses mid-turn, since a second write would interleave"
+              (check (condition-case _ (progn (claude-client-send "x") nil)
+                       (user-error t))
+                     t))))
+      (kill-buffer buf)))
 
-;; With no live process there is nothing to continue.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (setq claude-client--process nil claude-client--turn-active nil)
-        (check "send-refused-without-process"
-               (condition-case _ (progn (claude-client-send "x") nil)
-                 (user-error t))
-               t))
-    (kill-buffer buf)))
+  ;; With no live process there is nothing to continue.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq claude-client--process nil claude-client--turn-active nil)
+          (it "refuses without a live process, since there is nothing to continue"
+            (check (condition-case _ (progn (claude-client-send "x") nil)
+                     (user-error t))
+                   t)))
+      (kill-buffer buf))))
 
 ;; Notes drained at turn end are delivered to the model as the next turn --
 ;; this is what makes a note change what the model does, not just the log.
-(let ((buf (claude-test--buffer))
-      (sent nil))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string)
-                   (lambda (_p s) (setq sent s))))
-          (setq claude-client--process 'fake)
-          (setq-local claude-client-deliver-notes t)
-          (claude-test--with-running-turn
-           (claude-client-add-note "reconsider the approach"))
-          (setq claude-client--turn-active t)
-          (claude-test--feed buf (concat claude-test--result "\n"))
-          (check "notes-delivered-to-model"
-                 (and sent (string-match-p "reconsider the approach" sent) t) t)
-          (check "note-delivery-starts-a-turn" claude-client--turn-active t)))
-    (kill-buffer buf)))
+(describe "claude-client-deliver-notes"
+  (let ((buf (claude-test--buffer))
+        (sent nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string)
+                     (lambda (_p s) (setq sent s))))
+            (setq claude-client--process 'fake)
+            (setq-local claude-client-deliver-notes t)
+            (claude-test--with-running-turn
+             (claude-client-add-note "reconsider the approach"))
+            (setq claude-client--turn-active t)
+            (claude-test--feed buf (concat claude-test--result "\n"))
+            (it "sends the drained note to the model, not just to the log"
+              (check-that (and sent (string-match-p "reconsider the approach" sent))))
+            (it "begins a new turn to carry the note"
+              (check claude-client--turn-active t))))
+      (kill-buffer buf)))
 
-;; Delivery is opt-out: with it off the note is still recorded, but nothing
-;; is sent and no new turn begins.
-(let ((buf (claude-test--buffer))
-      (sent nil))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string)
-                   (lambda (_p s) (setq sent s))))
-          (setq claude-client--process 'fake)
-          (setq-local claude-client-deliver-notes nil)
-          (let ((claude-client-note-interrupts nil))
-            (claude-test--with-running-turn (claude-client-add-note "quiet note")))
-          (setq claude-client--turn-active t)
-          (claude-test--feed buf (concat claude-test--result "\n"))
-          (check "no-delivery-when-disabled" sent nil)
-          (check "no-turn-when-disabled" claude-client--turn-active nil)
-          (check "note-still-recorded"
-                 (and (memq 'notes-delivered (claude-test--kinds buf)) t) t)))
-    (kill-buffer buf)))
+  ;; Delivery is opt-out: with it off the note is still recorded, but nothing
+  ;; is sent and no new turn begins.
+  (let ((buf (claude-test--buffer))
+        (sent nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string)
+                     (lambda (_p s) (setq sent s))))
+            (setq claude-client--process 'fake)
+            (setq-local claude-client-deliver-notes nil)
+            (let ((claude-client-note-interrupts nil))
+              (claude-test--with-running-turn (claude-client-add-note "quiet note")))
+            (setq claude-client--turn-active t)
+            (claude-test--feed buf (concat claude-test--result "\n"))
+            (it "sends nothing when delivery is switched off"
+              (check sent nil))
+            (it "begins no new turn when delivery is switched off"
+              (check claude-client--turn-active nil))
+            (it "still records the note in the log"
+              (check-that (memq 'notes-delivered (claude-test--kinds buf))))))
+      (kill-buffer buf))))
 
 ;; A dead process ends the turn with it; otherwise the buffer would be
 ;; wedged against ever starting another run.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (setq claude-client--turn-active t)
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) nil)))
-          (claude-client--sentinel buf 'fake "exited"))
-        (check "sentinel-clears-turn" claude-client--turn-active nil)
-        (check "sentinel-clears-process" claude-client--process nil))
-    (kill-buffer buf)))
+(describe "claude-client--sentinel on a dead process"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq claude-client--turn-active t)
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) nil)))
+            (claude-client--sentinel buf 'fake "exited"))
+          (it "ends the turn with the process, so the buffer is not wedged"
+            (check claude-client--turn-active nil))
+          (it "forgets the process"
+            (check claude-client--process nil)))
+      (kill-buffer buf))))
 
 ;;;; Resume
 ;;
@@ -993,109 +1100,119 @@ stays alive after `result', so process liveness cannot stand in for it."
 ;; flag -- it means "create a new session with this id" and fails if a
 ;; transcript already exists.
 
-(let ((cmd (claude-client--command "sess-abc")))
-  (check "resume-flag-present" (and (member "--resume" cmd) t) t)
-  (check "resume-id-follows-flag"
-         (cadr (member "--resume" cmd)) "sess-abc")
-  ;; --session-id would mean "create new with this id" and hard-fail on an
-  ;; existing transcript; resuming must not use it.
-  (check "resume-does-not-use-session-id"
-         (and (member "--session-id" cmd) t) nil))
+(describe "claude-client--command with a resume id"
+  (let ((cmd (claude-client--command "sess-abc")))
+    (it "passes --resume"
+      (check-that (member "--resume" cmd)))
+    (it "passes the session id right after the flag"
+      (check (cadr (member "--resume" cmd)) "sess-abc"))
+    ;; --session-id would mean "create new with this id" and hard-fail on an
+    ;; existing transcript; resuming must not use it.
+    (it "does not use --session-id, which would hard-fail on an existing transcript"
+      (check (and (member "--session-id" cmd) t) nil)))
 
-;; Without an id the flag is absent entirely, so a normal start is unchanged.
-(let ((cmd (claude-client--command)))
-  (check "no-resume-flag-by-default" (and (member "--resume" cmd) t) nil))
+  ;; Without an id the flag is absent entirely, so a normal start is unchanged.
+  (let ((cmd (claude-client--command)))
+    (it "omits --resume entirely without an id, leaving a normal start unchanged"
+      (check (and (member "--resume" cmd) t) nil))))
 
 ;; Starting with a resume id logs it, so the transcript shows which session
 ;; was reopened rather than looking like a fresh conversation.
-(let ((sent nil))
-  (cl-letf (((symbol-function 'make-process) (lambda (&rest _) 'fake-proc))
-            ((symbol-function 'process-send-string) (lambda (_p s) (setq sent s)))
-            ((symbol-function 'pop-to-buffer) #'ignore)
-            ((symbol-function 'claude-client--mcp-config-file) (lambda () "/tmp/m.json"))
-            ((symbol-function 'claude-client--settings-file) (lambda () "/tmp/s.json"))
-            ((symbol-function 'claude-client--system-prompt-file) (lambda () "/tmp/p.txt")))
-    (let ((buf (get-buffer-create "*claude-client*")))
-      (unwind-protect
-          (progn
-            (with-current-buffer buf
-              (claude-client-mode)
-              (setq claude-client--process nil claude-client--turn-active nil))
-            (with-current-buffer buf
-              (claude-client-start "carry on" "sess-xyz"))
-            (with-current-buffer buf
-              (check "resume-logs-resumed-event"
-                     (plist-get (car claude-client--events) :kind) 'resumed)
-              (check "resume-event-carries-id"
-                     (plist-get (car claude-client--events) :session) "sess-xyz")
-              (check "resume-then-prompt"
-                     (mapcar (lambda (e) (plist-get e :kind)) claude-client--events)
-                     '(resumed prompt))))
-        (let ((kill-buffer-query-functions nil)) (kill-buffer buf))))))
+(describe "claude-client-start with a resume id"
+  (let ((sent nil))
+    (cl-letf (((symbol-function 'make-process) (lambda (&rest _) 'fake-proc))
+              ((symbol-function 'process-send-string) (lambda (_p s) (setq sent s)))
+              ((symbol-function 'pop-to-buffer) #'ignore)
+              ((symbol-function 'claude-client--mcp-config-file) (lambda () "/tmp/m.json"))
+              ((symbol-function 'claude-client--settings-file) (lambda () "/tmp/s.json"))
+              ((symbol-function 'claude-client--system-prompt-file) (lambda () "/tmp/p.txt")))
+      (let ((buf (get-buffer-create "*claude-client*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (claude-client-mode)
+                (setq claude-client--process nil claude-client--turn-active nil))
+              (with-current-buffer buf
+                (claude-client-start "carry on" "sess-xyz"))
+              (with-current-buffer buf
+                (it "logs a resumed event so the transcript is not mistaken for a fresh one"
+                  (check (plist-get (car claude-client--events) :kind) 'resumed))
+                (it "names the session that was reopened"
+                  (check (plist-get (car claude-client--events) :session) "sess-xyz"))
+                (it "logs the resume before the prompt"
+                  (check (mapcar (lambda (e) (plist-get e :kind)) claude-client--events)
+                         '(resumed prompt)))))
+          (let ((kill-buffer-query-functions nil)) (kill-buffer buf)))))))
 
 ;; A plain start logs no `resumed' event.
-(let ((sent nil))
-  (cl-letf (((symbol-function 'make-process) (lambda (&rest _) 'fake-proc))
-            ((symbol-function 'process-send-string) (lambda (_p s) (setq sent s)))
-            ((symbol-function 'pop-to-buffer) #'ignore)
-            ((symbol-function 'claude-client--mcp-config-file) (lambda () "/tmp/m.json"))
-            ((symbol-function 'claude-client--settings-file) (lambda () "/tmp/s.json"))
-            ((symbol-function 'claude-client--system-prompt-file) (lambda () "/tmp/p.txt")))
-    (let ((buf (get-buffer-create "*claude-client*")))
-      (unwind-protect
-          (progn
-            (with-current-buffer buf
-              (claude-client-mode)
-              (setq claude-client--process nil claude-client--turn-active nil))
-            (with-current-buffer buf (claude-client-start "fresh"))
-            (with-current-buffer buf
-              (check "fresh-start-has-no-resumed"
-                     (memq 'resumed
-                           (mapcar (lambda (e) (plist-get e :kind))
-                                   claude-client--events))
-                     nil)))
-        (let ((kill-buffer-query-functions nil)) (kill-buffer buf))))))
+(describe "claude-client-start without a resume id"
+  (let ((sent nil))
+    (cl-letf (((symbol-function 'make-process) (lambda (&rest _) 'fake-proc))
+              ((symbol-function 'process-send-string) (lambda (_p s) (setq sent s)))
+              ((symbol-function 'pop-to-buffer) #'ignore)
+              ((symbol-function 'claude-client--mcp-config-file) (lambda () "/tmp/m.json"))
+              ((symbol-function 'claude-client--settings-file) (lambda () "/tmp/s.json"))
+              ((symbol-function 'claude-client--system-prompt-file) (lambda () "/tmp/p.txt")))
+      (let ((buf (get-buffer-create "*claude-client*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (claude-client-mode)
+                (setq claude-client--process nil claude-client--turn-active nil))
+              (with-current-buffer buf (claude-client-start "fresh"))
+              (with-current-buffer buf
+                (it "logs no resumed event"
+                  (check (memq 'resumed
+                               (mapcar (lambda (e) (plist-get e :kind))
+                                       claude-client--events))
+                         nil))))
+          (let ((kill-buffer-query-functions nil)) (kill-buffer buf)))))))
 
 ;;;; Window management
 ;;
 ;; Placement mirrors the eat runner: an ordinary window in a configurable
 ;; direction, not a dedicated side window.
 
-(let ((captured nil))
-  (cl-letf (((symbol-function 'display-buffer)
-             (lambda (_buf &optional action) (setq captured action) nil)))
-    (let ((claude-client-window-direction 'right)
-          (claude-client-window-width 0.4))
-      (claude-client--display (current-buffer))
-      (check "display-uses-in-direction"
-             (and (memq 'display-buffer-in-direction (car captured)) t) t)
-      (check "display-honours-direction"
-             (alist-get 'direction captured) 'right)
-      (check "display-sets-width"
-             (alist-get 'window-width captured) 0.4))
-    ;; Vertical placement sizes by height instead.
-    (let ((claude-client-window-direction 'below)
-          (claude-client-window-height 0.3))
-      (claude-client--display (current-buffer))
-      (check "display-vertical-uses-height"
-             (alist-get 'window-height captured) 0.3))
-    ;; nil hands the decision to display-buffer-alist: no action argument at
-    ;; all, rather than an in-direction action.
-    (let ((claude-client-window-direction nil))
-      (setq captured 'untouched)
-      (claude-client--display (current-buffer))
-      (check "display-nil-direction-plain" captured nil))))
+(describe "claude-client--display placement"
+  (let ((captured nil))
+    (cl-letf (((symbol-function 'display-buffer)
+               (lambda (_buf &optional action) (setq captured action) nil)))
+      (let ((claude-client-window-direction 'right)
+            (claude-client-window-width 0.4))
+        (claude-client--display (current-buffer))
+        (it "places the conversation with `display-buffer-in-direction'"
+          (check-that (memq 'display-buffer-in-direction (car captured))))
+        (it "honours `claude-client-window-direction'"
+          (check (alist-get 'direction captured) 'right))
+        (it "sizes a horizontal split by width"
+          (check (alist-get 'window-width captured) 0.4)))
+      ;; Vertical placement sizes by height instead.
+      (let ((claude-client-window-direction 'below)
+            (claude-client-window-height 0.3))
+        (claude-client--display (current-buffer))
+        (it "sizes a vertical split by height instead"
+          (check (alist-get 'window-height captured) 0.3)))
+      ;; nil hands the decision to display-buffer-alist: no action argument at
+      ;; all, rather than an in-direction action.
+      (let ((claude-client-window-direction nil))
+        (setq captured 'untouched)
+        (claude-client--display (current-buffer))
+        (it "passes no action at all with a nil direction, leaving it to `display-buffer-alist'"
+          (check captured nil))))))
 
 ;; Focus is not stolen by default.
-(let ((selected nil))
-  (cl-letf (((symbol-function 'display-buffer) (lambda (&rest _) 'win))
-            ((symbol-function 'select-window) (lambda (w) (setq selected w))))
-    (let ((claude-client-focus-on-show nil))
-      (claude-client--display (current-buffer))
-      (check "no-focus-by-default" selected nil))
-    (let ((claude-client-focus-on-show t))
-      (claude-client--display (current-buffer))
-      (check "focus-when-requested" selected 'win))))
+(describe "claude-client-focus-on-show"
+  (let ((selected nil))
+    (cl-letf (((symbol-function 'display-buffer) (lambda (&rest _) 'win))
+              ((symbol-function 'select-window) (lambda (w) (setq selected w))))
+      (let ((claude-client-focus-on-show nil))
+        (claude-client--display (current-buffer))
+        (it "does not steal focus by default"
+          (check selected nil)))
+      (let ((claude-client-focus-on-show t))
+        (claude-client--display (current-buffer))
+        (it "selects the conversation window when asked to"
+          (check selected 'win))))))
 
 ;;;; Re-show after an ediff review (#44)
 ;;
@@ -1106,63 +1223,67 @@ stays alive after `result', so process liveness cannot stand in for it."
 ;; conversation window, so by the time the tool result arrives the
 ;; conversation is already off screen.
 
-(let ((buf (claude-test--buffer))
-      (shown nil))
-  (unwind-protect
-      (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) nil))
-                ((symbol-function 'claude-client--display)
-                 (lambda (b) (setq shown b))))
-        (let ((claude-client-restore-window-after-review t))
-          (claude-client--reshow-after-review
-           buf (list :kind 'tool-result :text "Status: applied"))
-          (check "reshow-after-tool-result" shown buf)))
-    (kill-buffer buf)))
+(describe "claude-client--reshow-after-review"
+  (let ((buf (claude-test--buffer))
+        (shown nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) nil))
+                  ((symbol-function 'claude-client--display)
+                   (lambda (b) (setq shown b))))
+          (let ((claude-client-restore-window-after-review t))
+            (claude-client--reshow-after-review
+             buf (list :kind 'tool-result :text "Status: applied"))
+            (it "brings the conversation back after a tool result"
+              (check shown buf))))
+      (kill-buffer buf)))
 
-;; Only tool results trigger it; ordinary text must not fight the user's
-;; window layout on every streamed message.
-(let ((buf (claude-test--buffer))
-      (shown nil))
-  (unwind-protect
-      (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) nil))
-                ((symbol-function 'claude-client--display)
-                 (lambda (b) (setq shown b))))
-        (let ((claude-client-restore-window-after-review t))
-          (claude-client--reshow-after-review buf (list :kind 'text :text "hi"))
-          (check "no-reshow-on-text" shown nil)))
-    (kill-buffer buf)))
+  ;; Only tool results trigger it; ordinary text must not fight the user's
+  ;; window layout on every streamed message.
+  (let ((buf (claude-test--buffer))
+        (shown nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) nil))
+                  ((symbol-function 'claude-client--display)
+                   (lambda (b) (setq shown b))))
+          (let ((claude-client-restore-window-after-review t))
+            (claude-client--reshow-after-review buf (list :kind 'text :text "hi"))
+            (it "leaves the layout alone on ordinary text, not fighting it every message"
+              (check shown nil))))
+      (kill-buffer buf)))
 
-;; A conversation that is already visible is left alone.
-(let ((buf (claude-test--buffer))
-      (shown nil))
-  (unwind-protect
-      (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) 'win))
-                ((symbol-function 'claude-client--display)
-                 (lambda (b) (setq shown b))))
-        (let ((claude-client-restore-window-after-review t))
-          (claude-client--reshow-after-review
-           buf (list :kind 'tool-result :text "x"))
-          (check "no-reshow-when-visible" shown nil)))
-    (kill-buffer buf)))
+  ;; A conversation that is already visible is left alone.
+  (let ((buf (claude-test--buffer))
+        (shown nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) 'win))
+                  ((symbol-function 'claude-client--display)
+                   (lambda (b) (setq shown b))))
+          (let ((claude-client-restore-window-after-review t))
+            (claude-client--reshow-after-review
+             buf (list :kind 'tool-result :text "x"))
+            (it "leaves a conversation that is already visible alone"
+              (check shown nil))))
+      (kill-buffer buf)))
 
-;; Opt-out respected.
-(let ((buf (claude-test--buffer))
-      (shown nil))
-  (unwind-protect
-      (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) nil))
-                ((symbol-function 'claude-client--display)
-                 (lambda (b) (setq shown b))))
-        (let ((claude-client-restore-window-after-review nil))
-          (claude-client--reshow-after-review
-           buf (list :kind 'tool-result :text "x"))
-          (check "reshow-opt-out" shown nil)))
-    (kill-buffer buf)))
+  ;; Opt-out respected.
+  (let ((buf (claude-test--buffer))
+        (shown nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) nil))
+                  ((symbol-function 'claude-client--display)
+                   (lambda (b) (setq shown b))))
+          (let ((claude-client-restore-window-after-review nil))
+            (claude-client--reshow-after-review
+             buf (list :kind 'tool-result :text "x"))
+            (it "does nothing when `claude-client-restore-window-after-review' is off"
+              (check shown nil))))
+      (kill-buffer buf)))
 
-;; The re-show is installed as a subscriber, not wired into the runner: the
-;; log stays the seam, and this is just one more reader of it.
-(check "reshow-is-a-subscriber"
-       (and (memq #'claude-client--reshow-after-review
-                  claude-client-event-functions) t)
-       t)
+  ;; The re-show is installed as a subscriber, not wired into the runner: the
+  ;; log stays the seam, and this is just one more reader of it.
+  (it "is installed as one more subscriber, keeping the log as the seam"
+    (check-that (memq #'claude-client--reshow-after-review
+                      claude-client-event-functions))))
 
 ;;;; Interruption (issue #39)
 ;;
@@ -1172,119 +1293,123 @@ stays alive after `result', so process liveness cannot stand in for it."
 ;; following turn, so an interrupt costs the in-flight work and nothing else.
 
 ;; The wire shape is a control_request, not a user turn.
-(let ((buf (claude-test--buffer))
-      (sent nil))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string)
-                   (lambda (_p s) (setq sent s))))
-          (setq claude-client--process 'fake claude-client--turn-active t)
-          (claude-client-interrupt)
-          (let ((msg (json-parse-string sent :object-type 'alist)))
-            (check "interrupt-is-control-request"
-                   (alist-get 'type msg) "control_request")
-            (check "interrupt-subtype"
-                   (alist-get 'subtype (alist-get 'request msg)) "interrupt")
-            (check "interrupt-has-request-id"
-                   (stringp (alist-get 'request_id msg)) t))
-          (check "interrupt-logged"
-                 (memq 'interrupted (claude-test--kinds buf)) '(interrupted))))
-    (kill-buffer buf)))
+(describe "claude-client-interrupt"
+  (let ((buf (claude-test--buffer))
+        (sent nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string)
+                     (lambda (_p s) (setq sent s))))
+            (setq claude-client--process 'fake claude-client--turn-active t)
+            (claude-client-interrupt)
+            (let ((msg (json-parse-string sent :object-type 'alist)))
+              (it "writes a control_request rather than a user turn"
+                (check (alist-get 'type msg) "control_request"))
+              (it "asks for the interrupt subtype"
+                (check (alist-get 'subtype (alist-get 'request msg)) "interrupt"))
+              (it "carries a request id"
+                (check (stringp (alist-get 'request_id msg)) t)))
+            (it "logs the interruption"
+              (check (memq 'interrupted (claude-test--kinds buf)) '(interrupted)))))
+      (kill-buffer buf)))
 
-;; Interrupting with nothing running is refused rather than sent blindly.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (setq claude-client--turn-active nil)
-        (check "interrupt-refused-when-idle"
-               (condition-case _ (progn (claude-client-interrupt) nil)
-                 (user-error t))
-               t))
-    (kill-buffer buf)))
+  ;; Interrupting with nothing running is refused rather than sent blindly.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq claude-client--turn-active nil)
+          (it "refuses when idle rather than sending the request blindly"
+            (check (condition-case _ (progn (claude-client-interrupt) nil)
+                     (user-error t))
+                   t)))
+      (kill-buffer buf))))
 
 ;; A note written mid-turn interrupts it, rather than waiting.
-(let ((buf (claude-test--buffer))
-      (sent nil))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string)
-                   (lambda (_p s) (setq sent s))))
-          (setq claude-client--process 'fake)
-          (let ((claude-client-note-interrupts t))
-            (claude-test--with-running-turn
-             (claude-client-add-note "stop, do the other thing")))
-          (check "note-interrupts-turn"
-                 (and sent (string-match-p "interrupt" sent) t) t)
-          (check "note-logs-interrupted"
-                 (and (memq 'interrupted (claude-test--kinds buf)) t) t)
-          ;; Still queued: it is delivered when `result' arrives for the
-          ;; turn being abandoned, not written into a dying turn.
-          (check "note-still-queued-until-result"
-                 claude-client--pending-notes '("stop, do the other thing"))))
-    (kill-buffer buf)))
+(describe "claude-client-note-interrupts"
+  (let ((buf (claude-test--buffer))
+        (sent nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string)
+                     (lambda (_p s) (setq sent s))))
+            (setq claude-client--process 'fake)
+            (let ((claude-client-note-interrupts t))
+              (claude-test--with-running-turn
+               (claude-client-add-note "stop, do the other thing")))
+            (it "abandons the running turn instead of making the note wait"
+              (check-that (and sent (string-match-p "interrupt" sent))))
+            (it "logs the interruption"
+              (check-that (memq 'interrupted (claude-test--kinds buf))))
+            ;; Still queued: it is delivered when `result' arrives for the
+            ;; turn being abandoned, not written into a dying turn.
+            (it "keeps the note queued until the abandoned turn's `result' arrives"
+              (check claude-client--pending-notes '("stop, do the other thing")))))
+      (kill-buffer buf)))
 
-;; Opting out restores the queueing behaviour: nothing is abandoned.
-(let ((buf (claude-test--buffer))
-      (sent nil))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string)
-                   (lambda (_p s) (setq sent s))))
-          (setq claude-client--process 'fake)
-          (let ((claude-client-note-interrupts nil))
-            (claude-test--with-running-turn (claude-client-add-note "later")))
-          (check "no-interrupt-when-opted-out" sent nil)
-          (check "opted-out-note-queues"
-                 claude-client--pending-notes '("later"))))
-    (kill-buffer buf)))
+  ;; Opting out restores the queueing behaviour: nothing is abandoned.
+  (let ((buf (claude-test--buffer))
+        (sent nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string)
+                     (lambda (_p s) (setq sent s))))
+            (setq claude-client--process 'fake)
+            (let ((claude-client-note-interrupts nil))
+              (claude-test--with-running-turn (claude-client-add-note "later")))
+            (it "abandons nothing when switched off"
+              (check sent nil))
+            (it "falls back to queueing the note"
+              (check claude-client--pending-notes '("later")))))
+      (kill-buffer buf))))
 
 ;; After an interrupt the delivered turn tells the model not to resume, so it
 ;; re-plans around the note instead of carrying on with abandoned work.
-(let ((buf (claude-test--buffer))
-      (sent nil))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string)
-                   (lambda (_p s) (setq sent s))))
-          (setq claude-client--process 'fake)
-          (let ((claude-client-note-interrupts t)
-                (claude-client-deliver-notes t))
-            (claude-test--with-running-turn (claude-client-add-note "change course")))
-          (setq sent nil)
-          ;; The interrupted turn's result arrives; the note goes out now.
-          (setq claude-client--turn-active t)
-          (claude-test--feed buf (concat claude-test--result "\n"))
-          (check "replan-mentions-interruption"
-                 (and sent (string-match-p "interrupted" sent) t) t)
-          (check "replan-says-do-not-resume"
-                 (and sent (string-match-p "Do not resume" sent) t) t)
-          (check "replan-carries-note"
-                 (and sent (string-match-p "change course" sent) t) t)))
-    (kill-buffer buf)))
+(describe "the turn delivered after an interrupt"
+  (let ((buf (claude-test--buffer))
+        (sent nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string)
+                     (lambda (_p s) (setq sent s))))
+            (setq claude-client--process 'fake)
+            (let ((claude-client-note-interrupts t)
+                  (claude-client-deliver-notes t))
+              (claude-test--with-running-turn (claude-client-add-note "change course")))
+            (setq sent nil)
+            ;; The interrupted turn's result arrives; the note goes out now.
+            (setq claude-client--turn-active t)
+            (claude-test--feed buf (concat claude-test--result "\n"))
+            (it "tells the model its previous turn was interrupted"
+              (check-that (and sent (string-match-p "interrupted" sent))))
+            (it "tells the model not to resume the abandoned work"
+              (check-that (and sent (string-match-p "Do not resume" sent))))
+            (it "carries the note it should re-plan around"
+              (check-that (and sent (string-match-p "change course" sent))))))
+      (kill-buffer buf)))
 
-;; A turn that ended on its own is not framed as a re-plan.
-(let ((buf (claude-test--buffer))
-      (sent nil))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string)
-                   (lambda (_p s) (setq sent s))))
-          (setq claude-client--process 'fake)
-          (let ((claude-client-note-interrupts nil)
-                (claude-client-deliver-notes t))
-            (claude-test--with-running-turn (claude-client-add-note "fyi")))
-          (setq sent nil claude-client--turn-active t)
-          (claude-test--feed buf (concat claude-test--result "\n"))
-          (check "uninterrupted-has-no-replan-framing"
-                 (and sent (string-match-p "Do not resume" sent)) nil)
-          (check "uninterrupted-still-carries-note"
-                 (and sent (string-match-p "fyi" sent) t) t)))
-    (kill-buffer buf)))
+  ;; A turn that ended on its own is not framed as a re-plan.
+  (let ((buf (claude-test--buffer))
+        (sent nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string)
+                     (lambda (_p s) (setq sent s))))
+            (setq claude-client--process 'fake)
+            (let ((claude-client-note-interrupts nil)
+                  (claude-client-deliver-notes t))
+              (claude-test--with-running-turn (claude-client-add-note "fyi")))
+            (setq sent nil claude-client--turn-active t)
+            (claude-test--feed buf (concat claude-test--result "\n"))
+            (it "omits the re-plan framing for a turn that ended on its own"
+              (check (and sent (string-match-p "Do not resume" sent)) nil))
+            (it "still carries the note"
+              (check-that (and sent (string-match-p "fyi" sent))))))
+      (kill-buffer buf))))
 
 ;;;; Backpressure (issue #39)
 ;;
@@ -1293,101 +1418,107 @@ stays alive after `result', so process liveness cannot stand in for it."
 ;; same delivery rather than firing more interrupts into a dying turn.
 
 ;; Two notes during one turn interrupt it once, and both are delivered.
-(let ((buf (claude-test--buffer))
-      (interrupts 0))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string)
-                   (lambda (_p s)
-                     (when (string-match-p "interrupt" s)
-                       (setq interrupts (1+ interrupts))))))
-          (setq claude-client--process 'fake claude-client--turn-active t)
-          (claude-client-add-note "first")
-          (claude-client-add-note "second")
-          (check "one-interrupt-for-many-notes" interrupts 1)
-          (check "later-notes-still-queued"
-                 claude-client--pending-notes '("first" "second"))
-          (check "one-interrupted-event"
-                 (length (seq-filter
-                          (lambda (e) (eq (plist-get e :kind) 'interrupted))
-                          claude-client--events))
-                 1)))
-    (kill-buffer buf)))
+(describe "several notes during one turn"
+  (let ((buf (claude-test--buffer))
+        (interrupts 0))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string)
+                     (lambda (_p s)
+                       (when (string-match-p "interrupt" s)
+                         (setq interrupts (1+ interrupts))))))
+            (setq claude-client--process 'fake claude-client--turn-active t)
+            (claude-client-add-note "first")
+            (claude-client-add-note "second")
+            (it "fires one interrupt, not one per note into a dying turn"
+              (check interrupts 1))
+            (it "queues every note for the same delivery"
+              (check claude-client--pending-notes '("first" "second")))
+            (it "logs a single interrupted event"
+              (check (length (seq-filter
+                              (lambda (e) (eq (plist-get e :kind) 'interrupted))
+                              claude-client--events))
+                     1))))
+      (kill-buffer buf)))
 
-;; An exact repeat says nothing new, so it is coalesced rather than sent twice.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string) (lambda (&rest _) nil)))
-          (setq claude-client--process 'fake claude-client--turn-active t)
-          (claude-client-add-note "same thing")
-          (claude-client-add-note "same thing")
-          (check "duplicate-note-coalesced"
-                 claude-client--pending-notes '("same thing"))
-          ;; Still logged twice: the human did write it twice.
-          (check "duplicate-still-recorded"
-                 (length (seq-filter (lambda (e) (eq (plist-get e :kind) 'note))
-                                     claude-client--events))
-                 2)))
-    (kill-buffer buf)))
+  ;; An exact repeat says nothing new, so it is coalesced rather than sent twice.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string) (lambda (&rest _) nil)))
+            (setq claude-client--process 'fake claude-client--turn-active t)
+            (claude-client-add-note "same thing")
+            (claude-client-add-note "same thing")
+            (it "coalesces an exact repeat rather than sending it twice"
+              (check claude-client--pending-notes '("same thing")))
+            ;; Still logged twice: the human did write it twice.
+            (it "still logs both, since the human did write it twice"
+              (check (length (seq-filter (lambda (e) (eq (plist-get e :kind) 'note))
+                                         claude-client--events))
+                     2))))
+      (kill-buffer buf))))
 
 ;; Explicitly interrupting a turn that is already being interrupted is
 ;; refused rather than sending a second control request.
-(let ((buf (claude-test--buffer))
-      (interrupts 0))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string)
-                   (lambda (_p s)
-                     (when (string-match-p "interrupt" s)
-                       (setq interrupts (1+ interrupts))))))
-          (setq claude-client--process 'fake claude-client--turn-active t)
-          (claude-client-interrupt)
-          (check "second-interrupt-refused"
-                 (condition-case _ (progn (claude-client-interrupt) nil)
-                   (user-error t))
-                 t)
-          (check "second-interrupt-not-sent" interrupts 1)))
-    (kill-buffer buf)))
+(describe "claude-client-interrupt on an already-interrupted turn"
+  (let ((buf (claude-test--buffer))
+        (interrupts 0))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string)
+                     (lambda (_p s)
+                       (when (string-match-p "interrupt" s)
+                         (setq interrupts (1+ interrupts))))))
+            (setq claude-client--process 'fake claude-client--turn-active t)
+            (claude-client-interrupt)
+            (it "refuses a second interrupt"
+              (check (condition-case _ (progn (claude-client-interrupt) nil)
+                       (user-error t))
+                     t))
+            (it "sends no second control request"
+              (check interrupts 1))))
+      (kill-buffer buf))))
 
 ;; The queue is bounded: the newest note is the current intent, so the oldest
 ;; are dropped when the model is too slow to drain them.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string) (lambda (&rest _) nil)))
-          (setq claude-client--process 'fake claude-client--turn-active t)
-          (let ((claude-client-max-pending-notes 3))
-            (dolist (n '("n1" "n2" "n3" "n4" "n5"))
-              (claude-client-add-note n))
-            (check "queue-bounded" (length claude-client--pending-notes) 3)
-            (check "newest-kept"
-                   claude-client--pending-notes '("n3" "n4" "n5"))
-            ;; A drop is recorded, not silent.
-            (check "drops-logged"
-                   (mapcar (lambda (e) (plist-get e :text))
-                           (seq-filter
-                            (lambda (e) (eq (plist-get e :kind) 'note-dropped))
-                            claude-client--events))
-                   '("n1" "n2")))))
-    (kill-buffer buf)))
+(describe "claude-client-max-pending-notes"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string) (lambda (&rest _) nil)))
+            (setq claude-client--process 'fake claude-client--turn-active t)
+            (let ((claude-client-max-pending-notes 3))
+              (dolist (n '("n1" "n2" "n3" "n4" "n5"))
+                (claude-client-add-note n))
+              (it "holds no more notes than the bound"
+                (check (length claude-client--pending-notes) 3))
+              (it "drops the oldest, keeping the newest as the current intent"
+                (check claude-client--pending-notes '("n3" "n4" "n5")))
+              ;; A drop is recorded, not silent.
+              (it "records each drop rather than losing it silently"
+                (check (mapcar (lambda (e) (plist-get e :text))
+                               (seq-filter
+                                (lambda (e) (eq (plist-get e :kind) 'note-dropped))
+                                claude-client--events))
+                       '("n1" "n2"))))))
+      (kill-buffer buf)))
 
-;; nil means keep everything.
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
-                  ((symbol-function 'process-send-string) (lambda (&rest _) nil)))
-          (setq claude-client--process 'fake claude-client--turn-active t)
-          (let ((claude-client-max-pending-notes nil))
-            (dolist (n '("a" "b" "c" "d")) (claude-client-add-note n))
-            (check "unbounded-keeps-all"
-                   (length claude-client--pending-notes) 4))))
-    (kill-buffer buf)))
+  ;; nil means keep everything.
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string) (lambda (&rest _) nil)))
+            (setq claude-client--process 'fake claude-client--turn-active t)
+            (let ((claude-client-max-pending-notes nil))
+              (dolist (n '("a" "b" "c" "d")) (claude-client-add-note n))
+              (it "keeps every note when set to nil"
+                (check (length claude-client--pending-notes) 4)))))
+      (kill-buffer buf))))
 
 ;;;; Conversation buffers (issue #56)
 ;;
@@ -1395,43 +1526,72 @@ stays alive after `result', so process liveness cannot stand in for it."
 ;; being pinned: a single hardcoded name meant starting a conversation in
 ;; one project silently killed another project's CLI.
 
-(let ((default-directory "/tmp/proj-a/"))
-  (check "buffer-name-uses-project"
-         (claude-client--buffer-name "/tmp/proj-a/" 1)
-         "*claude-client:proj-a:1*")
-  (check "buffer-name-numbers"
-         (claude-client--buffer-name "/tmp/proj-a/" 7)
-         "*claude-client:proj-a:7*"))
+(describe "claude-client--buffer-name"
+  (let ((default-directory "/tmp/proj-a/"))
+    (it "names the buffer after the project"
+      (check (claude-client--buffer-name "/tmp/proj-a/" 1)
+             "*claude-client:proj-a:1*"))
+    (it "numbers the conversation within the project"
+      (check (claude-client--buffer-name "/tmp/proj-a/" 7)
+             "*claude-client:proj-a:7*"))))
 
 ;; Numbers are per project and fill the lowest free slot.
-(let* ((a1 (get-buffer-create "*claude-client:proj-a:1*"))
-       (a2 (get-buffer-create "*claude-client:proj-a:2*"))
-       (b1 (get-buffer-create "*claude-client:proj-b:1*")))
-  (unwind-protect
-      ;; A buffer's project comes from its own `default-directory', the way
-      ;; `claude-client--new-buffer' pins it.
-      (progn
-        (dolist (cell (list (cons a1 "/tmp/proj-a/")
-                            (cons a2 "/tmp/proj-a/")
-                            (cons b1 "/tmp/proj-b/")))
-          (with-current-buffer (car cell)
-            (claude-client-mode)
-            (setq default-directory (cdr cell))))
-        (check "buffers-found" (length (claude-client--buffers)) 3)
-        (check "project-scopes-buffers"
-               (length (claude-client--project-buffers "/tmp/proj-a/")) 2)
-        (check "next-number-skips-used"
-               (claude-client--next-number "/tmp/proj-a/") 3)
-        ;; A hole left by a killed conversation is refilled, not skipped.
-        (let ((kill-buffer-query-functions nil)) (kill-buffer a1))
-        (check "next-number-refills-hole"
-               (claude-client--next-number "/tmp/proj-a/") 1))
-    (let ((kill-buffer-query-functions nil))
-      (dolist (b (list a1 a2 b1)) (when (buffer-live-p b) (kill-buffer b))))))
+(describe "finding and numbering conversation buffers"
+  (let* ((a1 (get-buffer-create "*claude-client:proj-a:1*"))
+         (a2 (get-buffer-create "*claude-client:proj-a:2*"))
+         (b1 (get-buffer-create "*claude-client:proj-b:1*")))
+    (unwind-protect
+        ;; A buffer's project comes from its own `default-directory', the way
+        ;; `claude-client--new-buffer' pins it.
+        (progn
+          (dolist (cell (list (cons a1 "/tmp/proj-a/")
+                              (cons a2 "/tmp/proj-a/")
+                              (cons b1 "/tmp/proj-b/")))
+            (with-current-buffer (car cell)
+              (claude-client-mode)
+              (setq default-directory (cdr cell))))
+          (it "finds every conversation buffer regardless of project"
+            (check (length (claude-client--buffers)) 3))
+          (it "scopes conversations to one project by its `default-directory'"
+            (check (length (claude-client--project-buffers "/tmp/proj-a/")) 2))
+          (it "numbers past the slots already used in that project"
+            (check (claude-client--next-number "/tmp/proj-a/") 3))
+          ;; A hole left by a killed conversation is refilled, not skipped.
+          (let ((kill-buffer-query-functions nil)) (kill-buffer a1))
+          (it "refills the hole a killed conversation left, rather than skipping it"
+            (check (claude-client--next-number "/tmp/proj-a/") 1)))
+      (let ((kill-buffer-query-functions nil))
+        (dolist (b (list a1 a2 b1)) (when (buffer-live-p b) (kill-buffer b)))))))
 
 ;; `cl-letf' is not used for these: several `symbol-function' places in one
 ;; form collide during macroexpansion, so the mocks silently overwrite each
 ;; other.  Save and restore by hand instead.
+;; A killed process leaves the session id and the on-disk transcript behind,
+;; so `s' can point at `r' (resume this conversation) instead of `g' (start a
+;; new one and erase the log).  Regression: the message used to say `g'
+;; unconditionally, which threw away the context the human wanted back.
+(describe "the message claude-client-send gives on a dead process"
+  (let ((buf (generate-new-buffer "*claude-send-dead*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (claude-client-mode)
+          (setq claude-client--process nil
+                claude-client--turn-active nil)
+          ;; `user-error' curls the apostrophe, so match on substance not glyph.
+          (let ((msg (lambda ()
+                       (condition-case err (claude-client-send "hi")
+                         (user-error (error-message-string err))))))
+            (setq claude-client--session-id "abc-123")
+            (it "points at `r' to resume when a session id survives, not `g' which erases the log"
+              (check (and (string-match-p "r." (funcall msg))
+                          (string-match-p "resumes" (funcall msg))
+                          t)
+                     t))
+            (setq claude-client--session-id nil)
+            (it "does not offer resuming when there is no session to resume"
+              (check (and (string-match-p "resumes" (funcall msg)) t) nil))))
+      (kill-buffer buf))))
+
 (defmacro claude-test--with-stubs (stubs &rest body)
   "Run BODY with STUBS, an alist of (SYMBOL . FUNCTION), then restore."
   (declare (indent 1))
@@ -1461,174 +1621,219 @@ ROOT-FN supplies the project root; ON-DELETE, when given, replaces
    (when on-delete (list (cons 'delete-process on-delete)))))
 
 ;; The regression: starting in project B must not touch project A's process.
-(let ((a nil) (b nil) (root "/tmp/proj-a/"))
-  (unwind-protect
-      (claude-test--with-stubs
-          (cons (cons 'process-live-p (lambda (p) (eq p 'fake-proc)))
-                (claude-test--start-stubs
-                 (lambda () root)
-                 (lambda (&rest _) (error "a live conversation was killed"))))
-        (setq a (claude-client-start "in A"))
-        (check "start-names-by-project" (buffer-name a) "*claude-client:proj-a:1*")
-        ;; Switch project and start again: delete-process would signal.
-        (setq root "/tmp/proj-b/")
-        (check "cross-project-start-spares-other"
-               (condition-case err
-                   (progn (setq b (claude-client-start "in B")) :no-kill)
-                 (error (error-message-string err)))
-               :no-kill)
-        (check "second-buffer-is-distinct" (buffer-name b)
-               "*claude-client:proj-b:1*")
-        (check "first-still-live" (buffer-live-p a) t))
-    (let ((kill-buffer-query-functions nil))
-      (dolist (x (list a b)) (when (and x (buffer-live-p x)) (kill-buffer x))))))
+(describe "claude-client-start across projects"
+  (let ((a nil) (b nil) (root "/tmp/proj-a/"))
+    (unwind-protect
+        (claude-test--with-stubs
+            (cons (cons 'process-live-p (lambda (p) (eq p 'fake-proc)))
+                  (claude-test--start-stubs
+                   (lambda () root)
+                   (lambda (&rest _) (error "a live conversation was killed"))))
+          (setq a (claude-client-start "in A"))
+          (it "names the new conversation after its project"
+            (check (buffer-name a) "*claude-client:proj-a:1*"))
+          ;; Switch project and start again: delete-process would signal.
+          (setq root "/tmp/proj-b/")
+          (it "leaves the other project's CLI running"
+            (check (condition-case err
+                       (progn (setq b (claude-client-start "in B")) :no-kill)
+                     (error (error-message-string err)))
+                   :no-kill))
+          (it "gives the second project its own buffer"
+            (check (buffer-name b) "*claude-client:proj-b:1*"))
+          (it "leaves the first conversation's buffer alive"
+            (check (buffer-live-p a) t)))
+      (let ((kill-buffer-query-functions nil))
+        (dolist (x (list a b)) (when (and x (buffer-live-p x)) (kill-buffer x)))))))
 
 ;; `g' from inside a conversation restarts in place rather than piling up.
-(let ((buf nil))
-  (unwind-protect
-      (claude-test--with-stubs
-          (cons (cons 'process-live-p (lambda (_p) nil))
-                (claude-test--start-stubs (lambda () "/tmp/proj-a/")))
-        (setq buf (claude-client-start "first"))
-        ;; No CLI to emit `result', so clear the in-flight flag by hand --
-        ;; otherwise the restart is refused, which is its own correct
-        ;; behaviour but not what this test is about.
-        (with-current-buffer buf (setq claude-client--turn-active nil))
-        (let ((again (with-current-buffer buf (claude-client-start "again"))))
-          (check "restart-in-place-reuses-buffer" (eq again buf) t)
-          (check "restart-in-place-adds-no-buffer"
-                 (length (claude-client--buffers)) 1)))
-    (let ((kill-buffer-query-functions nil))
-      (when (and buf (buffer-live-p buf)) (kill-buffer buf)))))
+(describe "claude-client-start from inside a conversation"
+  (let ((buf nil))
+    (unwind-protect
+        (claude-test--with-stubs
+            (cons (cons 'process-live-p (lambda (_p) nil))
+                  (claude-test--start-stubs (lambda () "/tmp/proj-a/")))
+          (setq buf (claude-client-start "first"))
+          ;; No CLI to emit `result', so clear the in-flight flag by hand --
+          ;; otherwise the restart is refused, which is its own correct
+          ;; behaviour but not what this test is about.
+          (with-current-buffer buf (setq claude-client--turn-active nil))
+          (let ((again (with-current-buffer buf (claude-client-start "again"))))
+            (it "restarts in the same buffer"
+              (check (eq again buf) t))
+            (it "adds no buffer, so conversations do not pile up"
+              (check (length (claude-client--buffers)) 1))))
+      (let ((kill-buffer-query-functions nil))
+        (when (and buf (buffer-live-p buf)) (kill-buffer buf))))))
 
 ;; Toggle: no conversation starts one, a visible one is hidden, a hidden
 ;; one is shown.
-(let ((buf nil) (started nil) (shown nil) (deleted nil))
-  (unwind-protect
-      (claude-test--with-stubs
-          (list (cons 'claude-client--project-root (lambda () "/tmp/proj-a/"))
-                (cons 'claude-client-start (lambda (&rest _) (interactive) (setq started t)))
-                (cons 'claude-client--display (lambda (b) (setq shown b)))
-                (cons 'delete-window (lambda (&optional w) (setq deleted (or w t)))))
-        ;; Nothing yet: toggle starts a conversation.
-        (claude-client-toggle)
-        (check "toggle-with-none-starts" started t)
-        ;; With one hidden conversation: shown, not started again.
-        (setq buf (get-buffer-create "*claude-client:proj-a:1*")
-              started nil)
-        (with-current-buffer buf
-          (claude-client-mode)
-          (setq default-directory "/tmp/proj-a/"))
-        ;; Nowhere at all (nil for this frame and for all frames).
-        (claude-test--with-stubs
-            (list (cons 'get-buffer-window (lambda (&rest _) nil)))
-          (claude-client-toggle))
-        (check "toggle-hidden-shows" shown buf)
-        (check "toggle-hidden-does-not-start" started nil)
-        ;; Visible on this frame: the window is hidden, not re-shown.
-        (setq shown nil)
-        (claude-test--with-stubs
-            (list (cons 'get-buffer-window (lambda (&rest _) 'fake-window)))
-          (claude-client-toggle))
-        (check "toggle-visible-hides" deleted 'fake-window)
-        (check "toggle-visible-does-not-show" shown nil))
-    (let ((kill-buffer-query-functions nil))
-      (when (and buf (buffer-live-p buf)) (kill-buffer buf)))))
-
-;; Frame-awareness: a conversation only on *another* frame is raised, not
-;; hidden and not duplicated.
-(let ((buf nil) (shown nil) (deleted nil) (focused nil) (selected nil))
-  (unwind-protect
-      (progn
-        (setq buf (get-buffer-create "*claude-client:proj-a:1*"))
-        (with-current-buffer buf
-          (claude-client-mode)
-          (setq default-directory "/tmp/proj-a/"))
-        (claude-test--with-stubs
-            (list (cons 'claude-client--project-root (lambda () "/tmp/proj-a/"))
-                  (cons 'claude-client--display (lambda (b) (setq shown b)))
-                  (cons 'delete-window (lambda (&optional w) (setq deleted (or w t))))
-                  ;; nil for this frame, a window when asked across frames.
-                  (cons 'get-buffer-window
-                        (lambda (&optional _buf all-frames)
-                          (and all-frames 'other-window)))
-                  (cons 'window-frame (lambda (&rest _) 'other-frame))
-                  (cons 'select-frame-set-input-focus
-                        (lambda (f) (setq focused f)))
-                  (cons 'select-window (lambda (w &rest _) (setq selected w))))
-          (claude-client-toggle))
-        (check "toggle-other-frame-raises" focused 'other-frame)
-        (check "toggle-other-frame-selects-window" selected 'other-window)
-        (check "toggle-other-frame-does-not-hide" deleted nil)
-        (check "toggle-other-frame-does-not-redisplay" shown nil))
-    (let ((kill-buffer-query-functions nil))
-      (when (and buf (buffer-live-p buf)) (kill-buffer buf)))))
-
-;; A split window is simply deleted.
-(let ((deleted nil) (iconified nil))
-  (claude-test--with-stubs
-      (list (cons 'delete-window (lambda (&optional w) (setq deleted (or w t))))
-            (cons 'iconify-frame (lambda (f) (setq iconified f))))
-    (claude-client--hide-window 'a-window))
-  (check "hide-window-deletes" deleted 'a-window)
-  (check "hide-window-spares-frame" iconified nil))
-
-;; A conversation alone on its own frame would trip `delete-window''s
-;; sole-window error, so the frame is iconified instead.
-(let ((iconified nil))
-  (claude-test--with-stubs
-      (list (cons 'delete-window
-                  (lambda (&optional _w) (error "Attempt to delete minibuffer or sole ordinary window")))
-            (cons 'window-frame (lambda (&rest _) 'lone-frame))
-            (cons 'iconify-frame (lambda (f) (setq iconified f))))
-    (claude-client--hide-window 'lone-window))
-  (check "hide-sole-window-iconifies" iconified 'lone-frame))
-
-;; Toggle is project-scoped: another project's conversation is not a
-;; candidate, so toggling in an empty project starts a new one.
-(let ((other nil) (started nil))
-  (unwind-protect
-      (progn
-        (setq other (get-buffer-create "*claude-client:proj-b:1*"))
-        (with-current-buffer other
-          (claude-client-mode)
-          (setq default-directory "/tmp/proj-b/"))
+(describe "claude-client-toggle"
+  (let ((buf nil) (started nil) (shown nil) (deleted nil))
+    (unwind-protect
         (claude-test--with-stubs
             (list (cons 'claude-client--project-root (lambda () "/tmp/proj-a/"))
                   (cons 'claude-client-start (lambda (&rest _) (interactive) (setq started t)))
-                  (cons 'claude-client--display #'ignore))
-          (claude-client-toggle))
-        (check "toggle-ignores-other-project" started t))
-    (let ((kill-buffer-query-functions nil))
-      (when (and other (buffer-live-p other)) (kill-buffer other)))))
+                  (cons 'claude-client--display (lambda (b) (setq shown b)))
+                  (cons 'delete-window (lambda (&optional w) (setq deleted (or w t)))))
+          ;; Nothing yet: toggle starts a conversation.
+          (claude-client-toggle)
+          (it "starts a conversation when there is none"
+            (check started t))
+          ;; With one hidden conversation: shown, not started again.
+          (setq buf (get-buffer-create "*claude-client:proj-a:1*")
+                started nil)
+          (with-current-buffer buf
+            (claude-client-mode)
+            (setq default-directory "/tmp/proj-a/"))
+          ;; Nowhere at all (nil for this frame and for all frames).
+          (claude-test--with-stubs
+              (list (cons 'get-buffer-window (lambda (&rest _) nil)))
+            (claude-client-toggle))
+          (it "shows a hidden conversation"
+            (check shown buf))
+          (it "does not start another one when a hidden conversation exists"
+            (check started nil))
+          ;; Visible on this frame: the window is hidden, not re-shown.
+          (setq shown nil)
+          (claude-test--with-stubs
+              (list (cons 'get-buffer-window (lambda (&rest _) 'fake-window)))
+            (claude-client-toggle))
+          (it "hides the window of a conversation visible on this frame"
+            (check deleted 'fake-window))
+          (it "does not re-show a conversation it just hid"
+            (check shown nil)))
+      (let ((kill-buffer-query-functions nil))
+        (when (and buf (buffer-live-p buf)) (kill-buffer buf))))))
+
+;; Frame-awareness: a conversation only on *another* frame is raised, not
+;; hidden and not duplicated.
+(describe "claude-client-toggle with the conversation on another frame"
+  (let ((buf nil) (shown nil) (deleted nil) (focused nil) (selected nil))
+    (unwind-protect
+        (progn
+          (setq buf (get-buffer-create "*claude-client:proj-a:1*"))
+          (with-current-buffer buf
+            (claude-client-mode)
+            (setq default-directory "/tmp/proj-a/"))
+          (claude-test--with-stubs
+              (list (cons 'claude-client--project-root (lambda () "/tmp/proj-a/"))
+                    (cons 'claude-client--display (lambda (b) (setq shown b)))
+                    (cons 'delete-window (lambda (&optional w) (setq deleted (or w t))))
+                    ;; nil for this frame, a window when asked across frames.
+                    (cons 'get-buffer-window
+                          (lambda (&optional _buf all-frames)
+                            (and all-frames 'other-window)))
+                    (cons 'window-frame (lambda (&rest _) 'other-frame))
+                    (cons 'select-frame-set-input-focus
+                          (lambda (f) (setq focused f)))
+                    (cons 'select-window (lambda (w &rest _) (setq selected w))))
+            (claude-client-toggle))
+          (it "raises the other frame"
+            (check focused 'other-frame))
+          (it "selects the conversation's window on that frame"
+            (check selected 'other-window))
+          (it "does not hide it"
+            (check deleted nil))
+          (it "does not duplicate it into this frame"
+            (check shown nil)))
+      (let ((kill-buffer-query-functions nil))
+        (when (and buf (buffer-live-p buf)) (kill-buffer buf))))))
+
+(describe "claude-client--hide-window"
+  ;; A split window is simply deleted.
+  (let ((deleted nil) (iconified nil))
+    (claude-test--with-stubs
+        (list (cons 'delete-window (lambda (&optional w) (setq deleted (or w t))))
+              (cons 'iconify-frame (lambda (f) (setq iconified f))))
+      (claude-client--hide-window 'a-window))
+    (it "deletes a split window"
+      (check deleted 'a-window))
+    (it "leaves the frame alone when the window could be deleted"
+      (check iconified nil)))
+
+  ;; A conversation alone on its own frame would trip `delete-window''s
+  ;; sole-window error, so the frame is iconified instead.
+  (let ((iconified nil))
+    (claude-test--with-stubs
+        (list (cons 'delete-window
+                    (lambda (&optional _w) (error "Attempt to delete minibuffer or sole ordinary window")))
+              (cons 'window-frame (lambda (&rest _) 'lone-frame))
+              (cons 'iconify-frame (lambda (f) (setq iconified f))))
+      (claude-client--hide-window 'lone-window))
+    (it "iconifies the frame when the conversation is its sole window"
+      (check iconified 'lone-frame))))
+
+;; Toggle is project-scoped: another project's conversation is not a
+;; candidate, so toggling in an empty project starts a new one.
+(describe "claude-client-toggle in a project with no conversation"
+  (let ((other nil) (started nil))
+    (unwind-protect
+        (progn
+          (setq other (get-buffer-create "*claude-client:proj-b:1*"))
+          (with-current-buffer other
+            (claude-client-mode)
+            (setq default-directory "/tmp/proj-b/"))
+          (claude-test--with-stubs
+              (list (cons 'claude-client--project-root (lambda () "/tmp/proj-a/"))
+                    (cons 'claude-client-start (lambda (&rest _) (interactive) (setq started t)))
+                    (cons 'claude-client--display #'ignore))
+            (claude-client-toggle))
+          (it "starts a new one rather than showing another project's conversation"
+            (check started t)))
+      (let ((kill-buffer-query-functions nil))
+        (when (and other (buffer-live-p other)) (kill-buffer other))))))
 
 ;; The single-letter keys.  Evil is not installed in batch, so this only
 ;; pins the plain-Emacs map and the evil-registration data; the evil path
 ;; itself needs a live evil (see `claude-client--setup-evil').
-(let ((buf (claude-test--buffer)))
-  (unwind-protect
-      (with-current-buffer buf
-        (check "letter-s-sends"
-               (lookup-key claude-client-mode-map (kbd "s")) 'claude-client-send)
-        (check "letter-n-notes"
-               (lookup-key claude-client-mode-map (kbd "n")) 'claude-client-add-note)
-        ;; The evil table must stay in step with the keymap, since the two
-        ;; are bound from separate places.
-        (check "evil-table-matches-keymap"
-               (sort (mapcar (lambda (c)
-                               (format "%s=%s" (car c)
-                                       (lookup-key claude-client-mode-map (kbd (car c)))))
-                             claude-client--evil-keys)
-                     #'string<)
-               (sort (mapcar (lambda (c) (format "%s=%s" (car c) (cdr c)))
-                             claude-client--evil-keys)
-                     #'string<))
-        ;; The evil-safe C-c vocabulary comes from the parent mode and must
-        ;; survive regardless.
-        (check "C-c-C-s-inherited"
-               (lookup-key agent-backend-mode-map (kbd "C-c C-s"))
-               'agent-backend-send-command)
-        ;; Guarded so a snipe-less Emacs is a no-op rather than an error.
-        (check "setup-evil-safe-without-evil"
-               (progn (claude-client--setup-evil) :no-error) :no-error))
-    (kill-buffer buf)))
+(describe "the single-letter keys"
+  (let ((buf (claude-test--buffer)))
+    (unwind-protect
+        (with-current-buffer buf
+          (it "binds `s' to send"
+            (check (lookup-key claude-client-mode-map (kbd "s"))
+                   'claude-client-send))
+          (it "binds `n' to add a note"
+            (check (lookup-key claude-client-mode-map (kbd "n"))
+                   'claude-client-add-note))
+          ;; The evil table must stay in step with the keymap, since the two
+          ;; are bound from separate places.
+          (it "keeps the evil table in step with the keymap, bound from separate places"
+            (check (sort (mapcar (lambda (c)
+                                   (format "%s=%s" (car c)
+                                           (lookup-key claude-client-mode-map (kbd (car c)))))
+                                 claude-client--evil-keys)
+                         #'string<)
+                   (sort (mapcar (lambda (c) (format "%s=%s" (car c) (cdr c)))
+                                 claude-client--evil-keys)
+                         #'string<)))
+          ;; `k' and `g' are left to evil on purpose: both are motions
+          ;; (`evil-previous-line', the `gg' prefix) and both sit in front of a
+          ;; destructive command here, so re-registering them made moving the
+          ;; cursor up kill the CLI process and `gg' dead.  Pinned as absences
+          ;; so re-adding them has to be a deliberate edit to this test.
+          (it "leaves `k' to evil, which needs it for `evil-previous-line'"
+            (check (and (assoc "k" claude-client--evil-keys) t) nil))
+          (it "leaves `g' to evil, which needs it for the `gg' prefix"
+            (check (and (assoc "g" claude-client--evil-keys) t) nil))
+          ;; ...while the commands stay reachable, evil or not.
+          (it "binds `?' to help"
+            (check (lookup-key claude-client-mode-map (kbd "?"))
+                   'claude-client-help))
+          (it "binds C-c C-q to quit"
+            (check (lookup-key agent-backend-mode-map (kbd "C-c C-q"))
+                   'agent-backend-quit-command))
+          ;; The evil-safe C-c vocabulary comes from the parent mode and must
+          ;; survive regardless.
+          (it "inherits the parent mode's evil-safe C-c C-s"
+            (check (lookup-key agent-backend-mode-map (kbd "C-c C-s"))
+                   'agent-backend-send-command))
+          ;; Guarded so a snipe-less Emacs is a no-op rather than an error.
+          (it "makes `claude-client--setup-evil' a no-op without evil, not an error"
+            (check (progn (claude-client--setup-evil) :no-error) :no-error)))
+      (kill-buffer buf))))
+
+(test-helper-summary)
+
+;;; claude-client-test.el ends here

--- a/test/init/init.el
+++ b/test/init/init.el
@@ -1,0 +1,76 @@
+;;; init.el --- Init file for the isolated test Emacs -*- lexical-binding: t; -*-
+
+;; Loaded by bin/test-emacs.sh with `--init-directory' pointing at this
+;; directory, so this is the whole configuration of the test instance -- no
+;; Doom, no user config, no personal packages.  Two reasons it exists rather
+;; than running the suites in the working Emacs:
+;;
+;;   - Every fixture that pops a window, an ediff or a *claude-client* buffer
+;;     used to land in the middle of whatever was being worked on.
+;;   - Anything that wedges or kills the instance (a runaway process filter, a
+;;     ws handler error, a hard crash) took the working session with it.
+;;
+;; Isolation is by state, not just by process: the MCP HTTP port, the
+;; emacsclient socket and the IDE lockfile directory are what a second Emacs
+;; would otherwise fight the working one over.  `mcp-emacs-ide' already picks a
+;; random WebSocket port, so that one needs no offset.
+;;
+;; It lives in test/init/ rather than test/ itself because Emacs warns when
+;; `user-emacs-directory' also sits on `load-path', and test/ has to be on
+;; `load-path' for the suites.
+
+;;; Code:
+
+(require 'package)
+
+;; `user-emacs-directory' is set by the script's `--init-directory', which
+;; points at .test-emacs/home/ rather than at this file's own directory.  It
+;; has to: `native-comp-eln-load-path' is derived from it at startup, before
+;; any init file runs, so an init directory inside the tracked tree gets an
+;; eln-cache/ dropped into the repo whatever this file does afterwards.  All
+;; instance state therefore lands under the git-ignored .test-emacs/.
+
+;; Deps come from a package dir the script prepares under .test-emacs/, so a
+;; run never mutates ~/.emacs.d and only refreshes MELPA when something is
+;; actually missing.
+(setq package-user-dir
+      (or (getenv "MCP_EMACS_TEST_PACKAGE_DIR")
+          (expand-file-name "package" user-emacs-directory)))
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
+(package-initialize)
+
+;; MCP_EMACS_TEST_REPO is always set by the script; the fallback is for a
+;; hand-rolled `emacs --init-directory test/init' invocation.
+(let ((repo (or (getenv "MCP_EMACS_TEST_REPO")
+                (expand-file-name "../.." (file-name-directory load-file-name)))))
+  (add-to-list 'load-path (expand-file-name "elisp" repo))
+  (add-to-list 'load-path (expand-file-name "test" repo)))
+
+;; Offset from the working instance's 8765 so both can listen at once.  Set
+;; before the server module is loaded, hence the bare defvar.
+(defvar mcp-emacs-server-port)
+(setq mcp-emacs-server-port
+      (string-to-number (or (getenv "MCP_EMACS_TEST_PORT") "8775")))
+
+;; Keep IDE lockfiles out of ~/.claude/ide, or a stale test lockfile can be
+;; picked up by a real Claude launched from the working Emacs.
+(defvar mcp-emacs-ide-lockfile-directory)
+(setq mcp-emacs-ide-lockfile-directory
+      (expand-file-name "ide/" user-emacs-directory))
+
+(setq inhibit-startup-screen t
+      make-backup-files nil
+      auto-save-default nil
+      create-lockfiles nil
+      ;; A prompt in a headless daemon is a hang, not a question.
+      confirm-kill-processes nil
+      ;; Suites assert on buffer text; an indentation surprise inherited from
+      ;; a personal default would be noise.
+      indent-tabs-mode nil)
+
+;; Batch only: in a daemon or GUI this would drop into a debugger on every
+;; error a fixture deliberately provokes.
+(when noninteractive
+  (setq debug-on-error t))
+
+;;; init.el ends here

--- a/test/mcp-emacs-apply-diff-test.el
+++ b/test/mcp-emacs-apply-diff-test.el
@@ -1,7 +1,10 @@
+;;; mcp-emacs-apply-diff-test.el --- Tests for the apply-diff ediff review -*- lexical-binding: t; -*-
+
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'cl-lib)
 (require 'mcp-emacs)
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
 
 (defun mcp--make-session (a-text b-text)
   "Return (buffer-a buffer-b entry-content result) for a fake diff session."
@@ -15,58 +18,70 @@
   (with-current-buffer buffer-a
     (buffer-substring-no-properties (point-min) (point-max))))
 
-;; 4.1 Accept unchanged -> applied, proposal applied to A.
-(let* ((s (mcp--make-session "old\n" "new\n"))
-       (a (nth 0 s)) (b (nth 1 s)) (entry (nth 2 s)) (result (nth 3 s)))
-  (unwind-protect
-      (progn
-        (mcp-emacs--apply-diff-accept a b entry result)
-        (check "accept-unchanged-status" (car result) 'applied)
-        (check "accept-unchanged-content" (mcp--a-text a) "new\n"))
-    (kill-buffer a) (kill-buffer b)))
+(describe "mcp-emacs--apply-diff-accept"
+  ;; 4.1 Accept unchanged -> applied, proposal applied to A.
+  (let* ((s (mcp--make-session "old\n" "new\n"))
+         (a (nth 0 s)) (b (nth 1 s)) (entry (nth 2 s)) (result (nth 3 s)))
+    (unwind-protect
+        (progn
+          (mcp-emacs--apply-diff-accept a b entry result)
+          (it "records the decision as applied"
+            (check (car result) 'applied))
+          (it "writes the proposal into buffer A"
+            (check (mcp--a-text a) "new\n")))
+      (kill-buffer a) (kill-buffer b)))
 
-;; 4.2 Reject -> rejected, A unchanged.
-(let* ((s (mcp--make-session "old\n" "new\n"))
-       (a (nth 0 s)) (b (nth 1 s)) (result (nth 3 s)))
-  (unwind-protect
-      (progn
-        (mcp-emacs--apply-diff-reject result)
-        (check "reject-status" (car result) 'rejected)
-        (check "reject-content-unchanged" (mcp--a-text a) "old\n"))
-    (kill-buffer a) (kill-buffer b)))
+  ;; 4.3 Human edits A then accepts -> applied with the edited content, not B.
+  (let* ((s (mcp--make-session "old\n" "new\n"))
+         (a (nth 0 s)) (b (nth 1 s)) (entry (nth 2 s)) (result (nth 3 s)))
+    (unwind-protect
+        (progn
+          (with-current-buffer a (erase-buffer) (insert "hand-edited\n"))
+          (mcp-emacs--apply-diff-accept a b entry result)
+          (it "records applied when the human edited A first"
+            (check (car result) 'applied))
+          (it "keeps the human's edit rather than overwriting it with B"
+            (check (mcp--a-text a) "hand-edited\n")))
+      (kill-buffer a) (kill-buffer b)))
 
-;; 4.3 Human edits A then accepts -> applied with the edited content, not B.
-(let* ((s (mcp--make-session "old\n" "new\n"))
-       (a (nth 0 s)) (b (nth 1 s)) (entry (nth 2 s)) (result (nth 3 s)))
-  (unwind-protect
-      (progn
-        (with-current-buffer a (erase-buffer) (insert "hand-edited\n"))
-        (mcp-emacs--apply-diff-accept a b entry result)
-        (check "edit-accept-status" (car result) 'applied)
-        (check "edit-accept-keeps-edit" (mcp--a-text a) "hand-edited\n"))
-    (kill-buffer a) (kill-buffer b)))
+  ;; Accept must not override a decision already recorded (quit hook is a no-op
+  ;; once set): the hook only defaults when result is still nil.
+  (let* ((s (mcp--make-session "old\n" "new\n"))
+         (a (nth 0 s)) (b (nth 1 s)) (entry (nth 2 s)) (result (nth 3 s)))
+    (unwind-protect
+        (progn
+          (mcp-emacs--apply-diff-accept a b entry result)
+          (unless (car result) (setcar result 'rejected)) ; quit hook runs after
+          (it "survives the quit hook default that runs after it"
+            (check (car result) 'applied)))
+      (kill-buffer a) (kill-buffer b))))
 
-;; 4.4 Quit without accepting -> the quit-hook default resolves to rejected.
-;; Model the quit hook: on quit, if result is unset, set it to rejected.
-(let* ((s (mcp--make-session "old\n" "new\n"))
-       (a (nth 0 s)) (b (nth 1 s)) (result (nth 3 s)))
-  (unwind-protect
-      (progn
-        (unless (car result) (setcar result 'rejected)) ; mirrors ediff-quit-hook
-        (check "quit-default-rejected" (car result) 'rejected)
-        (check "quit-content-unchanged" (mcp--a-text a) "old\n"))
-    (kill-buffer a) (kill-buffer b)))
+(describe "mcp-emacs--apply-diff-reject"
+  ;; 4.2 Reject -> rejected, A unchanged.
+  (let* ((s (mcp--make-session "old\n" "new\n"))
+         (a (nth 0 s)) (b (nth 1 s)) (result (nth 3 s)))
+    (unwind-protect
+        (progn
+          (mcp-emacs--apply-diff-reject result)
+          (it "records the decision as rejected"
+            (check (car result) 'rejected))
+          (it "leaves buffer A untouched"
+            (check (mcp--a-text a) "old\n")))
+      (kill-buffer a) (kill-buffer b))))
 
-;; Accept must not override a decision already recorded (quit hook is a no-op
-;; once set): the hook only defaults when result is still nil.
-(let* ((s (mcp--make-session "old\n" "new\n"))
-       (a (nth 0 s)) (b (nth 1 s)) (entry (nth 2 s)) (result (nth 3 s)))
-  (unwind-protect
-      (progn
-        (mcp-emacs--apply-diff-accept a b entry result)
-        (unless (car result) (setcar result 'rejected)) ; quit hook runs after
-        (check "accept-survives-quit-hook" (car result) 'applied))
-    (kill-buffer a) (kill-buffer b)))
+(describe "quitting a review without deciding"
+  ;; 4.4 Quit without accepting -> the quit-hook default resolves to rejected.
+  ;; Model the quit hook: on quit, if result is unset, set it to rejected.
+  (let* ((s (mcp--make-session "old\n" "new\n"))
+         (a (nth 0 s)) (b (nth 1 s)) (result (nth 3 s)))
+    (unwind-protect
+        (progn
+          (unless (car result) (setcar result 'rejected)) ; mirrors ediff-quit-hook
+          (it "defaults the decision to rejected"
+            (check (car result) 'rejected))
+          (it "leaves buffer A untouched"
+            (check (mcp--a-text a) "old\n")))
+      (kill-buffer a) (kill-buffer b))))
 
 ;;;; Window-layout save/restore (#21)
 
@@ -75,52 +90,59 @@
 ;; the setup lambda runs (installing the key bindings and quit hook on a fake
 ;; control buffer) without a real ediff session, then fire the quit hook and
 ;; assert the layout is put back.
-(let* ((buffer-a (generate-new-buffer " *win-a*"))
-       (buffer-b (generate-new-buffer " *win-b*"))
-       (result (list nil))
-       (control (generate-new-buffer " *fake-control*"))
-       (restored nil)
-       (mcp-emacs-ediff-window-direction 'plain))
-  (with-current-buffer buffer-a (insert "old\n"))
-  (with-current-buffer buffer-b (insert "new\n"))
-  (unwind-protect
-      (cl-letf (((symbol-function 'ediff-buffers)
-                 (lambda (_a _b setup-hooks &rest _)
-                   ;; ediff would bind `ediff-control-buffer' and run the
-                   ;; setup hooks; emulate just enough for the setup lambda.
-                   (let ((ediff-control-buffer control))
-                     (dolist (fn setup-hooks) (funcall fn)))
-                   control))
-                ((symbol-function 'set-window-configuration)
-                 (lambda (&rest _) (setq restored t))))
-        (let ((ctl (mcp-emacs--ediff-review buffer-a buffer-b "old\n" result)))
-          (check "review-returns-control" ctl control)
-          (check "quit-hook-installed"
-                 (and (with-current-buffer control ediff-quit-hook) t) t)
-          ;; Fire the quit hook (the single quit path).
-          (with-current-buffer control (run-hooks 'ediff-quit-hook))
-          (check "quit-defaults-rejected" (car result) 'rejected)
-          (check "layout-restored-on-quit" restored t)))
-    (dolist (b (list buffer-a buffer-b control))
-      (when (buffer-live-p b) (kill-buffer b)))))
+(describe "mcp-emacs--ediff-review window-layout restore"
+  (let* ((buffer-a (generate-new-buffer " *win-a*"))
+         (buffer-b (generate-new-buffer " *win-b*"))
+         (result (list nil))
+         (control (generate-new-buffer " *fake-control*"))
+         (restored nil)
+         (mcp-emacs-ediff-window-direction 'plain))
+    (with-current-buffer buffer-a (insert "old\n"))
+    (with-current-buffer buffer-b (insert "new\n"))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ediff-buffers)
+                   (lambda (_a _b setup-hooks &rest _)
+                     ;; ediff would bind `ediff-control-buffer' and run the
+                     ;; setup hooks; emulate just enough for the setup lambda.
+                     (let ((ediff-control-buffer control))
+                       (dolist (fn setup-hooks) (funcall fn)))
+                     control))
+                  ((symbol-function 'set-window-configuration)
+                   (lambda (&rest _) (setq restored t))))
+          (let ((ctl (mcp-emacs--ediff-review buffer-a buffer-b "old\n" result)))
+            (it "returns the ediff control buffer"
+              (check ctl control))
+            (it "installs a quit hook on the control buffer"
+              (check-that (with-current-buffer control ediff-quit-hook)))
+            ;; Fire the quit hook (the single quit path).
+            (with-current-buffer control (run-hooks 'ediff-quit-hook))
+            (it "defaults an undecided review to rejected on quit"
+              (check (car result) 'rejected))
+            (it "puts the saved window layout back on quit"
+              (check restored t))))
+      (dolist (b (list buffer-a buffer-b control))
+        (when (buffer-live-p b) (kill-buffer b))))))
 
 ;; The restore fires exactly once even though the hook could be entered per
 ;; keypress: a second run with the decision already set must not re-default it.
-(let* ((result (list 'applied))
-       (restored-count 0)
-       (control (generate-new-buffer " *fake-control-2*")))
-  (unwind-protect
-      (cl-letf (((symbol-function 'set-window-configuration)
-                 (lambda (&rest _) (setq restored-count (1+ restored-count)))))
-        (with-current-buffer control
-          (setq-local ediff-quit-hook
-                      (list (lambda ()
-                              (unless (car result) (setcar result 'rejected))
-                              (ignore-errors (set-window-configuration nil))))))
-        (with-current-buffer control (run-hooks 'ediff-quit-hook))
-        (check "accept-preserved-through-restore" (car result) 'applied)
-        (check "restore-called-once-per-quit" restored-count 1))
-    (when (buffer-live-p control) (kill-buffer control))))
+(describe "the quit hook re-entered after a decision"
+  (let* ((result (list 'applied))
+         (restored-count 0)
+         (control (generate-new-buffer " *fake-control-2*")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'set-window-configuration)
+                   (lambda (&rest _) (setq restored-count (1+ restored-count)))))
+          (with-current-buffer control
+            (setq-local ediff-quit-hook
+                        (list (lambda ()
+                                (unless (car result) (setcar result 'rejected))
+                                (ignore-errors (set-window-configuration nil))))))
+          (with-current-buffer control (run-hooks 'ediff-quit-hook))
+          (it "does not re-default an accept back to rejected"
+            (check (car result) 'applied))
+          (it "restores the layout exactly once per quit"
+            (check restored-count 1)))
+      (when (buffer-live-p control) (kill-buffer control)))))
 
 ;;;; Async apply-diff (deferred resolution)
 ;;
@@ -165,130 +187,146 @@ and `control' is the fake control buffer."
   (let ((f (make-temp-file "mcp-async-" nil ".txt" "old\n")))
     f))
 
-;; Returns immediately (nil) rather than blocking until a decision, and does
-;; not invoke the callback before the human resolves.
-(let ((file (mcp--async-fixture)))
-  (unwind-protect
-      (mcp--with-async-review ((calls nil))
-        (let ((ret (mcp-emacs-apply-diff-async
-                    file "new\n" 60 (lambda (out) (push out calls)))))
-          (check "async-returns-immediately" ret nil)
-          (check "async-no-callback-before-resolve" calls nil)))
-    (delete-file file)))
+(describe "mcp-emacs-apply-diff-async"
+  ;; Returns immediately (nil) rather than blocking until a decision, and does
+  ;; not invoke the callback before the human resolves.
+  (let ((file (mcp--async-fixture)))
+    (unwind-protect
+        (mcp--with-async-review ((calls nil))
+          (let ((ret (mcp-emacs-apply-diff-async
+                      file "new\n" 60 (lambda (out) (push out calls)))))
+            (it "returns immediately instead of blocking until a decision"
+              (check ret nil))
+            (it "does not invoke the callback before the human resolves"
+              (check calls nil))))
+      (delete-file file)))
 
-;; Accept -> the callback gets "Status: applied" plus buffer A's content.
-;; The stub must expose the RESULT cell so the test can record an accept the
-;; way the real accept key binding does; otherwise only the reject branch is
-;; ever reachable and the applied path goes untested.
-(let ((file (mcp--async-fixture)))
-  (unwind-protect
-      (let* ((control (generate-new-buffer " *fake-async-control*"))
-             (captured nil)
-             (cell nil)
-             (calls nil))
-        (unwind-protect
-            (cl-letf (((symbol-function 'mcp-emacs--ediff-review)
-                       (lambda (_a _b _entry result &optional on-resolve _tab)
-                         (setq captured on-resolve
-                               cell result)
-                         control)))
-              (mcp-emacs-apply-diff-async
-               file "new\n" 60 (lambda (out) (push out calls)))
-              ;; Mirror the accept command: record the decision, and put the
-              ;; proposal into buffer A (which is what gets reported back).
-              (setcar cell 'applied)
-              (let ((buf (find-buffer-visiting file)))
-                (with-current-buffer buf (erase-buffer) (insert "new\n")))
-              (funcall captured)
-              (check "async-accept-count" (length calls) 1)
-              (check "async-accept-status"
-                     (car calls) "Status: applied\nnew\n"))
-          (when (buffer-live-p control) (kill-buffer control))))
-    (let ((buf (find-buffer-visiting file)))
-      (when buf (with-current-buffer buf (set-buffer-modified-p nil))
-            (kill-buffer buf)))
-    (delete-file file)))
+  ;; Accept -> the callback gets "Status: applied" plus buffer A's content.
+  ;; The stub must expose the RESULT cell so the test can record an accept the
+  ;; way the real accept key binding does; otherwise only the reject branch is
+  ;; ever reachable and the applied path goes untested.
+  (let ((file (mcp--async-fixture)))
+    (unwind-protect
+        (let* ((control (generate-new-buffer " *fake-async-control*"))
+               (captured nil)
+               (cell nil)
+               (calls nil))
+          (unwind-protect
+              (cl-letf (((symbol-function 'mcp-emacs--ediff-review)
+                         (lambda (_a _b _entry result &optional on-resolve _tab)
+                           (setq captured on-resolve
+                                 cell result)
+                           control)))
+                (mcp-emacs-apply-diff-async
+                 file "new\n" 60 (lambda (out) (push out calls)))
+                ;; Mirror the accept command: record the decision, and put the
+                ;; proposal into buffer A (which is what gets reported back).
+                (setcar cell 'applied)
+                (let ((buf (find-buffer-visiting file)))
+                  (with-current-buffer buf (erase-buffer) (insert "new\n")))
+                (funcall captured)
+                (it "answers exactly once when the human accepts"
+                  (check (length calls) 1))
+                (it "reports the applied status with buffer A's content"
+                  (check (car calls) "Status: applied\nnew\n")))
+            (when (buffer-live-p control) (kill-buffer control))))
+      (let ((buf (find-buffer-visiting file)))
+        (when buf (with-current-buffer buf (set-buffer-modified-p nil))
+              (kill-buffer buf)))
+      (delete-file file)))
 
-;; Resolving twice must deliver exactly one answer: the quit hook can fire
-;; again (e.g. a second `q') after the decision is already recorded.
-(let ((file (mcp--async-fixture)))
-  (unwind-protect
-      (mcp--with-async-review ((calls nil))
-        (mcp-emacs-apply-diff-async
-         file "new\n" 60 (lambda (out) (push out calls)))
-        (resolve)
-        (resolve)
-        (check "async-single-delivery" (length calls) 1))
-    (let ((buf (find-buffer-visiting file)))
-      (when buf (with-current-buffer buf (set-buffer-modified-p nil))
-            (kill-buffer buf)))
-    (delete-file file)))
-
-;; Rejection surfaces as "Status: rejected" (result cell left unset).
-(let ((file (mcp--async-fixture)))
-  (unwind-protect
-      (mcp--with-async-review ((calls nil))
-        (mcp-emacs-apply-diff-async
-         file "new\n" 60 (lambda (out) (push out calls)))
-        (resolve)
-        (check "async-reject-status" (car calls) "Status: rejected"))
-    (let ((buf (find-buffer-visiting file)))
-      (when buf (with-current-buffer buf (set-buffer-modified-p nil))
-            (kill-buffer buf)))
-    (delete-file file)))
-
-;; Timeout fires the callback with "Status: timeout" when nobody resolves.
-;; A 1-second timeout keeps the batch run short.
-(let ((file (mcp--async-fixture)))
-  (unwind-protect
-      (mcp--with-async-review ((calls nil))
-        (mcp-emacs-apply-diff-async
-         file "new\n" 1 (lambda (out) (push out calls)))
-        (check "async-timeout-not-yet" calls nil)
-        (sleep-for 2)
-        (check "async-timeout-status" (car calls) "Status: timeout")
-        (check "async-timeout-single" (length calls) 1)
-        ;; A late human resolve after a timeout must not answer twice.
-        (resolve)
-        (check "async-timeout-then-resolve-single" (length calls) 1))
-    (let ((buf (find-buffer-visiting file)))
-      (when buf (with-current-buffer buf (set-buffer-modified-p nil))
-            (kill-buffer buf)))
-    (delete-file file)))
-
-;; The timeout timer is cancelled once the review resolves, so a finished
-;; review leaves nothing pending behind it.
-(let ((file (mcp--async-fixture)))
-  (unwind-protect
-      (mcp--with-async-review ((calls nil))
-        ;; Assert on `timer-list' directly.  The single-delivery guard would
-        ;; suppress a second callback even if the timer were never cancelled,
-        ;; so counting calls cannot tell the two mechanisms apart -- only an
-        ;; uncancelled timer shows up here.
-        (let ((before (length timer-list)))
+  ;; Resolving twice must deliver exactly one answer: the quit hook can fire
+  ;; again (e.g. a second `q') after the decision is already recorded.
+  (let ((file (mcp--async-fixture)))
+    (unwind-protect
+        (mcp--with-async-review ((calls nil))
           (mcp-emacs-apply-diff-async
-           file "new\n" 30 (lambda (out) (push out calls)))
-          (check "async-timer-armed" (> (length timer-list) before) t)
+           file "new\n" 60 (lambda (out) (push out calls)))
           (resolve)
-          (check "async-resolve-before-timeout" (length calls) 1)
-          (check "async-timer-cancelled" (length timer-list) before)))
-    (let ((buf (find-buffer-visiting file)))
-      (when buf (with-current-buffer buf (set-buffer-modified-p nil))
-            (kill-buffer buf)))
-    (delete-file file)))
+          (resolve)
+          (it "delivers one answer even when the review resolves twice"
+            (check (length calls) 1)))
+      (let ((buf (find-buffer-visiting file)))
+        (when buf (with-current-buffer buf (set-buffer-modified-p nil))
+              (kill-buffer buf)))
+      (delete-file file)))
+
+  ;; Rejection surfaces as "Status: rejected" (result cell left unset).
+  (let ((file (mcp--async-fixture)))
+    (unwind-protect
+        (mcp--with-async-review ((calls nil))
+          (mcp-emacs-apply-diff-async
+           file "new\n" 60 (lambda (out) (push out calls)))
+          (resolve)
+          (it "reports a rejected status when the result cell is left unset"
+            (check (car calls) "Status: rejected")))
+      (let ((buf (find-buffer-visiting file)))
+        (when buf (with-current-buffer buf (set-buffer-modified-p nil))
+              (kill-buffer buf)))
+      (delete-file file)))
+
+  ;; Timeout fires the callback with "Status: timeout" when nobody resolves.
+  ;; A 1-second timeout keeps the batch run short.
+  (let ((file (mcp--async-fixture)))
+    (unwind-protect
+        (mcp--with-async-review ((calls nil))
+          (mcp-emacs-apply-diff-async
+           file "new\n" 1 (lambda (out) (push out calls)))
+          (it "has not answered yet while the timeout is still pending"
+            (check calls nil))
+          (sleep-for 2)
+          (it "reports a timeout status when nobody resolves"
+            (check (car calls) "Status: timeout"))
+          (it "answers exactly once on timeout"
+            (check (length calls) 1))
+          ;; A late human resolve after a timeout must not answer twice.
+          (resolve)
+          (it "ignores a late human resolve after a timeout"
+            (check (length calls) 1)))
+      (let ((buf (find-buffer-visiting file)))
+        (when buf (with-current-buffer buf (set-buffer-modified-p nil))
+              (kill-buffer buf)))
+      (delete-file file)))
+
+  ;; The timeout timer is cancelled once the review resolves, so a finished
+  ;; review leaves nothing pending behind it.
+  (let ((file (mcp--async-fixture)))
+    (unwind-protect
+        (mcp--with-async-review ((calls nil))
+          ;; Assert on `timer-list' directly.  The single-delivery guard would
+          ;; suppress a second callback even if the timer were never cancelled,
+          ;; so counting calls cannot tell the two mechanisms apart -- only an
+          ;; uncancelled timer shows up here.
+          (let ((before (length timer-list)))
+            (mcp-emacs-apply-diff-async
+             file "new\n" 30 (lambda (out) (push out calls)))
+            (it "arms a timeout timer"
+              (check (> (length timer-list) before) t))
+            (resolve)
+            (it "answers once when the human resolves before the timeout"
+              (check (length calls) 1))
+            (it "cancels the timeout timer once the review resolves"
+              (check (length timer-list) before))))
+      (let ((buf (find-buffer-visiting file)))
+        (when buf (with-current-buffer buf (set-buffer-modified-p nil))
+              (kill-buffer buf)))
+      (delete-file file))))
 
 ;; A path that does not exist is NOT an error: `find-file-noselect' happily
 ;; makes a buffer for a new file, so the review opens as usual.  What matters
 ;; for the deferred HTTP reply is that the callback still fires on its own —
 ;; the request must never hang waiting for a session nobody will answer.
 ;; (Uses a real ediff rather than the stub, hence the 1-second timeout.)
-(let ((calls nil))
-  (mcp-emacs-apply-diff-async
-   "/nonexistent-dir-mcp-test/nope.txt" "new\n" 1
-   (lambda (out) (push out calls)))
-  (check "async-missing-path-defers" calls nil)
-  (sleep-for 2)
-  (check "async-missing-path-answers" (length calls) 1))
+(describe "mcp-emacs-apply-diff-async on a nonexistent path"
+  (let ((calls nil))
+    (mcp-emacs-apply-diff-async
+     "/nonexistent-dir-mcp-test/nope.txt" "new\n" 1
+     (lambda (out) (push out calls)))
+    (it "opens the review and defers rather than erroring"
+      (check calls nil))
+    (sleep-for 2)
+    (it "still answers on its own so the request cannot hang"
+      (check (length calls) 1))))
 
 ;;;; Org-task domain events (issue #39)
 ;;
@@ -311,79 +349,98 @@ and `control' is the fake control buffer."
            (list (lambda (e) (setq ,var (append ,var (list e)))))))
      ,@body))
 
-;; A successful status change emits one observation carrying the new state.
-(let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
-  (unwind-protect
-      (mcp--with-org-events evs
-        (mcp-emacs-org-task-set-session-status f "DONE")
-        (check "emit-session-status-count" (length evs) 1)
-        (check "emit-session-status-kind" (plist-get (car evs) :kind) 'session-status)
-        (check "emit-session-status-value" (plist-get (car evs) :status) "DONE")
-        (check "emit-session-status-path" (plist-get (car evs) :path) f))
-    (let ((b (find-buffer-visiting f)))
-      (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
-    (delete-file f)))
+(describe "mcp-emacs-org-task-set-session-status events"
+  ;; A successful status change emits one observation carrying the new state.
+  (let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
+    (unwind-protect
+        (mcp--with-org-events evs
+          (mcp-emacs-org-task-set-session-status f "DONE")
+          (it "emits exactly one observation for a successful status change"
+            (check (length evs) 1))
+          (it "labels the observation as a session-status event"
+            (check (plist-get (car evs) :kind) 'session-status))
+          (it "carries the new status"
+            (check (plist-get (car evs) :status) "DONE"))
+          (it "carries the path of the Org file that changed"
+            (check (plist-get (car evs) :path) f)))
+      (let ((b (find-buffer-visiting f)))
+        (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
+      (delete-file f)))
 
-;; A rejected keyword changes nothing, so it must emit nothing.
-(let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
-  (unwind-protect
-      (mcp--with-org-events evs
-        (mcp-emacs-org-task-set-session-status f "NOT-A-KEYWORD")
-        (check "no-emit-on-rejected-keyword" evs nil))
-    (let ((b (find-buffer-visiting f)))
-      (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
-    (delete-file f)))
+  ;; A rejected keyword changes nothing, so it must emit nothing.
+  (let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
+    (unwind-protect
+        (mcp--with-org-events evs
+          (mcp-emacs-org-task-set-session-status f "NOT-A-KEYWORD")
+          (it "emits nothing when the keyword is rejected and nothing changed"
+            (check evs nil)))
+      (let ((b (find-buffer-visiting f)))
+        (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
+      (delete-file f))))
 
-;; An item that cannot be identified changes nothing either.
-(let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n** TODO one\n")))
-  (unwind-protect
-      (mcp--with-org-events evs
-        (mcp-emacs-org-task-set-item-status f "no such item" "DONE")
-        (check "no-emit-on-unknown-item" evs nil))
-    (let ((b (find-buffer-visiting f)))
-      (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
-    (delete-file f)))
+(describe "mcp-emacs-org-task-set-item-status events"
+  ;; An item that cannot be identified changes nothing either.
+  (let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n** TODO one\n")))
+    (unwind-protect
+        (mcp--with-org-events evs
+          (mcp-emacs-org-task-set-item-status f "no such item" "DONE")
+          (it "emits nothing when the item cannot be identified"
+            (check evs nil)))
+      (let ((b (find-buffer-visiting f)))
+        (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
+      (delete-file f))))
 
-;; Appending an item observes the text and the keyword it was given.
-(let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
-  (unwind-protect
-      (mcp--with-org-events evs
-        (mcp-emacs-org-task-append-item f "a new item" "TODO")
-        (check "emit-item-added-kind" (plist-get (car evs) :kind) 'item-added)
-        (check "emit-item-added-text" (plist-get (car evs) :text) "a new item"))
-    (let ((b (find-buffer-visiting f)))
-      (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
-    (delete-file f)))
+(describe "mcp-emacs-org-task-append-item events"
+  ;; Appending an item observes the text and the keyword it was given.
+  (let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
+    (unwind-protect
+        (mcp--with-org-events evs
+          (mcp-emacs-org-task-append-item f "a new item" "TODO")
+          (it "labels the observation as an item-added event"
+            (check (plist-get (car evs) :kind) 'item-added))
+          (it "carries the text of the appended item"
+            (check (plist-get (car evs) :text) "a new item")))
+      (let ((b (find-buffer-visiting f)))
+        (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
+      (delete-file f))))
 
-;; A note observes its text.
-(let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
-  (unwind-protect
-      (mcp--with-org-events evs
-        (mcp-emacs-org-task-append-note f "progress note")
-        (check "emit-note-kind" (plist-get (car evs) :kind) 'note)
-        (check "emit-note-text" (plist-get (car evs) :text) "progress note"))
-    (let ((b (find-buffer-visiting f)))
-      (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
-    (delete-file f)))
+(describe "mcp-emacs-org-task-append-note events"
+  ;; A note observes its text.
+  (let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
+    (unwind-protect
+        (mcp--with-org-events evs
+          (mcp-emacs-org-task-append-note f "progress note")
+          (it "labels the observation as a note event"
+            (check (plist-get (car evs) :kind) 'note))
+          (it "carries the text of the note"
+            (check (plist-get (car evs) :text) "progress note")))
+      (let ((b (find-buffer-visiting f)))
+        (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
+      (delete-file f))))
 
 ;; A failing subscriber must not break the Org write it observes -- the
 ;; aggregate comes first, the record second.
-(let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
-  (unwind-protect
-      (let ((mcp-emacs-org-task-event-functions
-             (list (lambda (_e) (error "subscriber blew up")))))
-        ;; The write must return normally, not signal: the outer handler only
-        ;; catches `user-error', so an unguarded subscriber error escapes as a
-        ;; plain `error' and takes the tool call down with it.
-        (check "write-survives-bad-subscriber"
-               (condition-case _
-                   (progn (mcp-emacs-org-task-set-session-status f "DONE") t)
-                 (error nil))
-               t)
-        ;; And the Org file really did change.
-        (with-current-buffer (find-file-noselect f)
-          (check "write-applied-despite-subscriber"
-                 (and (string-match-p "DONE" (buffer-string)) t) t)))
-    (let ((b (find-buffer-visiting f)))
-      (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
-    (delete-file f)))
+(describe "an Org write whose event subscriber signals"
+  (let ((f (mcp--org-fixture "* TODO Task\n:PROPERTIES:\n:SESSION: s1\n:END:\n")))
+    (unwind-protect
+        (let ((mcp-emacs-org-task-event-functions
+               (list (lambda (_e) (error "subscriber blew up")))))
+          ;; The write must return normally, not signal: the outer handler only
+          ;; catches `user-error', so an unguarded subscriber error escapes as a
+          ;; plain `error' and takes the tool call down with it.
+          (it "returns normally instead of taking the tool call down"
+            (check (condition-case _
+                       (progn (mcp-emacs-org-task-set-session-status f "DONE") t)
+                     (error nil))
+                   t))
+          ;; And the Org file really did change.
+          (with-current-buffer (find-file-noselect f)
+            (it "still applies the change to the Org file"
+              (check-that (string-match-p "DONE" (buffer-string))))))
+      (let ((b (find-buffer-visiting f)))
+        (when b (with-current-buffer b (set-buffer-modified-p nil)) (kill-buffer b)))
+      (delete-file f))))
+
+(test-helper-summary)
+
+;;; mcp-emacs-apply-diff-test.el ends here

--- a/test/mcp-emacs-ide-test.el
+++ b/test/mcp-emacs-ide-test.el
@@ -5,6 +5,8 @@
 ;; directly and the client socket is stubbed so sent JSON is captured.
 
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'json)
 (require 'cl-lib)
 (require 'mcp-emacs)
@@ -19,9 +21,6 @@
 
 (defvar mcp-ide-test--sent nil
   "List of JSON strings the stubbed client \"sent\", newest last.")
-
-(defun mcp-ide-test--check (label got want)
-  (princ (format "%s %s\n" (if (equal got want) "PASS" "FAIL") label)))
 
 ;; Capture everything the module sends by stubbing the send helper.
 (defun mcp-ide-test--capture (_client obj)
@@ -42,120 +41,122 @@
 (defun mcp-ide-test--dispatch (session text)
   (mcp-emacs-ide--handle-message session 'stub-client text))
 
-;;;; initialize echoes the verified protocol version
+(describe "initialize"
+  (let ((s (mcp-ide-test--session)))
+    (mcp-ide-test--dispatch
+     s "{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"initialize\",\"params\":{}}")
+    (let* ((msg (mcp-ide-test--last))
+           (result (alist-get 'result msg)))
+      (it "answers under the request id"
+        (check (alist-get 'id msg) 0))
+      (it "echoes the verified protocol version"
+        (check (alist-get 'protocolVersion result)
+               mcp-emacs-ide-protocol-version)))))
 
-(let ((s (mcp-ide-test--session)))
-  (mcp-ide-test--dispatch
-   s "{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"initialize\",\"params\":{}}")
-  (let* ((msg (mcp-ide-test--last))
-         (result (alist-get 'result msg)))
-    (mcp-ide-test--check "initialize-id" (alist-get 'id msg) 0)
-    (mcp-ide-test--check "initialize-protocol-version"
-                         (alist-get 'protocolVersion result)
-                         mcp-emacs-ide-protocol-version)))
+(describe "tools/list"
+  (let ((s (mcp-ide-test--session)))
+    (mcp-ide-test--dispatch
+     s "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}")
+    (let* ((result (alist-get 'result (mcp-ide-test--last)))
+           (tools (alist-get 'tools result))
+           (names (sort (mapcar (lambda (t) (alist-get 'name t))
+                                (append tools nil))
+                        #'string<)))
+      (it "advertises all four tools"
+        (check names '("closeAllDiffTabs" "close_tab"
+                       "getDiagnostics" "openDiff"))))))
 
-;;;; tools/list advertises all four tools
+(describe "getDiagnostics"
+  (let ((s (mcp-ide-test--session)))
+    (mcp-ide-test--dispatch
+     s (concat "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\","
+               "\"params\":{\"name\":\"getDiagnostics\",\"arguments\":{}}}"))
+    (it "is answered, since Claude blocks otherwise"
+      (check (alist-get 'id (mcp-ide-test--last)) 3))))
 
-(let ((s (mcp-ide-test--session)))
-  (mcp-ide-test--dispatch
-   s "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}")
-  (let* ((result (alist-get 'result (mcp-ide-test--last)))
-         (tools (alist-get 'tools result))
-         (names (sort (mapcar (lambda (t) (alist-get 'name t))
-                              (append tools nil))
-                      #'string<)))
-    (mcp-ide-test--check "tools-list-names" names
-                         '("closeAllDiffTabs" "close_tab"
-                           "getDiagnostics" "openDiff"))))
+(describe "closeAllDiffTabs"
+  (let ((s (mcp-ide-test--session)))
+    (mcp-ide-test--dispatch
+     s (concat "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\","
+               "\"params\":{\"name\":\"closeAllDiffTabs\",\"arguments\":{}}}"))
+    (let* ((result (alist-get 'result (mcp-ide-test--last)))
+           (content (alist-get 'content result))
+           (text (alist-get 'text (aref content 0))))
+      (it "reports zero closed tabs when none are open"
+        (check text "CLOSED_0_DIFF_TABS")))))
 
-;;;; getDiagnostics is answered (Claude blocks otherwise)
+(describe "mcp-emacs-ide--complete-open-diff on accept"
+  (let ((s (mcp-ide-test--session)))
+    ;; Simulate an in-flight openDiff by registering a deferred id.
+    (puthash "tab-A" 4 (mcp-emacs-ide-session-deferred s))
+    (setq mcp-ide-test--sent nil)
+    (mcp-emacs-ide--complete-open-diff s "tab-A" "FILE_SAVED" "new content\n")
+    (let* ((result (alist-get 'result (mcp-ide-test--last)))
+           (content (alist-get 'content result)))
+      (it "answers the deferred openDiff request id"
+        (check (alist-get 'id (mcp-ide-test--last)) 4))
+      (it "reports FILE_SAVED as the status"
+        (check (alist-get 'text (aref content 0)) "FILE_SAVED"))
+      (it "returns the saved content alongside the status"
+        (check (alist-get 'text (aref content 1)) "new content\n"))
+      (it "consumes the deferred entry"
+        (check (gethash "tab-A" (mcp-emacs-ide-session-deferred s)) nil)))))
 
-(let ((s (mcp-ide-test--session)))
-  (mcp-ide-test--dispatch
-   s (concat "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\","
-             "\"params\":{\"name\":\"getDiagnostics\",\"arguments\":{}}}"))
-  (mcp-ide-test--check "getDiagnostics-answered"
-                       (alist-get 'id (mcp-ide-test--last)) 3))
+(describe "mcp-emacs-ide--complete-open-diff on reject"
+  (let ((s (mcp-ide-test--session)))
+    (puthash "tab-B" 5 (mcp-emacs-ide-session-deferred s))
+    (setq mcp-ide-test--sent nil)
+    (mcp-emacs-ide--complete-open-diff s "tab-B" "DIFF_REJECTED" "tab-B")
+    (let* ((result (alist-get 'result (mcp-ide-test--last)))
+           (content (alist-get 'content result)))
+      (it "reports DIFF_REJECTED as the status"
+        (check (alist-get 'text (aref content 0)) "DIFF_REJECTED"))
+      (it "returns the rejected tab name alongside the status"
+        (check (alist-get 'text (aref content 1)) "tab-B")))))
 
-;;;; closeAllDiffTabs is answered and reports zero when none open
+(describe "mcp-emacs-ide--complete-open-diff with nothing pending"
+  (let ((s (mcp-ide-test--session)))
+    (setq mcp-ide-test--sent nil)
+    (mcp-emacs-ide--complete-open-diff s "missing" "FILE_SAVED" "x")
+    (it "sends nothing rather than answering an unknown request"
+      (check mcp-ide-test--sent nil))))
 
-(let ((s (mcp-ide-test--session)))
-  (mcp-ide-test--dispatch
-   s (concat "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\","
-             "\"params\":{\"name\":\"closeAllDiffTabs\",\"arguments\":{}}}"))
-  (let* ((result (alist-get 'result (mcp-ide-test--last)))
-         (content (alist-get 'content result))
-         (text (alist-get 'text (aref content 0))))
-    (mcp-ide-test--check "closeAllDiffTabs-empty" text "CLOSED_0_DIFF_TABS")))
+(describe "mcp-emacs-ide--write-lockfile"
+  (let* ((mcp-emacs-ide-lockfile-directory
+          (expand-file-name "mcp-ide-test-lock/" temporary-file-directory))
+         (path (mcp-emacs-ide--write-lockfile 45678 "/tmp/proj/")))
+    (it "creates the lockfile"
+      (check (file-exists-p path) t))
+    (let ((data (json-parse-string
+                 (with-temp-buffer (insert-file-contents path) (buffer-string))
+                 :object-type 'alist)))
+      (it "identifies the IDE as Emacs"
+        (check (alist-get 'ideName data) "Emacs"))
+      (it "announces the ws transport"
+        (check (alist-get 'transport data) "ws"))
+      (it "records this Emacs process id"
+        (check (alist-get 'pid data) (emacs-pid))))
+    (mcp-emacs-ide--remove-lockfile path)
+    (it "is removed again by `mcp-emacs-ide--remove-lockfile'"
+      (check (file-exists-p path) nil))))
 
-;;;; openDiff completion: accept -> FILE_SAVED + content
-
-(let ((s (mcp-ide-test--session)))
-  ;; Simulate an in-flight openDiff by registering a deferred id.
-  (puthash "tab-A" 4 (mcp-emacs-ide-session-deferred s))
-  (setq mcp-ide-test--sent nil)
-  (mcp-emacs-ide--complete-open-diff s "tab-A" "FILE_SAVED" "new content\n")
-  (let* ((result (alist-get 'result (mcp-ide-test--last)))
-         (content (alist-get 'content result)))
-    (mcp-ide-test--check "openDiff-accept-id" (alist-get 'id (mcp-ide-test--last)) 4)
-    (mcp-ide-test--check "openDiff-accept-status"
-                         (alist-get 'text (aref content 0)) "FILE_SAVED")
-    (mcp-ide-test--check "openDiff-accept-content"
-                         (alist-get 'text (aref content 1)) "new content\n")
-    ;; Deferred entry consumed.
-    (mcp-ide-test--check "openDiff-accept-deferred-cleared"
-                         (gethash "tab-A" (mcp-emacs-ide-session-deferred s)) nil)))
-
-;;;; openDiff completion: reject -> DIFF_REJECTED + tab name
-
-(let ((s (mcp-ide-test--session)))
-  (puthash "tab-B" 5 (mcp-emacs-ide-session-deferred s))
-  (setq mcp-ide-test--sent nil)
-  (mcp-emacs-ide--complete-open-diff s "tab-B" "DIFF_REJECTED" "tab-B")
-  (let* ((result (alist-get 'result (mcp-ide-test--last)))
-         (content (alist-get 'content result)))
-    (mcp-ide-test--check "openDiff-reject-status"
-                         (alist-get 'text (aref content 0)) "DIFF_REJECTED")
-    (mcp-ide-test--check "openDiff-reject-tab"
-                         (alist-get 'text (aref content 1)) "tab-B")))
-
-;;;; complete-open-diff is a no-op when nothing is pending
-
-(let ((s (mcp-ide-test--session)))
-  (setq mcp-ide-test--sent nil)
-  (mcp-emacs-ide--complete-open-diff s "missing" "FILE_SAVED" "x")
-  (mcp-ide-test--check "complete-no-pending-noop" mcp-ide-test--sent nil))
-
-;;;; lockfile write + remove round-trip
-
-(let* ((mcp-emacs-ide-lockfile-directory
-        (expand-file-name "mcp-ide-test-lock/" temporary-file-directory))
-       (path (mcp-emacs-ide--write-lockfile 45678 "/tmp/proj/")))
-  (mcp-ide-test--check "lockfile-exists" (file-exists-p path) t)
-  (let ((data (json-parse-string
-               (with-temp-buffer (insert-file-contents path) (buffer-string))
-               :object-type 'alist)))
-    (mcp-ide-test--check "lockfile-idename" (alist-get 'ideName data) "Emacs")
-    (mcp-ide-test--check "lockfile-transport" (alist-get 'transport data) "ws")
-    (mcp-ide-test--check "lockfile-pid" (alist-get 'pid data) (emacs-pid)))
-  (mcp-emacs-ide--remove-lockfile path)
-  (mcp-ide-test--check "lockfile-removed" (file-exists-p path) nil))
-
-;;;; close_tab cleans up a tracked diff and its buffer
-
-(let ((s (mcp-ide-test--session))
-      (buffer-b (generate-new-buffer " *ide-test-b*")))
-  (puthash "tab-C"
-           (list :buffer-a nil :buffer-b buffer-b :control nil :result (list nil))
-           (mcp-emacs-ide-session-diffs s))
-  (puthash "tab-C" 9 (mcp-emacs-ide-session-deferred s))
-  (mcp-emacs-ide--cleanup-diff s "tab-C")
-  (mcp-ide-test--check "close_tab-diff-gone"
-                       (gethash "tab-C" (mcp-emacs-ide-session-diffs s)) nil)
-  (mcp-ide-test--check "close_tab-deferred-gone"
-                       (gethash "tab-C" (mcp-emacs-ide-session-deferred s)) nil)
-  (mcp-ide-test--check "close_tab-buffer-killed" (buffer-live-p buffer-b) nil))
+(describe "mcp-emacs-ide--cleanup-diff"
+  (let ((s (mcp-ide-test--session))
+        (buffer-b (generate-new-buffer " *ide-test-b*")))
+    (puthash "tab-C"
+             (list :buffer-a nil :buffer-b buffer-b :control nil :result (list nil))
+             (mcp-emacs-ide-session-diffs s))
+    (puthash "tab-C" 9 (mcp-emacs-ide-session-deferred s))
+    (mcp-emacs-ide--cleanup-diff s "tab-C")
+    (it "forgets the tracked diff"
+      (check (gethash "tab-C" (mcp-emacs-ide-session-diffs s)) nil))
+    (it "forgets the diff's deferred request"
+      (check (gethash "tab-C" (mcp-emacs-ide-session-deferred s)) nil))
+    (it "kills the diff's buffer"
+      (check (buffer-live-p buffer-b) nil))))
 
 (advice-remove 'mcp-emacs-ide--send #'mcp-ide-test--capture)
+
+(test-helper-summary)
 
 ;;; mcp-emacs-ide-test.el ends here

--- a/test/mcp-emacs-remote-test.el
+++ b/test/mcp-emacs-remote-test.el
@@ -1,4 +1,8 @@
+;;; mcp-emacs-remote-test.el --- Tests for the remote transcript tap -*- lexical-binding: t; -*-
+
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'cl-lib)
 
 ;; Stub the two upstream modules the remote module requires, so the tests
@@ -20,7 +24,15 @@
 
 (require 'mcp-emacs-remote)
 
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+;; The hook variables the taps subscribe to are owned by `agent-backend' and
+;; `mcp-emacs'; the remote module only forward-declares them, and a valueless
+;; `defvar' marks a symbol special just inside its own file.  Requiring the
+;; owners gets the real defvars, so a `let' below rebinds the same variable
+;; `add-hook' writes -- without them the test binds a lexical local and reads
+;; nil back.  Neither owner pulls in websocket.el or web-server, which is why
+;; these can be required where the two modules above are stubbed.
+(require 'agent-backend)
+(require 'mcp-emacs)
 
 (defun remote--kill-transcripts ()
   (dolist (b (buffer-list))
@@ -29,112 +41,117 @@
 
 ;; --- 5.1 Prompt input --------------------------------------------------------
 
-;; Empty / whitespace prompt -> user-error, nothing sent.
-(let ((sent nil))
-  (cl-letf (((symbol-function 'mcp-emacs-run-send-prompt) (lambda (tx) (setq sent tx))))
-    (check "empty-prompt-errors"
-           (condition-case _ (progn (mcp-emacs-remote--send "") nil) (user-error t)) t)
-    (check "whitespace-prompt-errors"
-           (condition-case _ (progn (mcp-emacs-remote--send "  \n ") nil) (user-error t)) t)
-    (check "empty-prompt-sends-nothing" sent nil)))
+(describe "mcp-emacs-remote--send"
+  (let ((sent nil))
+    (cl-letf (((symbol-function 'mcp-emacs-run-send-prompt) (lambda (tx) (setq sent tx))))
+      (it "rejects an empty prompt"
+        (check (condition-case _ (progn (mcp-emacs-remote--send "") nil) (user-error t)) t))
+      (it "rejects a whitespace-only prompt"
+        (check (condition-case _ (progn (mcp-emacs-remote--send "  \n ") nil) (user-error t)) t))
+      (it "sends nothing when the prompt is rejected"
+        (check sent nil))))
 
-;; Non-empty prompt -> delivered via send-prompt.
-(let ((sent nil))
-  (cl-letf (((symbol-function 'mcp-emacs-run-send-prompt) (lambda (tx) (setq sent tx))))
-    (mcp-emacs-remote--send "hello claude")
-    (check "prompt-delivered" sent "hello claude")))
+  (let ((sent nil))
+    (cl-letf (((symbol-function 'mcp-emacs-run-send-prompt) (lambda (tx) (setq sent tx))))
+      (mcp-emacs-remote--send "hello claude")
+      (it "delivers a non-empty prompt via send-prompt"
+        (check sent "hello claude")))))
 
-;; Whole-buffer send: empty buffer errors; non-empty delivers buffer text.
-(let ((sent nil))
-  (cl-letf (((symbol-function 'mcp-emacs-run-send-prompt) (lambda (tx) (setq sent tx))))
-    (with-temp-buffer
-      (check "buffer-empty-errors"
-             (condition-case _ (progn (mcp-emacs-remote-prompt-buffer) nil) (user-error t)) t))
-    (check "buffer-empty-sends-nothing" sent nil)
-    (with-temp-buffer
-      (insert "line one\nline two\n")
-      (mcp-emacs-remote-prompt-buffer))
-    (check "buffer-delivered" sent "line one\nline two\n")))
+(describe "mcp-emacs-remote-prompt-buffer"
+  (let ((sent nil))
+    (cl-letf (((symbol-function 'mcp-emacs-run-send-prompt) (lambda (tx) (setq sent tx))))
+      (with-temp-buffer
+        (it "rejects an empty buffer"
+          (check (condition-case _ (progn (mcp-emacs-remote-prompt-buffer) nil) (user-error t)) t)))
+      (it "sends nothing when the buffer is empty"
+        (check sent nil))
+      (with-temp-buffer
+        (insert "line one\nline two\n")
+        (mcp-emacs-remote-prompt-buffer))
+      (it "delivers the whole buffer text"
+        (check sent "line one\nline two\n")))))
 
 ;; --- 5.2 Transcript: one buffer per project, tool call recorded --------------
 
 (remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-alpha")))
-    (mcp-emacs-remote-record-tool-call "openDiff" '((tab_name . "t1")))
-    (mcp-emacs-remote-record-tool-call "openDiff" '((tab_name . "t2"))))
-  (let ((buf (get-buffer "*claude: proj-alpha*")))
-    (check "transcript-buffer-created" (and buf t) t)
-    (check "transcript-reused-single-buffer"
-           (length (seq-filter (lambda (b) (string-prefix-p "*claude: " (buffer-name b)))
-                               (buffer-list)))
-           1)
-    (with-current-buffer buf
-      (check "tool-heading-recorded"
-             (and (string-match-p "🔧 openDiff" (buffer-string)) t) t)
-      (check "tool-args-recorded"
-             (and (string-match-p "begin_src json" (buffer-string)) t) t))))
+(describe "mcp-emacs-remote-record-tool-call"
+  (let ((mcp-emacs-remote-enabled t))
+    (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-alpha")))
+      (mcp-emacs-remote-record-tool-call "openDiff" '((tab_name . "t1")))
+      (mcp-emacs-remote-record-tool-call "openDiff" '((tab_name . "t2"))))
+    (let ((buf (get-buffer "*claude: proj-alpha*")))
+      (it "creates a transcript buffer named after the project"
+        (check-that buf))
+      (it "reuses one buffer per project across calls"
+        (check (length (seq-filter (lambda (b) (string-prefix-p "*claude: " (buffer-name b)))
+                                   (buffer-list)))
+               1))
+      (with-current-buffer buf
+        (it "records the tool name as a heading"
+          (check-that (string-match-p "🔧 openDiff" (buffer-string))))
+        (it "records the tool arguments as a json block"
+          (check-that (string-match-p "begin_src json" (buffer-string)))))))
 
-;; Distinct projects -> distinct buffers.
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-beta")))
-    (mcp-emacs-remote-record-tool-call "openDiff" '((tab_name . "x"))))
-  (check "distinct-projects-distinct-buffers"
-         (and (get-buffer "*claude: proj-alpha*") (get-buffer "*claude: proj-beta*") t) t))
+  (let ((mcp-emacs-remote-enabled t))
+    (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-beta")))
+      (mcp-emacs-remote-record-tool-call "openDiff" '((tab_name . "x"))))
+    (it "gives distinct projects distinct transcript buffers"
+      (check-that (and (get-buffer "*claude: proj-alpha*")
+                       (get-buffer "*claude: proj-beta*")))))
 
-;; Quiet tools get a compact note, not a heading.
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-q")))
-    (mcp-emacs-remote-record-tool-call "getDiagnostics" '()))
-  (with-current-buffer (get-buffer "*claude: proj-q*")
-    (check "quiet-tool-no-heading"
-           (and (not (string-match-p "🔧 getDiagnostics" (buffer-string)))
-                (string-match-p "getDiagnostics" (buffer-string)) t) t)))
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-q")))
+        (mcp-emacs-remote-record-tool-call "getDiagnostics" '()))
+      (with-current-buffer (get-buffer "*claude: proj-q*")
+        (it "notes a quiet tool compactly instead of as a heading"
+          (check-that (and (not (string-match-p "🔧 getDiagnostics" (buffer-string)))
+                           (string-match-p "getDiagnostics" (buffer-string)))))))))
 
 ;; --- 5.3 Diff outcome --------------------------------------------------------
 
 (remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-d")))
-    (mcp-emacs-remote-record-diff-outcome "tab-A" "FILE_SAVED" "new content")
-    (mcp-emacs-remote-record-diff-outcome "tab-B" "DIFF_REJECTED" "tab-B"))
-  (with-current-buffer (get-buffer "*claude: proj-d*")
-    (let ((s (buffer-string)))
-      (check "accept-recorded"
-             (and (string-match-p "openDiff accepted :: tab-A" s) t) t)
-      (check "reject-recorded"
-             (and (string-match-p "openDiff rejected :: tab-B" s) t) t))))
+(describe "mcp-emacs-remote-record-diff-outcome"
+  (let ((mcp-emacs-remote-enabled t))
+    (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-d")))
+      (mcp-emacs-remote-record-diff-outcome "tab-A" "FILE_SAVED" "new content")
+      (mcp-emacs-remote-record-diff-outcome "tab-B" "DIFF_REJECTED" "tab-B"))
+    (with-current-buffer (get-buffer "*claude: proj-d*")
+      (let ((s (buffer-string)))
+        (it "records a saved diff as accepted, naming the tab"
+          (check-that (string-match-p "openDiff accepted :: tab-A" s)))
+        (it "records a rejected diff as rejected, naming the tab"
+          (check-that (string-match-p "openDiff rejected :: tab-B" s)))))))
 
 ;; --- 5.4 Passive safety ------------------------------------------------------
 
-;; Disabled -> the tap records nothing.
 (remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled nil))
-  (mcp-emacs-remote--tap-call-tool nil "openDiff" '((tab_name . "z")) 1)
-  (check "disabled-records-nothing"
-         (seq-find (lambda (b) (string-prefix-p "*claude: " (buffer-name b))) (buffer-list))
-         nil))
+(describe "mcp-emacs-remote--tap-call-tool"
+  (let ((mcp-emacs-remote-enabled nil))
+    (mcp-emacs-remote--tap-call-tool nil "openDiff" '((tab_name . "z")) 1)
+    (it "records nothing while recording is disabled"
+      (check (seq-find (lambda (b) (string-prefix-p "*claude: " (buffer-name b))) (buffer-list))
+             nil)))
 
-;; A rendering failure never propagates out of the recorder.
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-remote--append)
-             (lambda (&rest _) (error "boom"))))
-    (check "render-error-swallowed-tool"
-           (condition-case _ (progn (mcp-emacs-remote-record-tool-call "openDiff" '()) t)
-             (error nil))
-           t)
-    (check "render-error-swallowed-diff"
-           (condition-case _ (progn (mcp-emacs-remote-record-diff-outcome "t" "FILE_SAVED") t)
-             (error nil))
-           t)))
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-remote--append)
+                 (lambda (&rest _) (error "boom"))))
+        (it "swallows a rendering failure while recording a tool call"
+          (check (condition-case _ (progn (mcp-emacs-remote-record-tool-call "openDiff" '()) t)
+                   (error nil))
+                 t))
+        (it "swallows a rendering failure while recording a diff outcome"
+          (check (condition-case _ (progn (mcp-emacs-remote-record-diff-outcome "t" "FILE_SAVED") t)
+                   (error nil))
+                 t)))))
 
-;; The :before tap returns nil (does not alter the wrapped call's return).
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-r")))
-    (check "tap-returns-nil"
-           (mcp-emacs-remote--tap-call-tool nil "getDiagnostics" '() 1) nil)))
+  (let ((mcp-emacs-remote-enabled t))
+    (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-r")))
+      (it "returns nil so it cannot alter the wrapped call's return value"
+        (check (mcp-emacs-remote--tap-call-tool nil "getDiagnostics" '() 1) nil)))))
 
 (remote--kill-transcripts)
 
@@ -152,124 +169,131 @@
       (with-current-buffer buf
         (buffer-substring-no-properties (point-min) (point-max))))))
 
-;; Each event kind lands in the transcript.
 (remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
-    (mcp-emacs-remote--tap-runner-event
-     nil (list :kind 'started :session "abc-123" :model "claude-opus-5"))
-    (let ((text (remote--transcript-text)))
-      (check "runner-started-heading"
-             (and (string-match-p "^\\* Runner" text) t) t)
-      (check "runner-started-session"
-             (and (string-match-p ":SESSION: abc-123" text) t) t)
-      (check "runner-started-model"
-             (and (string-match-p ":MODEL: claude-opus-5" text) t) t))))
+(describe "mcp-emacs-remote--tap-runner-event"
+  (let ((mcp-emacs-remote-enabled t))
+    (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
+      (mcp-emacs-remote--tap-runner-event
+       nil (list :kind 'started :session "abc-123" :model "claude-opus-5"))
+      (let ((text (remote--transcript-text)))
+        (it "opens a Runner heading when the runner starts"
+          (check-that (string-match-p "^\\* Runner" text)))
+        (it "records the session id of a started runner"
+          (check-that (string-match-p ":SESSION: abc-123" text)))
+        (it "records the model of a started runner"
+          (check-that (string-match-p ":MODEL: claude-opus-5" text))))))
 
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
-    (mcp-emacs-remote--tap-runner-event nil (list :kind 'text :text "hello there"))
-    (check "runner-text-recorded"
-           (and (string-match-p "assistant :: hello there" (remote--transcript-text)) t)
-           t)))
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
+        (mcp-emacs-remote--tap-runner-event nil (list :kind 'text :text "hello there"))
+        (it "records assistant text on the assistant channel"
+          (check-that (string-match-p "assistant :: hello there" (remote--transcript-text)))))))
 
-;; A tool call reuses the existing tool-call recorder, so runner tool calls
-;; and IDE-surface tool calls render identically in the transcript.
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
-    (mcp-emacs-remote--tap-runner-event
-     nil (list :kind 'tool-use :name "mcp__emacs__apply_diff"
-               :input '((path . "/tmp/x"))))
-    (let ((text (remote--transcript-text)))
-      (check "runner-tool-heading"
-             (and (string-match-p "🔧 mcp__emacs__apply_diff" text) t) t)
-      (check "runner-tool-args"
-             (and (string-match-p "/tmp/x" text) t) t))))
+  ;; A tool call reuses the existing tool-call recorder, so runner tool calls
+  ;; and IDE-surface tool calls render identically in the transcript.
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
+        (mcp-emacs-remote--tap-runner-event
+         nil (list :kind 'tool-use :name "mcp__emacs__apply_diff"
+                   :input '((path . "/tmp/x"))))
+        (let ((text (remote--transcript-text)))
+          (it "renders a runner tool call with the same heading as an IDE tool call"
+            (check-that (string-match-p "🔧 mcp__emacs__apply_diff" text)))
+          (it "records the runner tool call's input arguments"
+            (check-that (string-match-p "/tmp/x" text)))))))
 
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
-    (mcp-emacs-remote--tap-runner-event
-     nil (list :kind 'tool-result :text "Status: applied\nnew\n"))
-    (check "runner-result-first-line"
-           (and (string-match-p "result :: Status: applied" (remote--transcript-text)) t)
-           t)))
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
+        (mcp-emacs-remote--tap-runner-event
+         nil (list :kind 'tool-result :text "Status: applied\nnew\n"))
+        (it "records only the first line of a tool result"
+          (check-that (string-match-p "result :: Status: applied"
+                                      (remote--transcript-text)))))))
 
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
-    (mcp-emacs-remote--tap-runner-event nil (list :kind 'finished :subtype "success"))
-    (check "runner-finished"
-           (and (string-match-p "runner success" (remote--transcript-text)) t) t)))
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
+        (mcp-emacs-remote--tap-runner-event nil (list :kind 'finished :subtype "success"))
+        (it "records how the runner finished"
+          (check-that (string-match-p "runner success" (remote--transcript-text)))))))
 
-;; Recording is off by default: the subscriber must stay silent (and create
-;; no transcript buffer) unless the feature is enabled.
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled nil))
-  (mcp-emacs-remote--tap-runner-event nil (list :kind 'text :text "should not appear"))
-  (check "runner-disabled-silent" (remote--transcript-text) nil))
+  ;; Recording is off by default: the subscriber must stay silent (and create
+  ;; no transcript buffer) unless the feature is enabled.
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled nil))
+      (mcp-emacs-remote--tap-runner-event nil (list :kind 'text :text "should not appear"))
+      (it "stays silent and creates no transcript while disabled"
+        (check (remote--transcript-text) nil))))
 
-;; The human's own writes land in the same transcript, on the same channel
-;; as the runner's events -- one shared record, not two.
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
-    (mcp-emacs-remote--tap-runner-event
-     nil (list :kind 'note :text "check the error path" :pending t))
-    (check "runner-note-recorded"
-           (and (string-match-p "human :: check the error path"
-                                (remote--transcript-text))
-                t)
-           t)))
+  ;; The human's own writes land in the same transcript, on the same channel
+  ;; as the runner's events -- one shared record, not two.
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
+        (mcp-emacs-remote--tap-runner-event
+         nil (list :kind 'note :text "check the error path" :pending t))
+        (it "records a human note in the same transcript as the runner's events"
+          (check-that (string-match-p "human :: check the error path"
+                                      (remote--transcript-text)))))))
 
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
-    (mcp-emacs-remote--tap-runner-event
-     nil (list :kind 'notes-delivered :notes '("a" "b")))
-    (check "runner-notes-delivered-recorded"
-           (and (string-match-p "carried 2 note" (remote--transcript-text)) t) t)))
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
+        (mcp-emacs-remote--tap-runner-event
+         nil (list :kind 'notes-delivered :notes '("a" "b")))
+        (it "records how many notes were carried into the turn"
+          (check-that (string-match-p "carried 2 note" (remote--transcript-text)))))))
 
-;; An unknown event kind is ignored rather than guessed at, so adding a new
-;; kind to the runner cannot produce a malformed transcript entry.
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
-    (mcp-emacs-remote--tap-runner-event nil (list :kind 'brand-new-kind :text "x"))
-    (check "runner-unknown-kind-ignored" (remote--transcript-text) nil)))
+  ;; An unknown event kind is ignored rather than guessed at, so adding a new
+  ;; kind to the runner cannot produce a malformed transcript entry.
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-s")))
+        (mcp-emacs-remote--tap-runner-event nil (list :kind 'brand-new-kind :text "x"))
+        (it "ignores an unknown event kind rather than guessing at it"
+          (check (remote--transcript-text) nil)))))
 
-;; A failure inside the transcript must never propagate into the runner.
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-remote--append)
-             (lambda (&rest _) (error "boom"))))
-    (check "runner-error-swallowed"
-           (condition-case _
-               (progn (mcp-emacs-remote--tap-runner-event
-                       nil (list :kind 'text :text "x"))
-                      t)
-             (error nil))
-           t)))
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-remote--append)
+                 (lambda (&rest _) (error "boom"))))
+        (it "never propagates a transcript failure into the runner"
+          (check (condition-case _
+                     (progn (mcp-emacs-remote--tap-runner-event
+                             nil (list :kind 'text :text "x"))
+                            t)
+                   (error nil))
+                 t))))))
 
-;; enable/disable manage hook membership, and both are idempotent.
-(let ((agent-backend-event-functions nil))
-  (cl-letf (((symbol-function 'advice-add) #'ignore)
-            ((symbol-function 'advice-remove) #'ignore))
-    (mcp-emacs-remote-enable)
-    (check "enable-subscribes"
-           (and (memq #'mcp-emacs-remote--tap-runner-event
-                      agent-backend-event-functions) t) t)
-    (mcp-emacs-remote-enable)
-    (check "enable-idempotent"
-           (length (seq-filter (lambda (f) (eq f #'mcp-emacs-remote--tap-runner-event))
-                               agent-backend-event-functions))
-           1)
-    (mcp-emacs-remote-disable)
-    (check "disable-unsubscribes"
-           (memq #'mcp-emacs-remote--tap-runner-event agent-backend-event-functions)
-           nil)))
+(describe "mcp-emacs-remote-enable and mcp-emacs-remote-disable"
+  (let ((agent-backend-event-functions nil))
+    (cl-letf (((symbol-function 'advice-add) #'ignore)
+              ((symbol-function 'advice-remove) #'ignore))
+      (mcp-emacs-remote-enable)
+      (it "subscribes the runner tap to the event hook"
+        (check-that (memq #'mcp-emacs-remote--tap-runner-event
+                          agent-backend-event-functions)))
+      (mcp-emacs-remote-enable)
+      (it "keeps a single runner subscription when enabled twice"
+        (check (length (seq-filter (lambda (f) (eq f #'mcp-emacs-remote--tap-runner-event))
+                                   agent-backend-event-functions))
+               1))
+      (mcp-emacs-remote-disable)
+      (it "unsubscribes the runner tap again"
+        (check (memq #'mcp-emacs-remote--tap-runner-event agent-backend-event-functions)
+               nil)))))
 
 (remote--kill-transcripts)
 
@@ -280,80 +304,90 @@
 ;; the human's Org edits and the AI's activity in the order they happened.
 
 (remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
-    (mcp-emacs-remote--tap-org-task-event
-     (list :kind 'session-status :path "/tmp/s.org" :status "STRT"))
-    (check "org-session-status-recorded"
-           (and (string-match-p "org session :: STRT" (remote--transcript-text)) t) t)))
+(describe "mcp-emacs-remote--tap-org-task-event"
+  (let ((mcp-emacs-remote-enabled t))
+    (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
+      (mcp-emacs-remote--tap-org-task-event
+       (list :kind 'session-status :path "/tmp/s.org" :status "STRT"))
+      (it "records an Org session status change"
+        (check-that (string-match-p "org session :: STRT" (remote--transcript-text))))))
+
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
+        (mcp-emacs-remote--tap-org-task-event
+         (list :kind 'item-status :path "/tmp/s.org" :ref "write tests" :status "DONE"))
+        (it "records an Org item status change, naming the item"
+          (check-that (string-match-p "org item :: write tests"
+                                      (remote--transcript-text)))))))
+
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
+        (mcp-emacs-remote--tap-org-task-event
+         (list :kind 'item-added :path "/tmp/s.org" :text "new thing" :status "TODO"))
+        (it "records a newly added Org item with its keyword and text"
+          (check-that (string-match-p "org item added :: TODO new thing"
+                                      (remote--transcript-text)))))))
+
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
+        (mcp-emacs-remote--tap-org-task-event
+         (list :kind 'note :path "/tmp/s.org" :text "first line\nsecond"))
+        (it "records only the first line of a multi-line Org note"
+          (check-that (and (string-match-p "org note :: first line" (remote--transcript-text))
+                           (not (string-match-p "second" (remote--transcript-text)))))))))
+
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled nil))
+      (mcp-emacs-remote--tap-org-task-event
+       (list :kind 'session-status :path "/tmp/s.org" :status "STRT"))
+      (it "stays silent and creates no transcript while disabled"
+        (check (remote--transcript-text) nil))))
+
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
+        (mcp-emacs-remote--tap-org-task-event (list :kind 'brand-new :path "/tmp/s.org"))
+        (it "ignores an unknown Org event kind rather than guessing at it"
+          (check (remote--transcript-text) nil)))))
+
+  (progn
+    (remote--kill-transcripts)
+    (let ((mcp-emacs-remote-enabled t))
+      (cl-letf (((symbol-function 'mcp-emacs-remote--append)
+                 (lambda (&rest _) (error "boom"))))
+        (it "never lets a transcript failure break the Org write being observed"
+          (check (condition-case _
+                     (progn (mcp-emacs-remote--tap-org-task-event
+                             (list :kind 'note :path "/tmp/s.org" :text "x"))
+                            t)
+                   (error nil))
+                 t))))))
+
+(describe "mcp-emacs-remote-enable and mcp-emacs-remote-disable for org-task events"
+  (let ((mcp-emacs-org-task-event-functions nil)
+        (agent-backend-event-functions nil))
+    (cl-letf (((symbol-function 'advice-add) #'ignore)
+              ((symbol-function 'advice-remove) #'ignore))
+      (mcp-emacs-remote-enable)
+      (it "subscribes the org-task tap to the org-task event hook"
+        (check-that (memq #'mcp-emacs-remote--tap-org-task-event
+                          mcp-emacs-org-task-event-functions)))
+      (mcp-emacs-remote-disable)
+      (it "unsubscribes the org-task tap again"
+        (check (memq #'mcp-emacs-remote--tap-org-task-event
+                     mcp-emacs-org-task-event-functions)
+               nil)))))
 
 (remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
-    (mcp-emacs-remote--tap-org-task-event
-     (list :kind 'item-status :path "/tmp/s.org" :ref "write tests" :status "DONE"))
-    (check "org-item-status-recorded"
-           (and (string-match-p "org item :: write tests" (remote--transcript-text)) t) t)))
 
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
-    (mcp-emacs-remote--tap-org-task-event
-     (list :kind 'item-added :path "/tmp/s.org" :text "new thing" :status "TODO"))
-    (check "org-item-added-recorded"
-           (and (string-match-p "org item added :: TODO new thing"
-                                (remote--transcript-text)) t) t)))
+(test-helper-summary)
 
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
-    (mcp-emacs-remote--tap-org-task-event
-     (list :kind 'note :path "/tmp/s.org" :text "first line\nsecond"))
-    (check "org-note-first-line-only"
-           (and (string-match-p "org note :: first line" (remote--transcript-text))
-                (not (string-match-p "second" (remote--transcript-text))) t)
-           t)))
-
-;; Disabled -> silent, and no transcript buffer created.
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled nil))
-  (mcp-emacs-remote--tap-org-task-event
-   (list :kind 'session-status :path "/tmp/s.org" :status "STRT"))
-  (check "org-disabled-silent" (remote--transcript-text) nil))
-
-;; Unknown kinds are ignored rather than guessed at.
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/proj-o")))
-    (mcp-emacs-remote--tap-org-task-event (list :kind 'brand-new :path "/tmp/s.org"))
-    (check "org-unknown-kind-ignored" (remote--transcript-text) nil)))
-
-;; A transcript failure must never break the Org write being observed.
-(remote--kill-transcripts)
-(let ((mcp-emacs-remote-enabled t))
-  (cl-letf (((symbol-function 'mcp-emacs-remote--append)
-             (lambda (&rest _) (error "boom"))))
-    (check "org-error-swallowed"
-           (condition-case _
-               (progn (mcp-emacs-remote--tap-org-task-event
-                       (list :kind 'note :path "/tmp/s.org" :text "x"))
-                      t)
-             (error nil))
-           t)))
-
-;; enable/disable manage the org-task hook too.
-(let ((mcp-emacs-org-task-event-functions nil)
-      (agent-backend-event-functions nil))
-  (cl-letf (((symbol-function 'advice-add) #'ignore)
-            ((symbol-function 'advice-remove) #'ignore))
-    (mcp-emacs-remote-enable)
-    (check "org-enable-subscribes"
-           (and (memq #'mcp-emacs-remote--tap-org-task-event
-                      mcp-emacs-org-task-event-functions) t) t)
-    (mcp-emacs-remote-disable)
-    (check "org-disable-unsubscribes"
-           (memq #'mcp-emacs-remote--tap-org-task-event
-                 mcp-emacs-org-task-event-functions)
-           nil)))
-
-(remote--kill-transcripts)
+;;; mcp-emacs-remote-test.el ends here

--- a/test/mcp-emacs-report-test.el
+++ b/test/mcp-emacs-report-test.el
@@ -1,90 +1,98 @@
+;;; mcp-emacs-report-test.el --- Tests for the tooling-issue reporter -*- lexical-binding: t; -*-
+
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'mcp-emacs-report)
 (require 'cl-lib)
 
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
-
 ;; --- 4.1 Handler validation --------------------------------------------------
 
-;; Missing title -> user-error, no filing attempted.
-(check "missing-title-errors"
-       (condition-case _ (progn (mcp-emacs-report-tooling-issue "") nil)
-         (user-error t))
-       t)
+(describe "mcp-emacs-report-tooling-issue argument validation"
+  (it "rejects an empty title without attempting to file"
+    (check (condition-case _ (progn (mcp-emacs-report-tooling-issue "") nil)
+             (user-error t))
+           t))
 
-(check "whitespace-title-errors"
-       (condition-case _ (progn (mcp-emacs-report-tooling-issue "   ") nil)
-         (user-error t))
-       t)
+  (it "rejects a whitespace-only title without attempting to file"
+    (check (condition-case _ (progn (mcp-emacs-report-tooling-issue "   ") nil)
+             (user-error t))
+           t))
 
-;; Invalid kind -> user-error naming the accepted values.
-(check "invalid-kind-errors"
-       (condition-case e
-           (progn (mcp-emacs-report-tooling-issue "t" "b" "nonsense") nil)
-         (user-error (and (string-match-p "bug" (error-message-string e)) t)))
-       t)
+  (it "names the accepted values when the kind is unknown"
+    (check (condition-case e
+               (progn (mcp-emacs-report-tooling-issue "t" "b" "nonsense") nil)
+             (user-error (and (string-match-p "bug" (error-message-string e)) t)))
+           t))
 
-;; A valid kind passes validation (still no real filing -- gh stubbed absent).
-(cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () nil)))
-  (check "valid-kind-accepted"
-         (condition-case _
-             (progn (mcp-emacs-report-tooling-issue "t" "b" "feature") t)
-           (user-error nil))
-         t))
+  ;; A valid kind passes validation (still no real filing -- gh stubbed absent).
+  (cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () nil)))
+    (it "accepts a known kind"
+      (check (condition-case _
+                 (progn (mcp-emacs-report-tooling-issue "t" "b" "feature") t)
+               (user-error nil))
+             t))))
 
 ;; --- 4.2 Fallback chain ------------------------------------------------------
 
-;; gh present + CLI succeeds -> CLI URL used, api-create never called.
-(let ((api-called nil))
+(describe "mcp-emacs-report-tooling-issue with gh present and the CLI succeeding"
+  (let ((api-called nil))
+    (cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () t))
+              ((symbol-function 'mcp-emacs-report--create-via-cli)
+               (lambda (_title _body) "https://github.com/gbastkowski/mcp-emacs/issues/1"))
+              ((symbol-function 'mcp-emacs-report--api-create)
+               (lambda (_title _body) (setq api-called t) nil))
+              ((symbol-function 'mcp-emacs-report--apply-label) (lambda (&rest _) nil)))
+      (it "reports the URL the CLI returned"
+        (check (mcp-emacs-report-tooling-issue "t" "b")
+               "Created issue: https://github.com/gbastkowski/mcp-emacs/issues/1"))
+      (it "never falls through to the API"
+        (check api-called nil)))))
+
+(describe "mcp-emacs-report-tooling-issue with gh present and the CLI failing"
   (cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () t))
-            ((symbol-function 'mcp-emacs-report--create-via-cli)
-             (lambda (_title _body) "https://github.com/gbastkowski/mcp-emacs/issues/1"))
+            ((symbol-function 'mcp-emacs-report--create-via-cli) (lambda (_t _b) nil))
             ((symbol-function 'mcp-emacs-report--api-create)
-             (lambda (_title _body) (setq api-called t) nil))
+             (lambda (_t _b) "https://github.com/gbastkowski/mcp-emacs/issues/2"))
             ((symbol-function 'mcp-emacs-report--apply-label) (lambda (&rest _) nil)))
-    (check "cli-success-uses-cli"
-           (mcp-emacs-report-tooling-issue "t" "b")
-           "Created issue: https://github.com/gbastkowski/mcp-emacs/issues/1")
-    (check "cli-success-skips-api" api-called nil)))
+    (it "falls back to creating the issue via the API"
+      (check (mcp-emacs-report-tooling-issue "t" "b")
+             "Created issue: https://github.com/gbastkowski/mcp-emacs/issues/2"))))
 
-;; gh present + CLI fails -> falls to api-create.
-(cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () t))
-          ((symbol-function 'mcp-emacs-report--create-via-cli) (lambda (_t _b) nil))
-          ((symbol-function 'mcp-emacs-report--api-create)
-           (lambda (_t _b) "https://github.com/gbastkowski/mcp-emacs/issues/2"))
-          ((symbol-function 'mcp-emacs-report--apply-label) (lambda (&rest _) nil)))
-  (check "cli-fail-falls-to-api"
-         (mcp-emacs-report-tooling-issue "t" "b")
-         "Created issue: https://github.com/gbastkowski/mcp-emacs/issues/2"))
-
-;; gh absent -> manual fallback text, neither create path called.
-(let ((cli-called nil) (api-called nil))
-  (cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () nil))
-            ((symbol-function 'mcp-emacs-report--create-via-cli)
-             (lambda (_t _b) (setq cli-called t) nil))
-            ((symbol-function 'mcp-emacs-report--api-create)
-             (lambda (_t _b) (setq api-called t) nil)))
-    (let ((out (mcp-emacs-report-tooling-issue "My title" "Body here")))
-      (check "no-gh-manual-fallback"
-             (and (string-match-p "manually" out)
-                  (string-match-p "My title" out)
-                  (string-match-p "Body here" out) t)
-             t)
-      (check "no-gh-skips-cli" cli-called nil)
-      (check "no-gh-skips-api" api-called nil))))
+(describe "mcp-emacs-report-tooling-issue with gh absent"
+  (let ((cli-called nil) (api-called nil))
+    (cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () nil))
+              ((symbol-function 'mcp-emacs-report--create-via-cli)
+               (lambda (_t _b) (setq cli-called t) nil))
+              ((symbol-function 'mcp-emacs-report--api-create)
+               (lambda (_t _b) (setq api-called t) nil)))
+      (let ((out (mcp-emacs-report-tooling-issue "My title" "Body here")))
+        (it "hands back title and body for the user to file manually"
+          (check (and (string-match-p "manually" out)
+                      (string-match-p "My title" out)
+                      (string-match-p "Body here" out) t)
+                 t))
+        (it "does not try the CLI"
+          (check cli-called nil))
+        (it "does not try the API"
+          (check api-called nil))))))
 
 ;; --- 4.3 Best-effort label ---------------------------------------------------
 
-;; A failing label call still yields a created-issue result (not an error).
 ;; Stub the low-level runner so the real `--apply-label' ignore-errors path
 ;; is exercised, not bypassed.
-(cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () t))
-          ((symbol-function 'mcp-emacs-report--create-via-cli)
-           (lambda (_t _b) "https://github.com/gbastkowski/mcp-emacs/issues/3"))
-          ((symbol-function 'mcp-emacs-report--run)
-           (lambda (&rest _) (error "label does not exist"))))
-  (check "missing-label-still-creates"
-         (condition-case _
-             (mcp-emacs-report-tooling-issue "t" "b" "server")
-           (error "ERRORED"))
-         "Created issue: https://github.com/gbastkowski/mcp-emacs/issues/3"))
+(describe "mcp-emacs-report-tooling-issue when labelling fails"
+  (cl-letf (((symbol-function 'mcp-emacs-report--gh-available-p) (lambda () t))
+            ((symbol-function 'mcp-emacs-report--create-via-cli)
+             (lambda (_t _b) "https://github.com/gbastkowski/mcp-emacs/issues/3"))
+            ((symbol-function 'mcp-emacs-report--run)
+             (lambda (&rest _) (error "label does not exist"))))
+    (it "still reports the created issue rather than erroring"
+      (check (condition-case _
+                 (mcp-emacs-report-tooling-issue "t" "b" "server")
+               (error "ERRORED"))
+             "Created issue: https://github.com/gbastkowski/mcp-emacs/issues/3"))))
+
+(test-helper-summary)
+
+;;; mcp-emacs-report-test.el ends here

--- a/test/mcp-emacs-run-resume-test.el
+++ b/test/mcp-emacs-run-resume-test.el
@@ -1,4 +1,8 @@
+;;; mcp-emacs-run-resume-test.el --- Tests for resuming a Claude session -*- lexical-binding: t; -*-
+
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'cl-lib)
 ;; Avoid loading the full runner (needs eat) -- stub the two helpers the
 ;; command uses; the unit tests below never call the command itself.
@@ -9,69 +13,76 @@
 (defun mcp-emacs-run--launch (&rest args) (setq mcp-emacs-run--launched args))
 (require 'mcp-emacs-run-resume)
 
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+(describe "mcp-emacs-run-resume--slug"
+  (it "turns a project path into its store directory name"
+    (check (mcp-emacs-run-resume--slug "/Users/x/git/mcp-emacs")
+           "-Users-x-git-mcp-emacs"))
+  (it "replaces dots as well as slashes"
+    (check (mcp-emacs-run-resume--slug "/Users/x/.emacs.d")
+           "-Users-x--emacs-d"))
+  (it "ignores a trailing slash on the project path"
+    (check (mcp-emacs-run-resume--slug "/Users/x/proj/")
+           "-Users-x-proj")))
 
-;;;; slug builder
-(check "slug-basic"
-       (mcp-emacs-run-resume--slug "/Users/x/git/mcp-emacs")
-       "-Users-x-git-mcp-emacs")
-(check "slug-dots"
-       (mcp-emacs-run-resume--slug "/Users/x/.emacs.d")
-       "-Users-x--emacs-d")
-(check "slug-trailing-slash"
-       (mcp-emacs-run-resume--slug "/Users/x/proj/")
-       "-Users-x-proj")
+(describe "mcp-emacs-run-resume--content-text"
+  (it "passes a plain string content through unchanged"
+    (check (mcp-emacs-run-resume--content-text "hi") "hi"))
+  (it "extracts the text of an array content block"
+    (check (mcp-emacs-run-resume--content-text
+            (vector '((type . "text") (text . "hello"))))
+           "hello"))
+  (it "skips non-text blocks and takes the first text one"
+    (check (mcp-emacs-run-resume--content-text
+            (vector '((type . "tool_result")) '((type . "text") (text . "real"))))
+           "real"))
+  (it "returns nil for missing content"
+    (check (mcp-emacs-run-resume--content-text nil) nil)))
 
-;;;; content normalisation
-(check "content-string" (mcp-emacs-run-resume--content-text "hi") "hi")
-(check "content-array-text"
-       (mcp-emacs-run-resume--content-text (vector '((type . "text") (text . "hello"))))
-       "hello")
-(check "content-array-skip-nontext"
-       (mcp-emacs-run-resume--content-text
-        (vector '((type . "tool_result")) '((type . "text") (text . "real"))))
-       "real")
-(check "content-nil" (mcp-emacs-run-resume--content-text nil) nil)
-
-;;;; noise predicate
-(check "noise-command" (and (mcp-emacs-run-resume--noise-p "<command-message>x</command-message>") t) t)
-(check "noise-local-caveat" (and (mcp-emacs-run-resume--noise-p "<local-command-caveat>y") t) t)
-(check "noise-caveat" (and (mcp-emacs-run-resume--noise-p "Caveat: blah") t) t)
-(check "noise-empty" (and (mcp-emacs-run-resume--noise-p "   ") t) t)
-(check "noise-real" (mcp-emacs-run-resume--noise-p "show open issues") nil)
+(describe "mcp-emacs-run-resume--noise-p"
+  (it "treats a slash-command message as noise"
+    (check-that (mcp-emacs-run-resume--noise-p "<command-message>x</command-message>")))
+  (it "treats a local command caveat as noise"
+    (check-that (mcp-emacs-run-resume--noise-p "<local-command-caveat>y")))
+  (it "treats a bare Caveat line as noise"
+    (check-that (mcp-emacs-run-resume--noise-p "Caveat: blah")))
+  (it "treats a blank message as noise"
+    (check-that (mcp-emacs-run-resume--noise-p "   ")))
+  (it "treats a genuine user prompt as signal"
+    (check (mcp-emacs-run-resume--noise-p "show open issues") nil)))
 
 ;;;; first-prompt over a fixture store
 (let* ((store (make-temp-file "resume-store-" t)))
-  ;; clean string prompt
-  (let ((f (expand-file-name "aaa.jsonl" store)))
-    (with-temp-file f
-      (insert "{\"type\":\"mode\"}\n"
-              "{\"type\":\"user\",\"message\":{\"content\":\"show open issues\"}}\n"))
-    (check "prompt-clean" (mcp-emacs-run-resume--first-prompt f) "show open issues"))
-  ;; caveat/command block precedes the real prompt -> skip to real
-  (let ((f (expand-file-name "bbb.jsonl" store)))
-    (with-temp-file f
-      (insert "{\"type\":\"user\",\"message\":{\"content\":\"<local-command-caveat>Caveat: x\"}}\n"
-              "{\"type\":\"user\",\"message\":{\"content\":\"<command-message>opsx:new</command-message>\"}}\n"
-              "{\"type\":\"user\",\"message\":{\"content\":\"the actual prompt\"}}\n"))
-    (check "prompt-skip-noise" (mcp-emacs-run-resume--first-prompt f) "the actual prompt"))
-  ;; array content
-  (let ((f (expand-file-name "ccc.jsonl" store)))
-    (with-temp-file f
-      (insert "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"array prompt\"}]}}\n"))
-    (check "prompt-array" (mcp-emacs-run-resume--first-prompt f) "array prompt"))
-  ;; multi-line prompt -> first line only
-  (let ((f (expand-file-name "ddd.jsonl" store)))
-    (with-temp-file f
-      (insert "{\"type\":\"user\",\"message\":{\"content\":\"line one\\nline two\"}}\n"))
-    (check "prompt-first-line" (mcp-emacs-run-resume--first-prompt f) "line one"))
-  ;; no genuine prompt in head -> nil (label falls back to id)
-  (let ((f (expand-file-name "eee.jsonl" store)))
-    (with-temp-file f
-      (insert "{\"type\":\"user\",\"message\":{\"content\":\"<command-message>only noise</command-message>\"}}\n"))
-    (check "prompt-none" (mcp-emacs-run-resume--first-prompt f) nil)
-    (check "label-id-fallback"
-           (string-suffix-p "eee" (mcp-emacs-run-resume--label f)) t)))
+  (describe "mcp-emacs-run-resume--first-prompt"
+    (let ((f (expand-file-name "aaa.jsonl" store)))
+      (with-temp-file f
+        (insert "{\"type\":\"mode\"}\n"
+                "{\"type\":\"user\",\"message\":{\"content\":\"show open issues\"}}\n"))
+      (it "picks the first user message, ignoring non-user lines"
+        (check (mcp-emacs-run-resume--first-prompt f) "show open issues")))
+    (let ((f (expand-file-name "bbb.jsonl" store)))
+      (with-temp-file f
+        (insert "{\"type\":\"user\",\"message\":{\"content\":\"<local-command-caveat>Caveat: x\"}}\n"
+                "{\"type\":\"user\",\"message\":{\"content\":\"<command-message>opsx:new</command-message>\"}}\n"
+                "{\"type\":\"user\",\"message\":{\"content\":\"the actual prompt\"}}\n"))
+      (it "skips leading caveat and command blocks to reach the real prompt"
+        (check (mcp-emacs-run-resume--first-prompt f) "the actual prompt")))
+    (let ((f (expand-file-name "ccc.jsonl" store)))
+      (with-temp-file f
+        (insert "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"array prompt\"}]}}\n"))
+      (it "reads a prompt stored as array content"
+        (check (mcp-emacs-run-resume--first-prompt f) "array prompt")))
+    (let ((f (expand-file-name "ddd.jsonl" store)))
+      (with-temp-file f
+        (insert "{\"type\":\"user\",\"message\":{\"content\":\"line one\\nline two\"}}\n"))
+      (it "keeps only the first line of a multi-line prompt"
+        (check (mcp-emacs-run-resume--first-prompt f) "line one")))
+    (let ((f (expand-file-name "eee.jsonl" store)))
+      (with-temp-file f
+        (insert "{\"type\":\"user\",\"message\":{\"content\":\"<command-message>only noise</command-message>\"}}\n"))
+      (it "returns nil when the head holds no genuine prompt"
+        (check (mcp-emacs-run-resume--first-prompt f) nil))
+      (it "falls back to the session id for the label"
+        (check (string-suffix-p "eee" (mcp-emacs-run-resume--label f)) t)))))
 
 ;;;; session-files: mtime ordering, newest first, .jsonl only
 (let* ((store (make-temp-file "resume-order-" t))
@@ -84,7 +95,13 @@
       (set-file-times old '(20000 0))
       (set-file-times new '(25000 0))
       (with-temp-file (expand-file-name "notes.txt" store) (insert "ignore"))
-      (let ((files (mcp-emacs-run-resume--session-files slug-root)))
-        (check "files-count" (length files) 2)
-        (check "files-newest-first"
-               (mcp-emacs-run-resume--session-id (car files)) "new")))))
+      (describe "mcp-emacs-run-resume--session-files"
+        (let ((files (mcp-emacs-run-resume--session-files slug-root)))
+          (it "lists only .jsonl transcripts, ignoring other files"
+            (check (length files) 2))
+          (it "orders sessions newest first by mtime"
+            (check (mcp-emacs-run-resume--session-id (car files)) "new")))))))
+
+(test-helper-summary)
+
+;;; mcp-emacs-run-resume-test.el ends here

--- a/test/mcp-emacs-run-test.el
+++ b/test/mcp-emacs-run-test.el
@@ -1,13 +1,22 @@
+;;; mcp-emacs-run-test.el --- Tests for the Claude terminal runner -*- lexical-binding: t; -*-
+
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'cl-lib)
 (require 'mcp-emacs-run)
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
-;; project-root from a subdir resolves to the git repo root
-(let ((default-directory (expand-file-name "elisp/"))
-      (repo (expand-file-name "./")))
-  (check "project-root-is-repo" (mcp-emacs-run--project-root) repo))
-(check "buffer-name" (mcp-emacs-run--buffer-name "/tmp/foo/" 1) "*claude:foo:1*")
-(check "buffer-name-2" (mcp-emacs-run--buffer-name "/tmp/foo/" 2) "*claude:foo:2*")
+
+(describe "mcp-emacs-run--project-root"
+  (let ((default-directory (expand-file-name "elisp/"))
+        (repo (expand-file-name "./")))
+    (it "resolves to the git repo root from a subdirectory"
+      (check (mcp-emacs-run--project-root) repo))))
+
+(describe "mcp-emacs-run--buffer-name"
+  (it "names the first session after the project directory"
+    (check (mcp-emacs-run--buffer-name "/tmp/foo/" 1) "*claude:foo:1*"))
+  (it "distinguishes sessions by their number"
+    (check (mcp-emacs-run--buffer-name "/tmp/foo/" 2) "*claude:foo:2*")))
 
 ;; Discovery + numbering: sessions are found from live *claude:*:<n>* buffers,
 ;; each matched to its project by the buffer's own default-directory.
@@ -19,36 +28,44 @@
   (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () root)))
     (unwind-protect
         (progn
-          (check "sessions-list-finds-both"
+          (describe "mcp-emacs-run--project-sessions"
+            (it "finds every live session buffer of the project"
+              (check
                  (sort (mapcar #'buffer-name (mcp-emacs-run--project-sessions root)) #'string<)
-                 '("*claude:numproj:1*" "*claude:numproj:3*"))
-          ;; lowest free slot fills the gap left by the killed 2
-          (check "next-number-refills-gap" (mcp-emacs-run--next-number root) 2)
-          (kill-buffer b3)
-          (check "next-number-after-kill" (mcp-emacs-run--next-number root) 2))
+                 '("*claude:numproj:1*" "*claude:numproj:3*"))))
+          (describe "mcp-emacs-run--next-number"
+            (it "fills the lowest free slot left by a killed session"
+              (check (mcp-emacs-run--next-number root) 2))
+            (kill-buffer b3)
+            (it "still picks the lowest free slot after the highest is killed"
+              (check (mcp-emacs-run--next-number root) 2))))
       (when (buffer-live-p b1) (kill-buffer b1))
       (when (buffer-live-p b3) (kill-buffer b3))))
-  ;; no sessions -> first number is 1
   (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () root)))
-    (check "next-number-fresh" (mcp-emacs-run--next-number root) 1)))
-(check "eat-guard-errors"
-       (condition-case _ (progn (mcp-emacs-run--ensure-eat) 'no) (user-error 'yes)) 'yes)
+    (describe "mcp-emacs-run--next-number with no sessions"
+      (it "starts numbering at 1"
+        (check (mcp-emacs-run--next-number root) 1)))))
+
+(describe "mcp-emacs-run--ensure-eat"
+  (it "signals a user-error when eat is unavailable"
+    (check (condition-case _ (progn (mcp-emacs-run--ensure-eat) 'no) (user-error 'yes)) 'yes)))
 
 ;; resolved width: columns preferred, clamped to max-fraction of frame width.
 (cl-letf (((symbol-function 'frame-width) (lambda (&optional _) 400)))
-  ;; configured columns fit under the clamp (0.5 * 400 = 200)
-  (let ((mcp-emacs-run-window-width-columns 120)
-        (mcp-emacs-run-window-max-width-fraction 0.5))
-    (check "width-columns-under-clamp" (mcp-emacs-run--resolved-width) 120))
-  ;; configured columns exceed the clamp -> reduced to the cap
-  (let ((mcp-emacs-run-window-width-columns 300)
-        (mcp-emacs-run-window-max-width-fraction 0.5))
-    (check "width-columns-clamped" (mcp-emacs-run--resolved-width) 200))
-  ;; nil columns -> fall back to the fraction (0.4 * 400 = 160, under cap)
-  (let ((mcp-emacs-run-window-width-columns nil)
-        (mcp-emacs-run-window-width 0.4)
-        (mcp-emacs-run-window-max-width-fraction 0.5))
-    (check "width-fraction-fallback" (mcp-emacs-run--resolved-width) 160)))
+  (describe "mcp-emacs-run--resolved-width"
+    (let ((mcp-emacs-run-window-width-columns 120)
+          (mcp-emacs-run-window-max-width-fraction 0.5))
+      (it "uses the configured columns when they fit under the clamp"
+        (check (mcp-emacs-run--resolved-width) 120)))
+    (let ((mcp-emacs-run-window-width-columns 300)
+          (mcp-emacs-run-window-max-width-fraction 0.5))
+      (it "reduces configured columns that exceed the clamp to the cap"
+        (check (mcp-emacs-run--resolved-width) 200)))
+    (let ((mcp-emacs-run-window-width-columns nil)
+          (mcp-emacs-run-window-width 0.4)
+          (mcp-emacs-run-window-max-width-fraction 0.5))
+      (it "falls back to the width fraction when no columns are configured"
+        (check (mcp-emacs-run--resolved-width) 160)))))
 
 ;; Headless launch: stub eat so no real terminal is spawned.  eat-make returns a
 ;; plain buffer whose default-directory is the project root (so discovery works).
@@ -63,22 +80,28 @@
             ((symbol-function 'mcp-emacs-run--project-root) (lambda () root)))
     (unwind-protect
         (progn
-          ;; headless start launches a numbered session, shows no window
           (let ((buf (mcp-emacs-run-start)))
-            (check "headless-buffer-numbered" (buffer-name buf) "*claude:headless-proj:1*")
-            (check "headless-discoverable" (memq buf (mcp-emacs-run--project-sessions root)) (list buf))
-            (check "headless-no-window" (get-buffer-window buf) nil)
-            ;; starting again always launches a NEW numbered session (no reuse)
-            (let ((again (mcp-emacs-run-start)))
-              (check "headless-start-is-new" (eq again buf) nil)
-              (check "headless-second-numbered" (buffer-name again) "*claude:headless-proj:2*")
-              (check "headless-two-sessions"
-                     (length (mcp-emacs-run--project-sessions root)) 2))
+            (describe "mcp-emacs-run-start"
+              (it "launches a numbered session for the project"
+                (check (buffer-name buf) "*claude:headless-proj:1*"))
+              (it "makes the new session discoverable"
+                (check (memq buf (mcp-emacs-run--project-sessions root)) (list buf)))
+              (it "shows no window for the new session"
+                (check (get-buffer-window buf) nil))
+              (let ((again (mcp-emacs-run-start)))
+                (it "never reuses an existing session"
+                  (check (eq again buf) nil))
+                (it "gives the second session the next number"
+                  (check (buffer-name again) "*claude:headless-proj:2*"))
+                (it "leaves both sessions running side by side"
+                  (check (length (mcp-emacs-run--project-sessions root)) 2))))
             ;; toggle with 2 sessions prompts; stub the picker to choose buf
             (cl-letf (((symbol-function 'mcp-emacs-run--pick-session)
                        (lambda (cands &optional _p) (car cands))))
               (mcp-emacs-run-toggle)
-              (check "headless-toggle-reveals" (and (get-buffer-window (car (mcp-emacs-run--project-sessions root))) t) t))
+              (describe "mcp-emacs-run-toggle"
+                (it "reveals the picked session in a window"
+                  (check (and (get-buffer-window (car (mcp-emacs-run--project-sessions root))) t) t))))
             (dolist (w (window-list))
               (when (memq (window-buffer w) (mcp-emacs-run--project-sessions root))
                 (ignore-errors (delete-window w))))))
@@ -89,31 +112,36 @@
        (file (expand-file-name "elisp/mcp-emacs-run.el" root)))
   (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () root)))
     (with-current-buffer (find-file-noselect file)
-      ;; region spanning lines 2..4 (put point at start of line 5 so bol trims to 4)
-      (goto-char (point-min)) (forward-line 1) (let ((b (point)))
-        (goto-char (point-min)) (forward-line 4)
-        (set-mark b) (activate-mark))
-      (check "ref-file-region"
-             (mcp-emacs-run--selection-reference) "@elisp/mcp-emacs-run.el:2-4")
-      (deactivate-mark)
-      (goto-char (point-min)) (forward-line 11) ; line 12
-      (check "ref-file-no-region"
-             (mcp-emacs-run--selection-reference) "@elisp/mcp-emacs-run.el:12")
+      (describe "mcp-emacs-run--selection-reference in a file buffer"
+        ;; region spanning lines 2..4 (put point at start of line 5 so bol trims to 4)
+        (goto-char (point-min)) (forward-line 1) (let ((b (point)))
+          (goto-char (point-min)) (forward-line 4)
+          (set-mark b) (activate-mark))
+        (it "cites the project-relative path with the region's line range"
+          (check (mcp-emacs-run--selection-reference) "@elisp/mcp-emacs-run.el:2-4"))
+        (deactivate-mark)
+        (goto-char (point-min)) (forward-line 11) ; line 12
+        (it "cites just the line at point when there is no region"
+          (check (mcp-emacs-run--selection-reference) "@elisp/mcp-emacs-run.el:12")))
       (kill-buffer))))
 (with-temp-buffer
   (insert "alpha\nbeta\ngamma\n")
-  (goto-char (point-min)) (set-mark (point)) (goto-char (line-end-position)) (activate-mark)
-  (check "ref-nonfile-region" (mcp-emacs-run--selection-reference) "alpha")
-  (deactivate-mark)
-  (goto-char (point-min)) (forward-line 1)
-  (check "ref-nonfile-no-region" (mcp-emacs-run--selection-reference) "beta"))
+  (describe "mcp-emacs-run--selection-reference in a non-file buffer"
+    (goto-char (point-min)) (set-mark (point)) (goto-char (line-end-position)) (activate-mark)
+    (it "quotes the selected text instead of a file reference"
+      (check (mcp-emacs-run--selection-reference) "alpha"))
+    (deactivate-mark)
+    (goto-char (point-min)) (forward-line 1)
+    (it "quotes the line at point when there is no region"
+      (check (mcp-emacs-run--selection-reference) "beta"))))
 
-;; Send guard: no live session anywhere -> user-error, no launch.
-(cl-letf (((symbol-function 'mcp-emacs-run--sessions-list) (lambda () nil)))
-  (check "send-no-session-errors"
+(describe "mcp-emacs-run-send-prompt with no live session"
+  (cl-letf (((symbol-function 'mcp-emacs-run--sessions-list) (lambda () nil)))
+    (it "signals a user-error rather than launching a session"
+      (check
          (condition-case _ (progn (mcp-emacs-run-send-prompt "hi") 'no)
            (user-error 'yes))
-         'yes))
+         'yes))))
 
 ;; Send delivery: --send resolves the single session and feeds its terminal.
 (let ((root (expand-file-name "/tmp/send-deliver/"))
@@ -126,9 +154,10 @@
             ((symbol-function 'eat-term-send-string)
              (lambda (term string) (push (cons term string) sent))))
     (unwind-protect
-        (progn
+        (describe "mcp-emacs-run--send"
           (mcp-emacs-run--send "hello")
-          (check "send-delivers-string" (car sent) '(fake-term . "hello")))
+          (it "feeds the string to the resolved session's terminal"
+            (check (car sent) '(fake-term . "hello"))))
       (kill-buffer buf))))
 
 ;; Single-keystroke senders: each delivers its exact byte sequence.
@@ -142,23 +171,26 @@
             ((symbol-function 'eat-term-send-string)
              (lambda (_term string) (setq sent string))))
     (unwind-protect
-        (dolist (case '(("send-return"    mcp-emacs-run-send-return    "\r")
-                        ("send-1"         mcp-emacs-run-send-1         "1")
-                        ("send-2"         mcp-emacs-run-send-2         "2")
-                        ("send-3"         mcp-emacs-run-send-3         "3")
-                        ("send-shift-tab" mcp-emacs-run-send-shift-tab "\e[Z")
-                        ("send-up"        mcp-emacs-run-send-up        "\e[A")
-                        ("send-down"      mcp-emacs-run-send-down      "\e[B")))
-          (setq sent nil)
-          (funcall (nth 1 case))
-          (check (format "keystroke-%s" (nth 0 case)) sent (nth 2 case)))
+        (describe "single-keystroke senders"
+          (it "each deliver their exact byte sequence"
+            (dolist (case '(("send-return"    mcp-emacs-run-send-return    "\r")
+                            ("send-1"         mcp-emacs-run-send-1         "1")
+                            ("send-2"         mcp-emacs-run-send-2         "2")
+                            ("send-3"         mcp-emacs-run-send-3         "3")
+                            ("send-shift-tab" mcp-emacs-run-send-shift-tab "\e[Z")
+                            ("send-up"        mcp-emacs-run-send-up        "\e[A")
+                            ("send-down"      mcp-emacs-run-send-down      "\e[B")))
+              (setq sent nil)
+              (funcall (nth 1 case))
+              (check sent (nth 2 case) (format "%s delivers its exact byte sequence" (nth 0 case))))))
       (kill-buffer buf))))
 
-;; Keystroke senders inherit the no-live-session guard.
-(cl-letf (((symbol-function 'mcp-emacs-run--sessions-list) (lambda () nil)))
-  (check "keystroke-no-session-errors"
+(describe "mcp-emacs-run-send-return with no live session"
+  (cl-letf (((symbol-function 'mcp-emacs-run--sessions-list) (lambda () nil)))
+    (it "inherits the no-live-session guard and signals a user-error"
+      (check
          (condition-case _ (progn (mcp-emacs-run-send-return) 'no) (user-error 'yes))
-         'yes))
+         'yes))))
 
 ;; Resolution tiers: same-project+visible beats same-project+hidden beats
 ;; cross-project; ambiguity within the winning tier invokes the picker once.
@@ -179,15 +211,16 @@
             ((symbol-function 'completing-read)
              (lambda (_p coll &rest _) (push coll picks) (caar coll))))
     (unwind-protect
-        (progn
-          ;; only a2 visible -> tier 1 has exactly a2, no prompt
+        (describe "mcp-emacs-run--resolve-session"
           (setq visible (list a2) picks nil)
-          (check "resolve-visible-same-project" (mcp-emacs-run--resolve-session) a2)
-          (check "resolve-visible-no-pick" picks nil)
-          ;; none visible -> tier 2 (same project) has a1 & a2 -> one prompt
+          (it "prefers the visible session of the current project"
+            (check (mcp-emacs-run--resolve-session) a2))
+          (it "does not prompt when the winning tier holds one candidate"
+            (check picks nil))
           (setq visible nil picks nil)
           (mcp-emacs-run--resolve-session)
-          (check "resolve-hidden-same-project-picks" (length picks) 1))
+          (it "prompts once when the current project has several hidden sessions"
+            (check (length picks) 1)))
       (dolist (b (list a1 a2 b1)) (when (buffer-live-p b) (kill-buffer b))))))
 
 ;; Cross-project fallback: current project has no session; a visible session of
@@ -199,7 +232,9 @@
   (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () rootX))
             ((symbol-function 'get-buffer-window) (lambda (buf &optional _a) (eq buf y1))))
     (unwind-protect
-        (check "resolve-cross-project-fallback" (mcp-emacs-run--resolve-session) y1)
+        (describe "mcp-emacs-run--resolve-session with no session in the current project"
+          (it "falls back to a visible session of another project"
+            (check (mcp-emacs-run--resolve-session) y1)))
       (kill-buffer y1))))
 
 ;; send-prompt resolves once: ambiguous tier -> picker invoked exactly once for
@@ -218,15 +253,16 @@
             ((symbol-function 'eat-term-send-string)
              (lambda (_t s) (push s sent))))
     (unwind-protect
-        (progn
+        (describe "mcp-emacs-run-send-prompt with an ambiguous tier"
           (mcp-emacs-run-send-prompt "hi")
-          (check "send-prompt-resolves-once" picks 1)
-          (check "send-prompt-sends-text-then-return" (reverse sent) '("hi" "\r")))
+          (it "invokes the picker once for the whole operation"
+            (check picks 1))
+          (it "sends the text and then a return"
+            (check (reverse sent) '("hi" "\r"))))
       (dolist (b (list b1 b2)) (when (buffer-live-p b) (kill-buffer b))))))
 
 ;;; Quit: sends the quit sequence, arms a timer, force-kills + removes buffer.
 
-;; Quit sends Ctrl-C twice to the resolved buffer and arms one timer.
 (let* ((buf (generate-new-buffer "*claude:quit:1*"))
        sent timers)
   (with-current-buffer buf (setq-local eat-terminal 'fake-term))
@@ -235,53 +271,67 @@
             ((symbol-function 'run-with-timer)
              (lambda (secs _rep _fn &rest _args) (push secs timers) 'fake-timer)))
     (unwind-protect
-        (progn
+        (describe "mcp-emacs-run-quit"
           (mcp-emacs-run-quit)
-          (check "quit-sends-double-ctrl-c" (car sent) "\003\003")
-          (check "quit-arms-one-timer" (length timers) 1)
-          (check "quit-timer-uses-timeout" (car timers) mcp-emacs-run-quit-timeout))
+          (it "sends Ctrl-C twice to the resolved session"
+            (check (car sent) "\003\003"))
+          (it "arms exactly one force-kill timer"
+            (check (length timers) 1))
+          (it "arms that timer for the configured quit timeout"
+            (check (car timers) mcp-emacs-run-quit-timeout)))
       (when (buffer-live-p buf) (kill-buffer buf)))))
 
-;; Quit with no live session -> user-error, nothing sent.
 (let (sent)
   (cl-letf (((symbol-function 'mcp-emacs-run--sessions-list) (lambda () nil))
             ((symbol-function 'eat-term-send-string) (lambda (_t s) (push s sent))))
-    (check "quit-no-session-errors"
-           (condition-case _ (progn (mcp-emacs-run-quit) 'no) (user-error 'yes)) 'yes)
-    (check "quit-no-session-sends-nothing" sent nil)))
+    (describe "mcp-emacs-run-quit with no live session"
+      (it "signals a user-error"
+        (check
+           (condition-case _ (progn (mcp-emacs-run-quit) 'no) (user-error 'yes)) 'yes))
+      (it "sends nothing"
+        (check sent nil)))))
 
-;; Timeout handler: still-live process -> force-killed, buffer killed.
 ;; Use a real long-lived process so the real delete-process/kill-buffer run.
 (let* ((buf (generate-new-buffer "*claude:quit-force:1*"))
        (proc (make-process :name "quit-force-test" :buffer buf
                            :command '("sleep" "60") :noquery t)))
-  (check "force-kill-precondition-live" (and (process-live-p proc) t) t)
-  (mcp-emacs-run--force-kill-buffer buf)
-  (check "force-kill-deletes-live-process" (process-live-p proc) nil)
-  (check "force-kill-kills-buffer" (buffer-live-p buf) nil))
+  (describe "mcp-emacs-run--force-kill-buffer with a still-live process"
+    (it "starts from a live process, so the kill is actually exercised"
+      (check (and (process-live-p proc) t) t))
+    (mcp-emacs-run--force-kill-buffer buf)
+    (it "force-kills the still-live process"
+      (check (process-live-p proc) nil))
+    (it "kills the buffer"
+      (check (buffer-live-p buf) nil))))
 
-;; Timeout handler: no process -> just kills the buffer, no error.
 (let ((buf (generate-new-buffer "*claude:quit-noproc:1*")))
-  (mcp-emacs-run--force-kill-buffer buf)
-  (check "force-kill-no-process-kills-buffer" (buffer-live-p buf) nil))
+  (describe "mcp-emacs-run--force-kill-buffer with no process"
+    (mcp-emacs-run--force-kill-buffer buf)
+    (it "just kills the buffer, without error"
+      (check (buffer-live-p buf) nil))))
 
-;; Timeout handler: already-killed buffer -> no-op, no error.
 (let ((buf (generate-new-buffer "*claude:quit-dead:1*")))
   (kill-buffer buf)
-  (check "force-kill-dead-buffer-noop"
+  (describe "mcp-emacs-run--force-kill-buffer with an already-killed buffer"
+    (it "is a no-op rather than an error"
+      (check
          (condition-case _ (progn (mcp-emacs-run--force-kill-buffer buf) 'ok) (error 'err))
-         'ok))
+         'ok))))
 
 ;;; Popup output window.
 
-(check "popup-buffer-name" (mcp-emacs-run--popup-buffer-name "explain") "*mcp-emacs:explain*")
+(describe "mcp-emacs-run--popup-buffer-name"
+  (it "names the popup buffer after its kind"
+    (check (mcp-emacs-run--popup-buffer-name "explain") "*mcp-emacs:explain*")))
 
-(check "markdown-guard-errors"
+(describe "mcp-emacs-run--ensure-markdown"
+  (it "signals a user-error when markdown-mode is unavailable"
+    (check
        (cl-letf (((symbol-function 'gfm-view-mode) nil))
          ;; fboundp is nil when the symbol has no function cell
          (fmakunbound 'gfm-view-mode)
          (condition-case _ (progn (mcp-emacs-run--ensure-markdown) 'no) (user-error 'yes)))
-       'yes)
+       'yes)))
 
 ;; Popup render: stub gfm-view-mode and the display step so no real window
 ;; machinery or markdown-mode is needed; assert content, read-only, fontify.
@@ -293,20 +343,27 @@
     (when (get-buffer "*mcp-emacs:explain*") (kill-buffer "*mcp-emacs:explain*"))
     (let ((buf (mcp-emacs-popup-show "# Title\n\nbody\n" "explain")))
       (unwind-protect
-          (progn
-            (check "popup-returns-buffer" (bufferp buf) t)
-            (check "popup-buffer-named" (buffer-name buf) "*mcp-emacs:explain*")
-            (check "popup-mode-ran" mode-ran t)
-            (check "popup-displayed" (eq displayed buf) t)
+          (describe "mcp-emacs-popup-show"
+            (it "returns a buffer"
+              (check (bufferp buf) t))
+            (it "names that buffer after the kind"
+              (check (buffer-name buf) "*mcp-emacs:explain*"))
+            (it "puts the buffer in markdown view mode"
+              (check mode-ran t))
+            (it "displays the buffer it returns"
+              (check (eq displayed buf) t))
             (with-current-buffer buf
-              (check "popup-content" (buffer-string) "# Title\n\nbody\n")
-              (check "popup-read-only" buffer-read-only t)
-              (check "popup-fontify-local"
-                     (buffer-local-value 'markdown-fontify-code-blocks-natively buf) t)
-              (check "popup-point-at-top" (point) (point-min))))
+              (it "holds the rendered markdown verbatim"
+                (check (buffer-string) "# Title\n\nbody\n"))
+              (it "leaves the buffer read-only"
+                (check buffer-read-only t))
+              (it "fontifies code blocks natively, buffer-locally"
+                (check
+                       (buffer-local-value 'markdown-fontify-code-blocks-natively buf) t))
+              (it "leaves point at the top of the output"
+                (check (point) (point-min)))))
         (when (buffer-live-p buf) (kill-buffer buf))))))
 
-;; Reuse per kind: second render same kind -> same buffer, content replaced.
 (let (displayed)
   (cl-letf (((symbol-function 'gfm-view-mode) #'ignore)
             ((symbol-function 'mcp-emacs-run--display-popup)
@@ -315,13 +372,14 @@
     (let ((first (mcp-emacs-popup-show "one" "explain")))
       (let ((second (mcp-emacs-popup-show "two" "explain")))
         (unwind-protect
-            (progn
-              (check "popup-reuse-same-buffer" (eq first second) t)
-              (check "popup-reuse-content"
-                     (with-current-buffer second (buffer-string)) "two"))
+            (describe "mcp-emacs-popup-show rendered twice for the same kind"
+              (it "reuses the same buffer"
+                (check (eq first second) t))
+              (it "replaces the previous content"
+                (check
+                       (with-current-buffer second (buffer-string)) "two")))
           (when (buffer-live-p first) (kill-buffer first)))))))
 
-;; Distinct kinds -> distinct buffers.
 (let (displayed)
   (cl-letf (((symbol-function 'gfm-view-mode) #'ignore)
             ((symbol-function 'mcp-emacs-run--display-popup)
@@ -331,13 +389,14 @@
     (let ((a (mcp-emacs-popup-show "a" "explain"))
           (b (mcp-emacs-popup-show "b" "diag")))
       (unwind-protect
-          (check "popup-distinct-kinds" (not (eq a b)) t)
+          (describe "mcp-emacs-popup-show for distinct kinds"
+            (it "gives each kind its own buffer"
+              (check (not (eq a b)) t)))
         (when (buffer-live-p a) (kill-buffer a))
         (when (buffer-live-p b) (kill-buffer b))))))
 
 ;;; Headless query.
 
-;; Command line: claude -p PROMPT --output-format text, run from project root.
 (let (cmd dir sentinel-fn out-buf)
   (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/qproj/"))
             ((symbol-function 'make-process)
@@ -348,18 +407,21 @@
                (setq out-buf (plist-get args :buffer))
                'fake-proc)))
     (let (result)
-      (mcp-emacs-run--query-headless "explain @x:1" (lambda (o) (setq result o)))
-      (check "query-command"
-             cmd (list mcp-emacs-run-executable "-p" "explain @x:1" "--output-format" "text"))
-      (check "query-runs-in-project-root" dir "/tmp/qproj/")
-      ;; Simulate a successful exit: fill stdout, drive the sentinel.
-      (cl-letf (((symbol-function 'process-status) (lambda (_) 'exit))
-                ((symbol-function 'process-exit-status) (lambda (_) 0)))
-        (with-current-buffer out-buf (insert "the answer"))
-        (funcall sentinel-fn 'fake-proc "finished\n")
-        (check "query-success-callback" result "the answer")))))
+      (describe "mcp-emacs-run--query-headless"
+        (mcp-emacs-run--query-headless "explain @x:1" (lambda (o) (setq result o)))
+        (it "runs claude -p PROMPT with text output format"
+          (check
+                 cmd (list mcp-emacs-run-executable "-p" "explain @x:1" "--output-format" "text")))
+        (it "runs the process from the project root"
+          (check dir "/tmp/qproj/"))
+        ;; Simulate a successful exit: fill stdout, drive the sentinel.
+        (cl-letf (((symbol-function 'process-status) (lambda (_) 'exit))
+                  ((symbol-function 'process-exit-status) (lambda (_) 0)))
+          (with-current-buffer out-buf (insert "the answer"))
+          (funcall sentinel-fn 'fake-proc "finished\n")
+          (it "passes the collected stdout to the callback on success"
+            (check result "the answer")))))))
 
-;; Non-zero exit: callback is NOT invoked.
 (let (sentinel-fn out-buf err-buf called)
   (cl-letf (((symbol-function 'mcp-emacs-run--project-root) (lambda () "/tmp/qproj/"))
             ((symbol-function 'make-process)
@@ -373,7 +435,9 @@
               ((symbol-function 'process-exit-status) (lambda (_) 1)))
       (with-current-buffer err-buf (insert "boom"))
       (funcall sentinel-fn 'fake-proc "exited abnormally\n")
-      (check "query-failure-no-callback" called nil))))
+      (describe "mcp-emacs-run--query-headless on a non-zero exit"
+        (it "does not invoke the callback"
+          (check called nil))))))
 
 ;;; Explain routing by session visibility.
 
@@ -383,18 +447,23 @@
             ((symbol-function 'mcp-emacs-run-send-prompt) (lambda (&rest _) (push 'tui fired)))
             ((symbol-function 'mcp-emacs-popup-show) (lambda (&rest _) (push 'popup fired)))
             ((symbol-function 'mcp-emacs-run--query-headless) (lambda (&rest _) (push 'headless fired))))
-    ;; Visible session -> TUI only.
-    (cl-letf (((symbol-function 'mcp-emacs-run--session-visible-p) (lambda (_) t)))
-      (setq fired nil)
-      (mcp-emacs-explain-selection-in-current-session)
-      (check "explain-visible-routes-tui" (reverse fired) '(tui)))
-    ;; Hidden session -> popup placeholder + headless.
-    (cl-letf (((symbol-function 'mcp-emacs-run--session-visible-p) (lambda (_) nil)))
-      (setq fired nil)
-      (mcp-emacs-explain-selection-in-current-session)
-      (check "explain-hidden-routes-popup" (reverse fired) '(popup headless)))
-    ;; No session -> headless popup (no error, no TUI).
-    (cl-letf (((symbol-function 'mcp-emacs-run--session-visible-p) (lambda (_) nil)))
-      (setq fired nil)
-      (mcp-emacs-explain-selection-in-current-session)
-      (check "explain-no-session-routes-popup" (reverse fired) '(popup headless)))))
+    (describe "mcp-emacs-explain-selection-in-current-session"
+      (cl-letf (((symbol-function 'mcp-emacs-run--session-visible-p) (lambda (_) t)))
+        (setq fired nil)
+        (mcp-emacs-explain-selection-in-current-session)
+        (it "routes to the TUI only when a session is visible"
+          (check (reverse fired) '(tui))))
+      (cl-letf (((symbol-function 'mcp-emacs-run--session-visible-p) (lambda (_) nil)))
+        (setq fired nil)
+        (mcp-emacs-explain-selection-in-current-session)
+        (it "shows a popup placeholder and queries headless when the session is hidden"
+          (check (reverse fired) '(popup headless))))
+      (cl-letf (((symbol-function 'mcp-emacs-run--session-visible-p) (lambda (_) nil)))
+        (setq fired nil)
+        (mcp-emacs-explain-selection-in-current-session)
+        (it "falls back to the headless popup with no session, without erroring"
+          (check (reverse fired) '(popup headless)))))))
+
+(test-helper-summary)
+
+;;; mcp-emacs-run-test.el ends here

--- a/test/mcp-emacs-server-async-test.el
+++ b/test/mcp-emacs-server-async-test.el
@@ -7,6 +7,8 @@
 ;; web-server, no live ediff.
 
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'json)
 (require 'cl-lib)
 (require 'mcp-emacs)
@@ -19,8 +21,6 @@
   (defun ws-stop (&rest _) nil)
   (provide 'web-server))
 (require 'mcp-emacs-server)
-
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
 
 (defun mcp-srv--text (response)
   "Return the text payload of a JSON-RPC RESPONSE object built by the server."
@@ -35,92 +35,111 @@
 
 ;;;; Registry
 
-;; apply_diff is the human-answered review, so it must carry an async handler
-;; while keeping its synchronous one as a direct-dispatch fallback.
-(let ((tool (mcp-emacs-server--find-tool "apply_diff")))
-  (check "apply-diff-has-async" (functionp (plist-get tool :async-handler)) t)
-  (check "apply-diff-keeps-sync" (functionp (plist-get tool :handler)) t))
+(describe "mcp-emacs-server--find-tool"
+  ;; apply_diff is the human-answered review, so it must carry an async handler
+  ;; while keeping its synchronous one as a direct-dispatch fallback.
+  (let ((tool (mcp-emacs-server--find-tool "apply_diff")))
+    (it "gives the human-answered apply_diff an async handler"
+      (check-that (functionp (plist-get tool :async-handler))))
+    (it "keeps apply_diff's synchronous handler as a direct-dispatch fallback"
+      (check-that (functionp (plist-get tool :handler)))))
 
-;; Ordinary tools must stay synchronous: deferring them would hold a
-;; connection open for a reply that is already available.
-(let ((tool (mcp-emacs-server--find-tool "project_info")))
-  (check "sync-tool-has-no-async" (plist-get tool :async-handler) nil))
+  ;; Ordinary tools must stay synchronous: deferring them would hold a
+  ;; connection open for a reply that is already available.
+  (let ((tool (mcp-emacs-server--find-tool "project_info")))
+    (it "leaves an ordinary tool without an async handler"
+      (check (plist-get tool :async-handler) nil))))
 
 ;;;; Deferral
 
-;; An async tool returns non-nil (the call was started) and does NOT answer
-;; synchronously -- that is the whole point of the path.
-(let* ((sent nil)
-       (tool (list :name "fake_async"
-                   :async-handler (lambda (_args done)
-                                    (setq mcp-srv-test--done done))))
-       (mcp-emacs-server-extra-tools (list tool)))
-  (defvar mcp-srv-test--done nil)
-  (setq mcp-srv-test--done nil)
-  (let ((started (mcp-emacs-server--tools-call-async
-                  (list (cons 'name "fake_async") (cons 'arguments nil))
-                  42
-                  (lambda (response) (push response sent)))))
-    (check "async-call-started" started t)
-    (check "async-no-immediate-response" sent nil)
-    ;; Resolving the tool writes the response, carrying the original id.
-    (funcall mcp-srv-test--done "Status: applied\nnew\n")
-    (check "async-response-sent" (length sent) 1)
-    (check "async-response-id" (mcp-srv--id (car sent)) 42)
-    (check "async-response-text"
-           (mcp-srv--text (car sent)) "Status: applied\nnew\n")))
+(describe "mcp-emacs-server--tools-call-async with an async tool"
+  (let* ((sent nil)
+         (tool (list :name "fake_async"
+                     :async-handler (lambda (_args done)
+                                      (setq mcp-srv-test--done done))))
+         (mcp-emacs-server-extra-tools (list tool)))
+    (defvar mcp-srv-test--done nil)
+    (setq mcp-srv-test--done nil)
+    (let ((started (mcp-emacs-server--tools-call-async
+                    (list (cons 'name "fake_async") (cons 'arguments nil))
+                    42
+                    (lambda (response) (push response sent)))))
+      (it "reports that the call was started"
+        (check started t))
+      (it "does not answer synchronously"
+        (check sent nil))
+      ;; Resolving the tool writes the response, carrying the original id.
+      (funcall mcp-srv-test--done "Status: applied\nnew\n")
+      (it "writes exactly one response once the tool resolves"
+        (check (length sent) 1))
+      (it "carries the original request id into the deferred response"
+        (check (mcp-srv--id (car sent)) 42))
+      (it "passes the tool's text through to the deferred response"
+        (check (mcp-srv--text (car sent)) "Status: applied\nnew\n")))))
 
-;; A synchronous tool must report "not handled" so the caller falls through
-;; to the normal dispatch path instead of hanging.
-(let ((sent nil))
-  (let ((started (mcp-emacs-server--tools-call-async
-                  (list (cons 'name "project_info") (cons 'arguments nil))
-                  7
-                  (lambda (response) (push response sent)))))
-    (check "sync-tool-not-deferred" started nil)
-    (check "sync-tool-no-response" sent nil)))
+(describe "mcp-emacs-server--tools-call-async with a synchronous tool"
+  ;; A synchronous tool must report "not handled" so the caller falls through
+  ;; to the normal dispatch path instead of hanging.
+  (let ((sent nil))
+    (let ((started (mcp-emacs-server--tools-call-async
+                    (list (cons 'name "project_info") (cons 'arguments nil))
+                    7
+                    (lambda (response) (push response sent)))))
+      (it "reports not handled so the caller falls through to normal dispatch"
+        (check started nil))
+      (it "writes no response of its own"
+        (check sent nil)))))
 
-;; An unknown tool is likewise not deferred: it must reach normal dispatch,
-;; which turns it into a JSON-RPC error rather than an open connection.
-(let ((sent nil))
-  (let ((started (mcp-emacs-server--tools-call-async
-                  (list (cons 'name "no_such_tool") (cons 'arguments nil))
-                  8
-                  (lambda (response) (push response sent)))))
-    (check "unknown-tool-not-deferred" started nil)
-    (check "unknown-tool-no-response" sent nil)))
+(describe "mcp-emacs-server--tools-call-async with an unknown tool"
+  ;; An unknown tool is likewise not deferred: it must reach normal dispatch,
+  ;; which turns it into a JSON-RPC error rather than an open connection.
+  (let ((sent nil))
+    (let ((started (mcp-emacs-server--tools-call-async
+                    (list (cons 'name "no_such_tool") (cons 'arguments nil))
+                    8
+                    (lambda (response) (push response sent)))))
+      (it "does not defer, so the call reaches normal dispatch and errors there"
+        (check started nil))
+      (it "leaves the connection unanswered rather than holding it open"
+        (check sent nil)))))
 
-;; The deferred response is a well-formed JSON-RPC success object, since it
-;; is written straight to the socket without going through `--dispatch'.
-(let* ((sent nil)
-       (tool (list :name "fake_async2"
-                   :async-handler (lambda (_args done)
-                                    (funcall done "Status: rejected"))))
-       (mcp-emacs-server-extra-tools (list tool)))
-  (mcp-emacs-server--tools-call-async
-   (list (cons 'name "fake_async2") (cons 'arguments nil))
-   99
-   (lambda (response) (push response sent)))
-  (let* ((response (car sent))
-         (encoded (json-encode response)))
-    (check "deferred-has-jsonrpc" (cdr (assoc "jsonrpc" response)) "2.0")
-    (check "deferred-text" (mcp-srv--text response) "Status: rejected")
-    ;; Round-trips through json-encode without error.
-    (check "deferred-encodes" (stringp encoded) t)))
+(describe "the deferred response object"
+  ;; The deferred response is a well-formed JSON-RPC success object, since it
+  ;; is written straight to the socket without going through `--dispatch'.
+  (let* ((sent nil)
+         (tool (list :name "fake_async2"
+                     :async-handler (lambda (_args done)
+                                      (funcall done "Status: rejected"))))
+         (mcp-emacs-server-extra-tools (list tool)))
+    (mcp-emacs-server--tools-call-async
+     (list (cons 'name "fake_async2") (cons 'arguments nil))
+     99
+     (lambda (response) (push response sent)))
+    (let* ((response (car sent))
+           (encoded (json-encode response)))
+      (it "is tagged as JSON-RPC 2.0 even though it skips `--dispatch'"
+        (check (cdr (assoc "jsonrpc" response)) "2.0"))
+      (it "wraps the tool's text as its content payload"
+        (check (mcp-srv--text response) "Status: rejected"))
+      (it "round-trips through `json-encode' without error"
+        (check-that (stringp encoded))))))
 
-;; Arguments reach the async handler unchanged.
-(let* ((seen nil)
-       (tool (list :name "fake_async3"
-                   :async-handler (lambda (args done)
-                                    (setq seen args)
-                                    (funcall done "ok"))))
-       (mcp-emacs-server-extra-tools (list tool)))
-  (mcp-emacs-server--tools-call-async
-   (list (cons 'name "fake_async3")
-         (cons 'arguments (list (cons 'path "/tmp/x") (cons 'timeout 30))))
-   1 (lambda (_r) nil))
-  (check "async-args-passed-path" (alist-get 'path seen) "/tmp/x")
-  (check "async-args-passed-timeout" (alist-get 'timeout seen) 30))
+(describe "async handler arguments"
+  (let* ((seen nil)
+         (tool (list :name "fake_async3"
+                     :async-handler (lambda (args done)
+                                      (setq seen args)
+                                      (funcall done "ok"))))
+         (mcp-emacs-server-extra-tools (list tool)))
+    (mcp-emacs-server--tools-call-async
+     (list (cons 'name "fake_async3")
+           (cons 'arguments (list (cons 'path "/tmp/x") (cons 'timeout 30))))
+     1 (lambda (_r) nil))
+    (it "reaches the handler with string arguments unchanged"
+      (check (alist-get 'path seen) "/tmp/x"))
+    (it "reaches the handler with numeric arguments unchanged"
+      (check (alist-get 'timeout seen) 30))))
+
 ;;;; Body decoding (UTF-8)
 ;; web-server reads the socket with :coding no-conversion, so the body slot
 ;; holds raw UTF-8 bytes; parse-body must decode them so non-ASCII survives
@@ -130,20 +149,27 @@
 (require (quote eieio))
 (defclass mcp-srv-test--request () ((body :initarg :body)))
 
-;; A UTF-8 em dash (U+2014) inside the raw body decodes to one character.
-(let* ((raw-em-dash (string #x3FFFE2 #x3FFF80 #x3FFF94))
-       (request (make-instance
-                 (quote mcp-srv-test--request)
-                 :body (format "{%c%s%c:%c%s%c}" 34 "text" 34 34 raw-em-dash 34)))
-       (parsed (mcp-emacs-server--parse-body request))
-       (text (alist-get (quote text) parsed)))
-  (check "body-decodes-em-dash" (string= text (string #x2014)) t)
-  (check "body-em-dash-single-char" (length text) 1))
+(describe "mcp-emacs-server--parse-body"
+  ;; A UTF-8 em dash (U+2014) inside the raw body decodes to one character.
+  (let* ((raw-em-dash (string #x3FFFE2 #x3FFF80 #x3FFF94))
+         (request (make-instance
+                   (quote mcp-srv-test--request)
+                   :body (format "{%c%s%c:%c%s%c}" 34 "text" 34 34 raw-em-dash 34)))
+         (parsed (mcp-emacs-server--parse-body request))
+         (text (alist-get (quote text) parsed)))
+    (it "decodes raw UTF-8 bytes back into the em dash they encode"
+      (check-that (string= text (string #x2014))))
+    (it "yields one character for the em dash rather than three bytes"
+      (check (length text) 1)))
 
-;; Pure-ASCII bodies are unaffected.
-(let* ((request (make-instance
-                 (quote mcp-srv-test--request)
-                 :body (format "{%c%s%c:%c%s%c}" 34 "method" 34 34 "ping" 34)))
-       (parsed (mcp-emacs-server--parse-body request)))
-  (check "body-ascii-method" (alist-get (quote method) parsed) "ping"))
+  ;; Pure-ASCII bodies are unaffected.
+  (let* ((request (make-instance
+                   (quote mcp-srv-test--request)
+                   :body (format "{%c%s%c:%c%s%c}" 34 "method" 34 34 "ping" 34)))
+         (parsed (mcp-emacs-server--parse-body request)))
+    (it "leaves a pure-ASCII body unchanged"
+      (check (alist-get (quote method) parsed) "ping"))))
 
+(test-helper-summary)
+
+;;; mcp-emacs-server-async-test.el ends here

--- a/test/opencode-client-sse-test.el
+++ b/test/opencode-client-sse-test.el
@@ -1,8 +1,10 @@
+;;; opencode-client-sse-test.el --- Tests for the opencode SSE client -*- lexical-binding: t; -*-
+
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'cl-lib)
 (require 'opencode-client)
-(defun check (label got want)
-  (princ (format "%s %s: got=%S want=%S\n" (if (equal got want) "PASS" "FAIL") label got want)))
 (defun mk (seq part)
   (json-encode `((type . "sync") (syncEvent . ((type . "message.part.updated.1") (seq . ,seq) (data . ((part . ,part))))))))
 (defun new-backend ()
@@ -18,32 +20,42 @@
         (f2 (mk 2 '((id . "p1") (messageID . "m") (type . "text") (text . "Hello world"))))
         (f3 (mk 3 '((id . "p2") (messageID . "m") (type . "tool") (tool . "read") (state . ((status . "completed"))))))
         (stale (mk 1 '((id . "p1") (type . "text") (text . "STALE")))))
-    (let* ((payload (concat "data: " f1 "\n\n")) (m (/ (length payload) 2)))
-      (opencode-client--stream-filter buf nil (substring payload 0 m))
-      (check "partial-no-apply" (hash-table-count (oref backend parts)) 0)
-      (opencode-client--stream-filter buf nil (substring payload m)))
-    (check "after-f1-parts" (hash-table-count (oref backend parts)) 1)
-    (opencode-client--stream-filter buf nil (concat "data: " f2 "\n\ndata: " f3 "\n\n"))
-    (check "after-f2f3-parts" (hash-table-count (oref backend parts)) 2)
-    (check "seq" (oref backend seq) 3)
-    (check "p1-upserted" (alist-get 'text (gethash "p1" (oref backend parts))) "Hello world")
-    (opencode-client--stream-filter buf nil (concat "data: " stale "\n\n"))
-    (check "stale-text" (alist-get 'text (gethash "p1" (oref backend parts))) "Hello world")
-    (check "stale-seq" (oref backend seq) 3)
+    (describe "opencode-client--stream-filter"
+      (let* ((payload (concat "data: " f1 "\n\n")) (m (/ (length payload) 2)))
+        (opencode-client--stream-filter buf nil (substring payload 0 m))
+        (it "applies nothing until an event's terminating blank line arrives"
+          (check (hash-table-count (oref backend parts)) 0))
+        (opencode-client--stream-filter buf nil (substring payload m)))
+      (it "upserts the part once the split event is complete"
+        (check (hash-table-count (oref backend parts)) 1))
+      (opencode-client--stream-filter buf nil (concat "data: " f2 "\n\ndata: " f3 "\n\n"))
+      (it "handles several events in one chunk, adding the new part"
+        (check (hash-table-count (oref backend parts)) 2))
+      (it "tracks the highest sequence number seen"
+        (check (oref backend seq) 3))
+      (it "replaces an existing part's text when its id repeats"
+        (check (alist-get 'text (gethash "p1" (oref backend parts))) "Hello world"))
+      (opencode-client--stream-filter buf nil (concat "data: " stale "\n\n"))
+      (it "ignores an out-of-order event rather than overwriting newer text"
+        (check (alist-get 'text (gethash "p1" (oref backend parts))) "Hello world"))
+      (it "leaves the sequence number alone for a stale event"
+        (check (oref backend seq) 3)))
     (opencode-client--render)
     (princ "=== buffer ===\n") (princ (buffer-string))))
 
 ;; Response envelope unwrapping (opencode 1.18.0 wraps most responses in `data').
-(check "unwrap-object"
-       (opencode-client--unwrap '((data . ((id . "ses_1") (title . "t")))))
-       '((id . "ses_1") (title . "t")))
-(check "unwrap-list"
-       (opencode-client--unwrap '((data . (((id . "a")) ((id . "b")))) (cursor . "c")))
-       '(((id . "a")) ((id . "b"))))
-(check "unwrap-flat-health"
-       (opencode-client--unwrap '((healthy . t)))
-       '((healthy . t)))
-(check "unwrap-nil" (opencode-client--unwrap nil) nil)
+(describe "opencode-client--unwrap"
+  (it "unwraps a `data'-wrapped object"
+    (check (opencode-client--unwrap '((data . ((id . "ses_1") (title . "t")))))
+           '((id . "ses_1") (title . "t"))))
+  (it "unwraps a `data'-wrapped list, dropping the cursor"
+    (check (opencode-client--unwrap '((data . (((id . "a")) ((id . "b")))) (cursor . "c")))
+           '(((id . "a")) ((id . "b")))))
+  (it "passes an unwrapped response through untouched"
+    (check (opencode-client--unwrap '((healthy . t)))
+           '((healthy . t))))
+  (it "returns nil for an empty response"
+    (check (opencode-client--unwrap nil) nil)))
 
 ;; History seeding: adapt a canned history payload into the render model.
 (with-temp-buffer
@@ -60,62 +72,69 @@
     (oset backend session-id "ses_x")
     (cl-letf (((symbol-function 'opencode-client--request)
                (lambda (&rest _) history)))
-      (opencode-client--seed-history backend)
-      (check "seed-messages-order" (oref backend messages) '("m1" "m2"))
-      (check "seed-user-text"
-             (alist-get 'text (gethash "m1:text" (oref backend parts))) "Hi there")
-      (check "seed-tool-name-mapped"
-             (alist-get 'tool (gethash "p3" (oref backend parts))) "read")
-      (opencode-client--render)
-      (check "seed-render"
-             (buffer-string)
-             "Hi there\nHello\n  · thinking\n  [tool: read completed]\n"))))
+      (describe "opencode-client--seed-history"
+        (opencode-client--seed-history backend)
+        (it "records the messages in the order the history gave them"
+          (check (oref backend messages) '("m1" "m2")))
+        (it "adapts a user message into a synthetic text part"
+          (check (alist-get 'text (gethash "m1:text" (oref backend parts))) "Hi there"))
+        (it "maps a history tool part's `name' onto the render model's `tool'"
+          (check (alist-get 'tool (gethash "p3" (oref backend parts))) "read"))
+        (opencode-client--render)
+        (it "renders the seeded history as text, reasoning and tool lines"
+          (check (buffer-string)
+                 "Hi there\nHello\n  · thinking\n  [tool: read completed]\n"))))))
 
-;; Empty history seeds nothing.
 (with-temp-buffer
   (opencode-client-mode)
   (let ((backend (new-backend)))
     (oset backend session-id "ses_empty")
     (cl-letf (((symbol-function 'opencode-client--request) (lambda (&rest _) nil)))
-      (opencode-client--seed-history backend)
-      (opencode-client--render)
-      (check "seed-empty-messages" (oref backend messages) nil)
-      (check "seed-empty-render" (buffer-string) ""))))
+      (describe "opencode-client--seed-history with an empty history"
+        (opencode-client--seed-history backend)
+        (opencode-client--render)
+        (it "seeds no messages"
+          (check (oref backend messages) nil))
+        (it "renders an empty buffer"
+          (check (buffer-string) ""))))))
 
 ;; Password resolution precedence and header emission.
-(let ((opencode-client-password "direct")
-      (opencode-client-password-command "echo should-not-run"))
-  (check "pw-direct-wins" (opencode-client--password) "direct"))
+(describe "opencode-client--password"
+  (let ((opencode-client-password "direct")
+        (opencode-client-password-command "echo should-not-run"))
+    (it "prefers a directly configured password over the command"
+      (check (opencode-client--password) "direct")))
 
-(let ((opencode-client-password nil)
-      (opencode-client-password-command "printf '  cmdpw\n'"))
-  (check "pw-from-command-trimmed" (opencode-client--password) "cmdpw"))
+  (let ((opencode-client-password nil)
+        (opencode-client-password-command "printf '  cmdpw\n'"))
+    (it "trims whitespace off the password command's output"
+      (check (opencode-client--password) "cmdpw")))
 
-(let ((opencode-client-password nil)
-      (opencode-client-password-command "printf ''"))
-  (check "pw-empty-command-nil" (opencode-client--password) nil))
+  (let ((opencode-client-password nil)
+        (opencode-client-password-command "printf ''"))
+    (it "returns nil when the password command prints nothing"
+      (check (opencode-client--password) nil)))
 
-(let ((opencode-client-password nil)
-      (opencode-client-password-command nil))
-  (check "pw-none-nil" (opencode-client--password) nil))
+  (let ((opencode-client-password nil)
+        (opencode-client-password-command nil))
+    (it "returns nil when neither password nor command is configured"
+      (check (opencode-client--password) nil))))
 
-(let ((opencode-client-password "s3cret")
-      (opencode-client-password-command nil))
-  (check "headers-auth-present"
-         (assoc "Authorization" (opencode-client--headers))
-         (cons "Authorization"
-               (concat "Basic " (base64-encode-string "opencode:s3cret" t)))))
+(describe "opencode-client--headers"
+  (let ((opencode-client-password "s3cret")
+        (opencode-client-password-command nil))
+    (it "emits basic auth for the opencode user when a password exists"
+      (check (assoc "Authorization" (opencode-client--headers))
+             (cons "Authorization"
+                   (concat "Basic " (base64-encode-string "opencode:s3cret" t))))))
 
-(let ((opencode-client-password nil)
-      (opencode-client-password-command nil))
-  (check "headers-auth-absent"
-         (assoc "Authorization" (opencode-client--headers)) nil))
+  (let ((opencode-client-password nil)
+        (opencode-client-password-command nil))
+    (it "omits the Authorization header when there is no password"
+      (check (assoc "Authorization" (opencode-client--headers)) nil))))
 
 ;;;; Shared event vocabulary (agent-backend port)
 
-;; A text part in the SSE stream is published as a `:text' event on the
-;; shared hook; a tool part becomes `:tool-use'.  Unknown part types are
-;; silent (the vocabulary's "ignore unknown kinds" contract).
 (with-temp-buffer
   (opencode-client-mode)
   (let ((backend (new-backend))
@@ -123,14 +142,15 @@
         (buf (current-buffer)))
     (add-hook 'agent-backend-event-functions
               (lambda (b ev) (push (cons b (plist-get ev :kind)) seen)))
-    (opencode-client--publish-part buf '((type . "text") (text . "hi there")))
-    (opencode-client--publish-part buf '((type . "tool") (tool . "read") (state . ((status . "completed")))))
-    (opencode-client--publish-part buf '((type . "reasoning") (text . "skip me")))
-    (check "publish-text-kind" (mapcar #'cdr seen) '(tool-use text))
-    (check "publish-text-buffer" (caar seen) buf)))
+    (describe "opencode-client--publish-part"
+      (opencode-client--publish-part buf '((type . "text") (text . "hi there")))
+      (opencode-client--publish-part buf '((type . "tool") (tool . "read") (state . ((status . "completed")))))
+      (opencode-client--publish-part buf '((type . "reasoning") (text . "skip me")))
+      (it "publishes text as `text' and tool as `tool-use', staying silent on unknown kinds"
+        (check (mapcar #'cdr seen) '(tool-use text)))
+      (it "publishes the event against the backend's buffer"
+        (check (caar seen) buf)))))
 
-;; A note is a steering prompt: delivery "steer", and a `:note' event
-;; on the shared hook.
 (with-temp-buffer
   (opencode-client-mode)
   (let ((backend (new-backend))
@@ -144,22 +164,25 @@
                  nil)))
       (add-hook 'agent-backend-event-functions
                 (lambda (_b ev) (push ev seen)))
-      (agent-backend-add-note backend "  steer me  ")
-      (check "note-trimmed" (alist-get 'text (cdr (assq 'prompt (caddr sent)))) "steer me")
-      (check "note-delivery-steer" (alist-get 'delivery (caddr sent)) "steer")
-      (check "note-event" (plist-get (car seen) :kind) 'note))))
+      (describe "agent-backend-add-note"
+        (agent-backend-add-note backend "  steer me  ")
+        (it "trims the note text before sending it as the prompt"
+          (check (alist-get 'text (cdr (assq 'prompt (caddr sent)))) "steer me"))
+        (it "delivers a note as a steering prompt"
+          (check (alist-get 'delivery (caddr sent)) "steer"))
+        (it "publishes a `note' event on the shared hook"
+          (check (plist-get (car seen) :kind) 'note))))))
 
-;; The note-policy of the opencode backend is `:steer' (notes ARE
-;; steering prompts), and the session id is what drives the HTTP call.
 (with-temp-buffer
   (opencode-client-mode)
   (let ((backend (new-backend)))
     (oset backend session-id "ses9")
-    (check "note-policy-steer" (agent-backend-note-policy backend) :steer)
-    (check "project-root-nil" (agent-backend-project-root backend) nil)))
+    (describe "the opencode backend's shared-surface metadata"
+      (it "declares a `:steer' note policy, since notes are steering prompts"
+        (check (agent-backend-note-policy backend) :steer))
+      (it "has no project root, as the session id drives the HTTP call instead"
+        (check (agent-backend-project-root backend) nil)))))
 
-;; Sending a prompt posts delivery "queue" (a normal turn, not a note)
-;; and publishes a `:prompt' event.
 (with-temp-buffer
   (opencode-client-mode)
   (let ((backend (new-backend))
@@ -173,15 +196,16 @@
                  nil)))
       (add-hook 'agent-backend-event-functions
                 (lambda (_b ev) (push ev seen)))
-      (agent-backend-send backend "hello")
-      (check "send-delivery-queue" (alist-get 'delivery (caddr sent)) "queue")
-      (check "send-event" (plist-get (car seen) :kind) 'prompt))))
+      (describe "agent-backend-send"
+        (agent-backend-send backend "hello")
+        (it "queues a prompt as a normal turn rather than steering"
+          (check (alist-get 'delivery (caddr sent)) "queue"))
+        (it "publishes a `prompt' event on the shared hook"
+          (check (plist-get (car seen) :kind) 'prompt))))))
 
 
 ;;;; Permission and question replies
 
-;; The shared reply methods hit the opencode endpoints with the
-;; backend's session id.
 (with-temp-buffer
   (opencode-client-mode)
   (let ((backend (new-backend))
@@ -189,24 +213,23 @@
     (oset backend session-id "ses3")
     (cl-letf (((symbol-function 'opencode-client--request)
                (lambda (&rest args) (setq sent args) nil)))
-      (agent-backend-reply-permission backend "req-1" "allow")
-      (check "permission-path"
-             (cadr sent)
-             "/api/session/ses3/permission/req-1/reply")
-      (check "permission-decision"
-             (alist-get 'decision (caddr sent)) "allow"))
+      (describe "agent-backend-reply-permission"
+        (agent-backend-reply-permission backend "req-1" "allow")
+        (it "posts to the permission reply endpoint for the backend's session"
+          (check (cadr sent) "/api/session/ses3/permission/req-1/reply"))
+        (it "sends the decision in the body"
+          (check (alist-get 'decision (caddr sent)) "allow"))))
     (cl-letf (((symbol-function 'opencode-client--request)
                (lambda (&rest args) (setq sent args) nil)))
-      (agent-backend-reply-question backend "req-2" "42")
-      (check "question-path"
-             (cadr sent)
-             "/api/session/ses3/question/req-2/reply")
-      (check "question-answer"
-             (alist-get 'answer (caddr sent)) "42"))))
+      (describe "agent-backend-reply-question"
+        (agent-backend-reply-question backend "req-2" "42")
+        (it "posts to the question reply endpoint for the backend's session"
+          (check (cadr sent) "/api/session/ses3/question/req-2/reply"))
+        (it "sends the answer in the body"
+          (check (alist-get 'answer (caddr sent)) "42"))))))
 
 ;;;; Sessions on the shared surface
 
-;; `agent-backend-list-sessions' returns (:id :label :time) plists.
 (with-temp-buffer
   (opencode-client-mode)
   (let ((backend (new-backend)))
@@ -215,28 +238,32 @@
                  (list (list (cons 'id "a") (cons 'title "Alpha")
                              (cons 'time "2026-01-01"))
                        (list (cons 'id "b"))))))
-      (let ((sessions (agent-backend-list-sessions backend)))
-        (check "sessions-first-id" (plist-get (car sessions) :id) "a")
-        (check "sessions-first-label" (plist-get (car sessions) :label) "Alpha")
-        (check "sessions-first-time" (plist-get (car sessions) :time) "2026-01-01")
-        (check "sessions-second-id" (plist-get (cadr sessions) :id) "b")
-        (check "sessions-second-label-fallback" (plist-get (cadr sessions) :label) "b")))))
+      (describe "agent-backend-list-sessions"
+        (let ((sessions (agent-backend-list-sessions backend)))
+          (it "carries the session id through as `:id'"
+            (check (plist-get (car sessions) :id) "a"))
+          (it "uses the session title as `:label'"
+            (check (plist-get (car sessions) :label) "Alpha"))
+          (it "carries the session time through as `:time'"
+            (check (plist-get (car sessions) :time) "2026-01-01"))
+          (it "converts every session in the list"
+            (check (plist-get (cadr sessions) :id) "b"))
+          (it "falls back to the id as label for an untitled session"
+            (check (plist-get (cadr sessions) :label) "b")))))))
 
-;; Resume is not natively supported: it signals a user-error that names
-;; the alternative (switch-session), rather than silently doing nothing.
 (with-temp-buffer
   (opencode-client-mode)
   (let ((backend (new-backend)))
     (oset backend session-id "ses4")
-    (let ((err (condition-case e
-                   (agent-backend-resume backend "ses4")
-                 (user-error (error-message-string e)))))
-      (check "resume-errors"
-             (and (stringp err)
-                  (numberp (string-match-p "switch-session" err)))
-             t))))
+    (describe "agent-backend-resume"
+      (let ((err (condition-case e
+                     (agent-backend-resume backend "ses4")
+                   (user-error (error-message-string e)))))
+        (it "signals a user-error naming switch-session, since resume is unsupported"
+          (check (and (stringp err)
+                      (numberp (string-match-p "switch-session" err)))
+                 t))))))
 
-;; Interrupt posts to the interrupt endpoint and publishes `interrupted'.
 (with-temp-buffer
   (opencode-client-mode)
   (let ((backend (new-backend))
@@ -248,76 +275,91 @@
                (lambda (&rest args) (setq sent args) nil)))
       (add-hook 'agent-backend-event-functions
                 (lambda (_b ev) (push ev seen)))
-      (agent-backend-interrupt backend)
-      (check "interrupt-path" (cadr sent) "/api/session/ses5/interrupt")
-      (check "interrupt-event" (plist-get (car seen) :kind) 'interrupted))))
+      (describe "agent-backend-interrupt"
+        (agent-backend-interrupt backend)
+        (it "posts to the session's interrupt endpoint"
+          (check (cadr sent) "/api/session/ses5/interrupt"))
+        (it "publishes an `interrupted' event on the shared hook"
+          (check (plist-get (car seen) :kind) 'interrupted))))))
 
-;; Quit stops the stream process of the backend's buffer, if any.
 (with-temp-buffer
   (opencode-client-mode)
   (let ((backend (new-backend))
         (killed nil))
-    (let ((proc (start-process "fake-sse" nil "sleep" "10")))
-      (oset backend stream-process proc)
-      (cl-letf (((symbol-function 'delete-process)
-                 (lambda (p) (setq killed p))))
-        (agent-backend-quit backend))
-      (check "quit-kills-stream" (eq killed proc) t))
-    (check "quit-sets-nil" (oref backend stream-process) nil)))
+    (describe "agent-backend-quit"
+      (let ((proc (start-process "fake-sse" nil "sleep" "10")))
+        (oset backend stream-process proc)
+        (cl-letf (((symbol-function 'delete-process)
+                   (lambda (p) (setq killed p))))
+          (agent-backend-quit backend))
+        (it "stops the stream process of the backend's buffer"
+          (check (eq killed proc) t)))
+      (it "forgets the stream process afterwards"
+        (check (oref backend stream-process) nil)))))
 
 ;;;; Per-project parallel servers (multiple ports)
 
-;; The base URL follows the instance's own host/port when set, else the defaults.
-(let ((b (make-instance 'opencode-client-backend :host "127.0.0.1" :port 5001)))
-  (check "base-url-instance-port" (opencode-client--base-url b) "http://127.0.0.1:5001")
-  (check "base-url-instance-host" (string-match-p "127.0.0.1:5001" (opencode-client--base-url b)) 7))
-(let ((b (make-instance 'opencode-client-backend)))
-  (check "base-url-default" (opencode-client--base-url b)
-         (format "http://%s:%d" opencode-client-host opencode-client-port)))
+(describe "opencode-client--base-url"
+  (let ((b (make-instance 'opencode-client-backend :host "127.0.0.1" :port 5001)))
+    (it "follows the instance's own host and port when set"
+      (check (opencode-client--base-url b) "http://127.0.0.1:5001"))
+    (it "puts the instance's host:port where a URL authority belongs"
+      (check (string-match-p "127.0.0.1:5001" (opencode-client--base-url b)) 7)))
+  (let ((b (make-instance 'opencode-client-backend)))
+    (it "falls back to the configured defaults when the instance has none"
+      (check (opencode-client--base-url b)
+             (format "http://%s:%d" opencode-client-host opencode-client-port)))))
 
-;; free-port probes upward from the configured port and skips taken ports.
-(cl-letf (((symbol-function 'make-network-process)
-           (lambda (&rest args)
-             (let ((port (plist-get args :service)))
-               (when (eq port opencode-client-port)
-                 (error "port %d taken" port)))
-             (make-symbol "fake-sock")))
-          ((symbol-function 'get-process) (lambda (_name) nil))
-          ((symbol-function 'delete-process) (lambda (_proc) nil)))
-  (let ((opencode-client-port 4096))
-    (check "free-port-skips-taken" (opencode-client--free-port) 4097)))
+(describe "opencode-client--free-port"
+  (cl-letf (((symbol-function 'make-network-process)
+             (lambda (&rest args)
+               (let ((port (plist-get args :service)))
+                 (when (eq port opencode-client-port)
+                   (error "port %d taken" port)))
+               (make-symbol "fake-sock")))
+            ((symbol-function 'get-process) (lambda (_name) nil))
+            ((symbol-function 'delete-process) (lambda (_proc) nil)))
+    (let ((opencode-client-port 4096))
+      (it "probes upward from the configured port and skips a taken one"
+        (check (opencode-client--free-port) 4097)))))
 
-;; ensure-server starts one server per project and reuses it: the
-;; serve stub registers under the project dir, so a second ensure for the
-;; same project returns the same instance instead of starting another.
-(cl-letf (((symbol-function 'opencode-client-serve)
-           (lambda ()
-             (let ((b (make-instance 'opencode-client-backend :port 5002)))
-               (setq opencode-client--servers
-                     (cons (cons (expand-file-name default-directory) b)
-                           opencode-client--servers))
-               b)))
-          ((symbol-function 'expand-file-name) (lambda (d) (concat "/proj/" d))))
-  (let ((opencode-client--servers nil))
-    (let ((b1 (opencode-client--ensure-server)))
-      (check "ensure-server-first" (oref b1 port) 5002)
-      (let ((b2 (opencode-client--ensure-server)))
-        (check "ensure-server-reuses" (eq b1 b2) t))
-      (check "registry-length" (length opencode-client--servers) 1))))
+(describe "opencode-client--ensure-server"
+  (cl-letf (((symbol-function 'opencode-client-serve)
+             (lambda ()
+               (let ((b (make-instance 'opencode-client-backend :port 5002)))
+                 (setq opencode-client--servers
+                       (cons (cons (expand-file-name default-directory) b)
+                             opencode-client--servers))
+                 b)))
+            ((symbol-function 'expand-file-name) (lambda (d) (concat "/proj/" d))))
+    (let ((opencode-client--servers nil))
+      (let ((b1 (opencode-client--ensure-server)))
+        (it "starts a server for a project that has none"
+          (check (oref b1 port) 5002))
+        (let ((b2 (opencode-client--ensure-server)))
+          (it "reuses the running server for the same project"
+            (check (eq b1 b2) t)))
+        (it "registers the project's server exactly once"
+          (check (length opencode-client--servers) 1)))))
 
-;; Different projects get different servers (parallel sessions).
-(cl-letf (((symbol-function 'opencode-client-serve)
-           (lambda ()
-             (let ((b (make-instance 'opencode-client-backend :port 5002)))
-               (setq opencode-client--servers
-                     (cons (cons (expand-file-name default-directory) b)
-                           opencode-client--servers))
-               b)))
-          ((symbol-function 'expand-file-name) (lambda (d) (concat "/proj/" d))))
-  (let ((opencode-client--servers nil)
-        (default-directory "/proj/one"))
-    (let ((b1 (opencode-client--ensure-server)))
-      (setq default-directory "/proj/two")
-      (let ((b2 (opencode-client--ensure-server)))
-        (check "parallel-projects-distinct" (eq b1 b2) nil)
-        (check "parallel-projects-two-servers" (length opencode-client--servers) 2)))))
+  (cl-letf (((symbol-function 'opencode-client-serve)
+             (lambda ()
+               (let ((b (make-instance 'opencode-client-backend :port 5002)))
+                 (setq opencode-client--servers
+                       (cons (cons (expand-file-name default-directory) b)
+                             opencode-client--servers))
+                 b)))
+            ((symbol-function 'expand-file-name) (lambda (d) (concat "/proj/" d))))
+    (let ((opencode-client--servers nil)
+          (default-directory "/proj/one"))
+      (let ((b1 (opencode-client--ensure-server)))
+        (setq default-directory "/proj/two")
+        (let ((b2 (opencode-client--ensure-server)))
+          (it "gives a different project its own server, for parallel sessions"
+            (check (eq b1 b2) nil))
+          (it "keeps one registry entry per project"
+            (check (length opencode-client--servers) 2)))))))
+
+(test-helper-summary)
+
+;;; opencode-client-sse-test.el ends here

--- a/test/orgspec-agenda-test.el
+++ b/test/orgspec-agenda-test.el
@@ -1,44 +1,55 @@
+;;; orgspec-agenda-test.el --- Tests for the orgspec agenda integration -*- lexical-binding: t; -*-
+
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'orgspec-agenda)
 
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
-
-;; Build a temp changes dir: two active changes + one archived.
+;; Build a temp changes dir: two active changes, one archived, one with no
+;; change.org at all.
 (let* ((root (make-temp-file "orgspec-agenda-" t))
        (changes (expand-file-name "changes" root)))
   (dolist (id '("add-auth" "fix-lockout"))
     (let ((d (expand-file-name id changes)))
       (make-directory d t)
       (with-temp-file (expand-file-name "change.org" d) (insert "* Delta\n"))))
-  ;; An archived change must be excluded.
   (let ((a (expand-file-name "archive/old-change" changes)))
     (make-directory a t)
     (with-temp-file (expand-file-name "change.org" a) (insert "* Delta\n")))
-  ;; A change dir with no change.org must be skipped.
   (make-directory (expand-file-name "half-baked" changes) t)
 
-  (let ((files (orgspec-agenda-files changes)))
-    (check "files-count" (length files) 2)
-    (check "files-active-only"
-           (and (seq-every-p (lambda (f) (not (string-match-p "/archive/" f))) files) t)
-           t)
-    (check "files-existing"
-           (and (seq-every-p #'file-exists-p files) t) t))
+  (describe "orgspec-agenda-files"
+    (let ((files (orgspec-agenda-files changes)))
+      (it "collects one file per active change"
+        (check (length files) 2))
+      (it "excludes changes under archive/"
+        (check-that (seq-every-p (lambda (f) (not (string-match-p "/archive/" f)))
+                                 files)))
+      (it "returns only files that exist, skipping dirs without change.org"
+        (check-that (seq-every-p #'file-exists-p files)))))
 
-  ;; install registers one entry under the key, idempotently.
-  (let ((org-agenda-custom-commands nil)
-        (orgspec-agenda-key "o"))
-    (orgspec-agenda-install changes)
-    (check "install-one" (length org-agenda-custom-commands) 1)
-    (check "install-key" (car (car org-agenda-custom-commands)) "o")
-    (orgspec-agenda-install changes)
-    (check "install-idempotent" (length org-agenda-custom-commands) 1)
-    (let ((entry (car org-agenda-custom-commands)))
-      (check "install-type" (nth 2 entry) 'tags-todo)
-      (check "install-match-has-ops"
-             (and (string-match-p "ADDED" (nth 3 entry))
-                  (string-match-p "RENAMED" (nth 3 entry)) t)
-             t))))
+  (describe "orgspec-agenda-install"
+    (let ((org-agenda-custom-commands nil)
+          (orgspec-agenda-key "o"))
+      (orgspec-agenda-install changes)
+      (it "registers exactly one agenda command"
+        (check (length org-agenda-custom-commands) 1))
+      (it "registers it under `orgspec-agenda-key'"
+        (check (car (car org-agenda-custom-commands)) "o"))
+      (orgspec-agenda-install changes)
+      (it "keeps a single entry when installed twice"
+        (check (length org-agenda-custom-commands) 1))
+      (let ((entry (car org-agenda-custom-commands)))
+        (it "registers a tags-todo search"
+          (check (nth 2 entry) 'tags-todo))
+        (it "matches every delta operation keyword"
+          (check-that (and (string-match-p "ADDED" (nth 3 entry))
+                           (string-match-p "RENAMED" (nth 3 entry)))))))))
 
-;; A missing changes dir yields no files (no error).
-(check "files-missing" (orgspec-agenda-files "/nonexistent/xyz") nil)
+(describe "orgspec-agenda-files with a missing directory"
+  (it "returns no files rather than signalling"
+    (check (orgspec-agenda-files "/nonexistent/xyz") nil)))
+
+(test-helper-summary)
+
+;;; orgspec-agenda-test.el ends here

--- a/test/orgspec-fold-spike-test.el
+++ b/test/orgspec-fold-spike-test.el
@@ -12,11 +12,10 @@
 ;;   emacs --batch -L elisp -l test/orgspec-fold-spike-test.el
 ;; A FAIL line in the output fails the run (CI greps for FAIL).
 
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'org)
 (require 'org-element)
-
-(defun check (l g w)
-  (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
 
 ;; A delta requirement as stored in a change file: L2 headline carrying a TODO
 ;; keyword and an :ADDED: op tag, an :AREA: routing property, an :IMPL: drawer,
@@ -74,19 +73,22 @@ The system SHALL already do a thing.
     (org-set-tags nil)                  ; drop :ADDED: op tag
 
     (let ((result (buffer-string)))
-      ;; requirement re-leveled L2 -> L1, scenario L3 -> L2
-      (check "requirement is L1"
-             (and (string-match-p "^\\* Notify on account lockout" result) t) t)
-      (check "scenario is L2"
-             (and (string-match-p "^\\*\\* Lockout triggered" result) t) t)
-      ;; workflow state removed from the durable spec
-      (check "TODO stripped" (string-match-p "\\* TODO " result) nil)
-      (check "op tag dropped" (string-match-p ":ADDED:" result) nil)
-      ;; traceability kept
-      (check "IMPL drawer kept"
-             (and (string-match-p ":IMPL:" result) t) t)
-      ;; existing content untouched
-      (check "existing requirement intact"
-             (and (string-match-p "^\\* Existing requirement" result) t) t))))
+      (describe "org-paste-subtree re-leveling"
+        (it "promotes the delta requirement from L2 to L1"
+          (check-that (string-match-p "^\\* Notify on account lockout" result)))
+        (it "promotes its scenario from L3 to L2"
+          (check-that (string-match-p "^\\*\\* Lockout triggered" result))))
+
+      (describe "the fold rules"
+        (it "strips the workflow TODO keyword from the durable spec"
+          (check (string-match-p "\\* TODO " result) nil))
+        (it "drops the op tag from the durable spec"
+          (check (string-match-p ":ADDED:" result) nil))
+        (it "keeps the :IMPL: traceability drawer"
+          (check-that (string-match-p ":IMPL:" result)))
+        (it "leaves the existing spec content untouched"
+          (check-that (string-match-p "^\\* Existing requirement" result)))))))
+
+(test-helper-summary)
 
 ;;; orgspec-fold-spike-test.el ends here

--- a/test/orgspec-fold-test.el
+++ b/test/orgspec-fold-test.el
@@ -1,8 +1,10 @@
+;;; orgspec-fold-test.el --- Tests for folding a delta into the specs -*- lexical-binding: t; -*-
+
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'orgspec-parse)
 (require 'orgspec-fold)
-
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
 
 ;; Parse a `* Delta' change string into its requirements (in order).
 (defun fold-test--reqs (change)
@@ -25,12 +27,19 @@ The system SHALL do the new thing.
 - THEN c
 ")
        (out (orgspec-fold-area "" (fold-test--reqs delta))))
-  (check "added-requirement-L1" (and (string-match-p "^\\* New thing" out) t) t)
-  (check "added-scenario-L2" (and (string-match-p "^\\*\\* New scenario" out) t) t)
-  (check "added-todo-stripped" (string-match-p "\\* TODO " out) nil)
-  (check "added-op-tag-dropped" (string-match-p ":ADDED:" out) nil)
-  (check "added-area-stripped" (string-match-p ":AREA:" out) nil)
-  (check "added-shall-kept" (and (string-match-p "SHALL" out) t) t))
+  (describe "orgspec-fold-area with an ADDED requirement"
+    (it "appends the new requirement as a top-level headline"
+      (check-that (string-match-p "^\\* New thing" out)))
+    (it "appends its scenarios one level below the requirement"
+      (check-that (string-match-p "^\\*\\* New scenario" out)))
+    (it "strips the TODO keyword from the folded headline"
+      (check (string-match-p "\\* TODO " out) nil))
+    (it "drops the delta operation tag"
+      (check (string-match-p ":ADDED:" out) nil))
+    (it "strips the AREA property that routed the requirement"
+      (check (string-match-p ":AREA:" out) nil))
+    (it "keeps the SHALL body text"
+      (check-that (string-match-p "SHALL" out)))))
 
 ;; --- ADDED with IMPL drawer kept --------------------------------------------
 
@@ -49,7 +58,9 @@ The system SHALL do it.
 - THEN c
 ")
        (out (orgspec-fold-area "" (fold-test--reqs delta))))
-  (check "added-impl-kept" (and (string-match-p ":IMPL:" out) t) t))
+  (describe "orgspec-fold-area with a hand-written IMPL drawer"
+    (it "preserves the IMPL drawer through the fold"
+      (check-that (string-match-p ":IMPL:" out)))))
 
 ;; --- REMOVED: existing requirement deleted ----------------------------------
 
@@ -70,8 +81,11 @@ The system SHALL go.
 Removed.
 ")
        (out (orgspec-fold-area spec (fold-test--reqs delta))))
-  (check "removed-gone" (string-match-p "Drop me" out) nil)
-  (check "removed-keeps-others" (and (string-match-p "^\\* Keep me" out) t) t))
+  (describe "orgspec-fold-area with a REMOVED requirement"
+    (it "deletes the named requirement from the spec"
+      (check (string-match-p "Drop me" out) nil))
+    (it "leaves the other requirements untouched"
+      (check-that (string-match-p "^\\* Keep me" out)))))
 
 ;; --- RENAMED: headline renamed via :FROM: -----------------------------------
 
@@ -89,8 +103,11 @@ The system SHALL exist.
 Renamed.
 ")
        (out (orgspec-fold-area spec (fold-test--reqs delta))))
-  (check "renamed-to-new" (and (string-match-p "^\\* New name" out) t) t)
-  (check "renamed-old-gone" (string-match-p "^\\* Old name" out) nil))
+  (describe "orgspec-fold-area with a RENAMED requirement"
+    (it "renames the requirement identified by FROM to the new headline"
+      (check-that (string-match-p "^\\* New name" out)))
+    (it "leaves no requirement under the old name"
+      (check (string-match-p "^\\* Old name" out) nil))))
 
 ;; --- MODIFIED: replace, keeping all current scenarios -----------------------
 
@@ -111,10 +128,15 @@ The system SHALL do new and improved.
 - GIVEN b
 ")
        (out (orgspec-fold-area spec (fold-test--reqs delta))))
-  (check "modified-body-updated" (and (string-match-p "new and improved" out) t) t)
-  (check "modified-old-body-gone" (string-match-p "SHALL do old" out) nil)
-  (check "modified-keeps-scenario" (and (string-match-p "Keep scenario" out) t) t)
-  (check "modified-adds-scenario" (and (string-match-p "Extra scenario" out) t) t))
+  (describe "orgspec-fold-area with a MODIFIED requirement"
+    (it "replaces the requirement body with the new wording"
+      (check-that (string-match-p "new and improved" out)))
+    (it "drops the superseded body text"
+      (check (string-match-p "SHALL do old" out) nil))
+    (it "carries over the scenarios the delta restates"
+      (check-that (string-match-p "Keep scenario" out)))
+    (it "adds the scenarios the delta introduces"
+      (check-that (string-match-p "Extra scenario" out)))))
 
 ;; --- MODIFIED drop-guard: dropping a current scenario is an error -----------
 
@@ -132,11 +154,12 @@ The system SHALL do it differently.
 *** Different scenario
 - GIVEN b
 "))
-  (check "modified-drop-guard-signals"
-         (condition-case _
-             (progn (orgspec-fold-area spec (fold-test--reqs delta)) nil)
-           (orgspec-fold-error t))
-         t))
+  (describe "orgspec-fold-area drop guard"
+    (it "signals rather than silently dropping a current scenario"
+      (check (condition-case _
+                 (progn (orgspec-fold-area spec (fold-test--reqs delta)) nil)
+               (orgspec-fold-error t))
+             t))))
 
 ;; --- Fixed apply order: REMOVED before ADDED (same name reused) -------------
 
@@ -163,5 +186,9 @@ The system SHALL do v2.
 Removed.
 ")
        (out (orgspec-fold-area spec (fold-test--reqs delta))))
-  (check "order-removed-then-added" (and (string-match-p "SHALL do v2" out)
-                                         (not (string-match-p "SHALL do v1" out)) t) t))
+  (describe "orgspec-fold-area apply order"
+    (it "applies REMOVED before ADDED so a reused name does not collide"
+      (check (and (string-match-p "SHALL do v2" out)
+                  (not (string-match-p "SHALL do v1" out)) t) t))))
+
+;;; orgspec-fold-test.el ends here

--- a/test/orgspec-lifecycle-test.el
+++ b/test/orgspec-lifecycle-test.el
@@ -1,7 +1,9 @@
-(add-to-list 'load-path (expand-file-name "elisp"))
-(require 'orgspec-lifecycle)
+;;; orgspec-lifecycle-test.el --- Tests for the orgspec requirement lifecycle -*- lexical-binding: t; -*-
 
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+(add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
+(require 'orgspec-lifecycle)
 
 (defconst life-test--change "* Delta
 ** Notify on lockout                                 :ADDED:
@@ -27,40 +29,49 @@ The system MUST also do b.
       (goto-char (point-min))
       (funcall fn))))
 
-;; goto finds an untagged-keyword requirement by name.
-(life-test--in-buffer
- (lambda ()
-   (check "goto-found" (and (orgspec-lifecycle-goto-requirement "Notify on lockout") t) t)
-   (check "goto-on-heading" (org-get-heading t t t t) "Notify on lockout")))
+(describe "orgspec-lifecycle-goto-requirement"
+  (life-test--in-buffer
+   (lambda ()
+     (it "finds an untagged-keyword requirement by name"
+       (check (and (orgspec-lifecycle-goto-requirement "Notify on lockout") t) t))
+     (it "leaves point on the matched heading"
+       (check (org-get-heading t t t t) "Notify on lockout"))))
 
-;; goto returns nil and does not move for an absent name.
-(life-test--in-buffer
- (lambda ()
-   (goto-char (point-max))
-   (let ((before (point)))
-     (check "goto-absent" (orgspec-lifecycle-goto-requirement "Nope") nil)
-     (check "goto-absent-nomove" (point) before))))
+  (life-test--in-buffer
+   (lambda ()
+     (goto-char (point-max))
+     (let ((before (point)))
+       (it "returns nil for an absent name"
+         (check (orgspec-lifecycle-goto-requirement "Nope") nil))
+       (it "does not move point when the name is absent"
+         (check (point) before))))))
 
-;; advance-at-point sets the active keyword.
-(life-test--in-buffer
- (lambda ()
-   (orgspec-lifecycle-goto-requirement "Notify on lockout")
-   (orgspec-lifecycle-advance-at-point 'active)
-   (check "advance-active" (org-get-todo-state) orgspec-todo-active)))
+(describe "orgspec-lifecycle-advance-at-point"
+  (life-test--in-buffer
+   (lambda ()
+     (orgspec-lifecycle-goto-requirement "Notify on lockout")
+     (orgspec-lifecycle-advance-at-point 'active)
+     (it "sets the active keyword"
+       (check (org-get-todo-state) orgspec-todo-active))))
 
-;; advance-at-point 'done reaches a done state.
-(life-test--in-buffer
- (lambda ()
-   (orgspec-lifecycle-goto-requirement "Second requirement")
-   (orgspec-lifecycle-advance-at-point 'done)
-   (check "advance-done"
-          (and (member (substring-no-properties (org-get-todo-state))
-                       org-done-keywords)
-               t)
-          t)))
+  (life-test--in-buffer
+   (lambda ()
+     (orgspec-lifecycle-goto-requirement "Second requirement")
+     (orgspec-lifecycle-advance-at-point 'done)
+     (it "reaches a done state for the done role"
+       (check-that (member (substring-no-properties (org-get-todo-state))
+                           org-done-keywords))))))
 
-;; role->keyword map.
-(check "role-active" (orgspec-lifecycle--keyword-for-role 'active) orgspec-todo-active)
-(check "role-blocked" (orgspec-lifecycle--keyword-for-role 'blocked) orgspec-todo-blocked)
-(check "role-removed" (orgspec-lifecycle--keyword-for-role 'removed) orgspec-todo-removed)
-(check "role-done" (orgspec-lifecycle--keyword-for-role 'done) 'done)
+(describe "orgspec-lifecycle--keyword-for-role"
+  (it "maps active to the active keyword"
+    (check (orgspec-lifecycle--keyword-for-role 'active) orgspec-todo-active))
+  (it "maps blocked to the blocked keyword"
+    (check (orgspec-lifecycle--keyword-for-role 'blocked) orgspec-todo-blocked))
+  (it "maps removed to the removed keyword"
+    (check (orgspec-lifecycle--keyword-for-role 'removed) orgspec-todo-removed))
+  (it "maps done to the `done' marker rather than a keyword"
+    (check (orgspec-lifecycle--keyword-for-role 'done) 'done)))
+
+(test-helper-summary)
+
+;;; orgspec-lifecycle-test.el ends here

--- a/test/orgspec-mcp-test.el
+++ b/test/orgspec-mcp-test.el
@@ -1,28 +1,29 @@
+;;; orgspec-mcp-test.el --- Tests for the orgspec MCP tools -*- lexical-binding: t; -*-
+
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'cl-lib)
 (require 'orgspec-mcp)
 
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
-
-;; Registration: the six orgspec tools land on the server extra-tools var.
-(check "reg-count" (length mcp-emacs-server-extra-tools) 8)
-(check "reg-names"
-       (sort (mapcar (lambda (tl) (plist-get tl :name)) mcp-emacs-server-extra-tools)
-             #'string<)
-       '("orgspec_advance" "orgspec_agenda" "orgspec_archive"
-         "orgspec_new" "orgspec_parse" "orgspec_review"
-         "orgspec_status" "orgspec_validate"))
-;; Idempotent re-register keeps the count at eight.
-(orgspec-mcp-register)
-(check "reg-idempotent" (length mcp-emacs-server-extra-tools) 8)
-;; Every descriptor has the required plist keys.
-(check "reg-well-formed"
-       (seq-every-p (lambda (tl) (and (plist-get tl :name)
-                                      (plist-get tl :description)
-                                      (plist-get tl :schema)
-                                      (functionp (plist-get tl :handler))))
-                    mcp-emacs-server-extra-tools)
-       t)
+(describe "orgspec-mcp-register"
+  (it "lands every orgspec tool on the server extra-tools var"
+    (check (length mcp-emacs-server-extra-tools) 8))
+  (it "registers the orgspec tools under their advertised names"
+    (check (sort (mapcar (lambda (tl) (plist-get tl :name)) mcp-emacs-server-extra-tools)
+                 #'string<)
+           '("orgspec_advance" "orgspec_agenda" "orgspec_archive"
+             "orgspec_new" "orgspec_parse" "orgspec_review"
+             "orgspec_status" "orgspec_validate")))
+  (orgspec-mcp-register)
+  (it "keeps the tool count unchanged when registered twice"
+    (check (length mcp-emacs-server-extra-tools) 8))
+  (it "gives every descriptor a name, description, schema and callable handler"
+    (check-that (seq-every-p (lambda (tl) (and (plist-get tl :name)
+                                               (plist-get tl :description)
+                                               (plist-get tl :schema)
+                                               (functionp (plist-get tl :handler))))
+                             mcp-emacs-server-extra-tools))))
 
 ;; Drive the new -> status -> parse -> advance handlers on a temp project.
 (let* ((root (make-temp-file "orgspec-mcp-" t))
@@ -33,33 +34,45 @@
     ;; No ambient project here, so the tool is told which one to act on --
     ;; the routing an agent over HTTP has to use anyway.
     (orgspec-mcp-call "orgspec_new" `((id . "add-auth") (root . ,root)))
-    (let ((f (orgspec-commands--change-file "add-auth")))
-      (check "new-created" (file-exists-p f) t)
-      (with-temp-file f
-        (insert "* Tasks\n- [ ] a\n- [x] b\n* Delta\n"
-                "** Login required :ADDED:\n:PROPERTIES:\n:AREA: auth\n:END:\n"
-                "The system SHALL require login.\n*** happy\n- GIVEN x\n")))
-    (check "status-text" (orgspec-mcp--status '((id . "add-auth")))
-           "add-auth: 1/2 tasks done")
-    (let ((s (orgspec-mcp--parse '((id . "add-auth")))))
-      (check "parse-has-req" (and (string-match-p "Login required" s) t) t)
-      (check "parse-has-area" (and (string-match-p "area=auth" s) t) t))
-    (check "advance-active"
-           (orgspec-mcp--advance
-            '((id . "add-auth") (requirement . "Login required") (role . "active")))
-           (format "Login required -> %s" orgspec-todo-active))))
+    (describe "orgspec_new"
+      (let ((f (orgspec-commands--change-file "add-auth")))
+        (it "writes a change file for the new change"
+          (check (file-exists-p f) t))
+        (with-temp-file f
+          (insert "* Tasks\n- [ ] a\n- [x] b\n* Delta\n"
+                  "** Login required :ADDED:\n:PROPERTIES:\n:AREA: auth\n:END:\n"
+                  "The system SHALL require login.\n*** happy\n- GIVEN x\n"))))
+
+    (describe "orgspec-mcp--status"
+      (it "reports how many of the change's tasks are done"
+        (check (orgspec-mcp--status '((id . "add-auth")))
+               "add-auth: 1/2 tasks done")))
+
+    (describe "orgspec-mcp--parse"
+      (let ((s (orgspec-mcp--parse '((id . "add-auth")))))
+        (it "includes each delta requirement's heading"
+          (check-that (string-match-p "Login required" s)))
+        (it "includes the requirement's area property"
+          (check-that (string-match-p "area=auth" s)))))
+
+    (describe "orgspec-mcp--advance"
+      (it "moves a requirement to the active todo keyword"
+        (check (orgspec-mcp--advance
+                '((id . "add-auth") (requirement . "Login required") (role . "active")))
+               (format "Login required -> %s" orgspec-todo-active))))))
 
 ;;;; Project routing (issue #57)
 
-;; Every tool advertises the optional `root' argument, so a caller over
-;; HTTP can name the project instead of inheriting the session's buffer.
-(check "root-in-every-schema"
-       (seq-every-p
-        (lambda (tl)
-          (let ((props (alist-get "properties" (plist-get tl :schema) nil nil #'equal)))
-            (and props (assoc "root" props) t)))
-        mcp-emacs-server-extra-tools)
-       t)
+(describe "orgspec tool schemas"
+  ;; Every tool advertises the optional `root' argument, so a caller over
+  ;; HTTP can name the project instead of inheriting the session's buffer.
+  (it "all advertise an optional `root' so a caller can name the project"
+    (check-that
+     (seq-every-p
+      (lambda (tl)
+        (let ((props (alist-get "properties" (plist-get tl :schema) nil nil #'equal)))
+          (and props (assoc "root" props) t)))
+      mcp-emacs-server-extra-tools))))
 
 ;; `root' wins over the ambient project: the write lands in the stated
 ;; project, not in the one `default-directory' would have chosen.
@@ -69,12 +82,13 @@
        (orgspec-root "orgspec"))
   (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
     (orgspec-mcp-call "orgspec_new" `((id . "routed") (root . ,stated)))
-    (check "root-routes-write"
-           (file-exists-p (expand-file-name "orgspec/changes/routed/change.org" stated))
-           t)
-    (check "root-spares-ambient"
-           (file-exists-p (expand-file-name "orgspec/changes/routed/change.org" ambient))
-           nil)))
+    (describe "a stated `root'"
+      (it "wins over the ambient project and takes the write"
+        (check (file-exists-p (expand-file-name "orgspec/changes/routed/change.org" stated))
+               t))
+      (it "leaves the ambient project untouched"
+        (check (file-exists-p (expand-file-name "orgspec/changes/routed/change.org" ambient))
+               nil)))))
 
 ;; With no project stated and none detectable, the root is a guess from
 ;; `default-directory' -- creating a tree there is the bug, so refuse.
@@ -83,14 +97,15 @@
        (orgspec-root "orgspec")
        (orgspec-project-root nil))
   (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
-    (check "guessed-root-refused"
-           (condition-case err
-               (progn (orgspec-mcp-call "orgspec_new" '((id . "nope"))) :created)
-             (user-error (and (string-match-p "guess" (error-message-string err))
-                              :refused)))
-           :refused)
-    (check "guessed-root-writes-nothing"
-           (file-directory-p (expand-file-name "orgspec" elsewhere)) nil)))
+    (describe "orgspec_new with no project stated and none detectable"
+      (it "refuses rather than acting on a guessed root"
+        (check (condition-case err
+                   (progn (orgspec-mcp-call "orgspec_new" '((id . "nope"))) :created)
+                 (user-error (and (string-match-p "guess" (error-message-string err))
+                                  :refused)))
+               :refused))
+      (it "creates nothing where it would have guessed"
+        (check (file-directory-p (expand-file-name "orgspec" elsewhere)) nil)))))
 
 ;; An existing tree is opt-in enough: no root needed to keep working in it.
 (let* ((initialised (make-temp-file "orgspec-existing-" t))
@@ -99,8 +114,13 @@
        (orgspec-project-root nil))
   (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
     (make-directory (expand-file-name "orgspec/changes" initialised) t)
-    (check "existing-tree-needs-no-root"
-           (progn (orgspec-mcp-call "orgspec_new" '((id . "ok")))
-                  (file-exists-p
-                   (expand-file-name "orgspec/changes/ok/change.org" initialised)))
-           t)))
+    (describe "orgspec_new in a directory with an existing orgspec tree"
+      (it "needs no stated root to keep working in that tree"
+        (check (progn (orgspec-mcp-call "orgspec_new" '((id . "ok")))
+                      (file-exists-p
+                       (expand-file-name "orgspec/changes/ok/change.org" initialised)))
+               t)))))
+
+(test-helper-summary)
+
+;;; orgspec-mcp-test.el ends here

--- a/test/orgspec-parse-test.el
+++ b/test/orgspec-parse-test.el
@@ -1,7 +1,9 @@
-(add-to-list 'load-path (expand-file-name "elisp"))
-(require 'orgspec-parse)
+;;; orgspec-parse-test.el --- Tests for the orgspec parser -*- lexical-binding: t; -*-
 
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
+(add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
+(require 'orgspec-parse)
 
 (defun parse-test--change (s)
   (with-temp-buffer
@@ -9,8 +11,8 @@
     (insert s)
     (orgspec-parse-change "t")))
 
-;; A delta requirement: op, area, from, body, scenarios, impl all extracted.
-(let* ((chg (parse-test--change "* Delta
+(describe "orgspec-parse-change on a delta requirement"
+  (let* ((chg (parse-test--change "* Delta
 ** TODO Notify on lockout                            :ADDED:
 :PROPERTIES:
 :AREA: auth
@@ -24,24 +26,29 @@ The system SHALL notify.
 - WHEN b
 - THEN c
 "))
-       (req (car (orgspec-change-requirements chg))))
-  (check "parse-op" (orgspec-requirement-op req) 'added)
-  (check "parse-name" (orgspec-requirement-name req) "Notify on lockout")
-  (check "parse-area" (orgspec-requirement-area req) "auth")
-  (check "parse-scenarios" (length (orgspec-requirement-scenarios req)) 1)
-  (check "parse-scenario-name"
-         (orgspec-scenario-name (car (orgspec-requirement-scenarios req)))
-         "Lockout triggered")
-  (check "parse-impl" (length (orgspec-requirement-impl req)) 1)
-  (check "parse-normative"
-         (and (string-match-p orgspec-normative-regexp
-                              (orgspec-requirement-body req)) t) t)
-  (check "parse-source-has-subtree"
-         (and (string-match-p "Notify on lockout"
-                              (orgspec-requirement-source req)) t) t))
+         (req (car (orgspec-change-requirements chg))))
+    (it "reads the operation from the headline tag"
+      (check (orgspec-requirement-op req) 'added))
+    (it "takes the requirement name from the headline text"
+      (check (orgspec-requirement-name req) "Notify on lockout"))
+    (it "reads the area from the AREA property"
+      (check (orgspec-requirement-area req) "auth"))
+    (it "collects the scenarios below the requirement"
+      (check (length (orgspec-requirement-scenarios req)) 1))
+    (it "names each scenario after its headline"
+      (check (orgspec-scenario-name (car (orgspec-requirement-scenarios req)))
+             "Lockout triggered"))
+    (it "collects the links in the IMPL drawer"
+      (check (length (orgspec-requirement-impl req)) 1))
+    (it "keeps the normative wording in the body"
+      (check-that (string-match-p orgspec-normative-regexp
+                                  (orgspec-requirement-body req))))
+    (it "retains the whole subtree as the source text"
+      (check-that (string-match-p "Notify on lockout"
+                                  (orgspec-requirement-source req))))))
 
-;; RENAMED carries :FROM:.
-(let* ((chg (parse-test--change "* Delta
+(describe "orgspec-parse-change on a RENAMED requirement"
+  (let* ((chg (parse-test--change "* Delta
 ** New name                                          :RENAMED:
 :PROPERTIES:
 :AREA: auth
@@ -49,15 +56,24 @@ The system SHALL notify.
 :END:
 Renamed.
 "))
-       (req (car (orgspec-change-requirements chg))))
-  (check "parse-renamed-op" (orgspec-requirement-op req) 'renamed)
-  (check "parse-from" (orgspec-requirement-from req) "Old name"))
+         (req (car (orgspec-change-requirements chg))))
+    (it "reads the renamed operation from the headline tag"
+      (check (orgspec-requirement-op req) 'renamed))
+    (it "carries the previous name from the FROM property"
+      (check (orgspec-requirement-from req) "Old name"))))
 
-;; A spec buffer parses to plain (op nil) requirements at L1.
-(let* ((reqs (with-temp-buffer
-               (let ((org-inhibit-startup t)) (org-mode))
-               (insert "* Req one\nThe system SHALL a.\n** S1\n- GIVEN x\n* Req two\nThe system SHALL b.\n")
-               (orgspec-parse-spec))))
-  (check "parse-spec-count" (length reqs) 2)
-  (check "parse-spec-no-op" (orgspec-requirement-op (car reqs)) nil)
-  (check "parse-spec-name" (orgspec-requirement-name (car reqs)) "Req one"))
+(describe "orgspec-parse-spec"
+  (let* ((reqs (with-temp-buffer
+                 (let ((org-inhibit-startup t)) (org-mode))
+                 (insert "* Req one\nThe system SHALL a.\n** S1\n- GIVEN x\n* Req two\nThe system SHALL b.\n")
+                 (orgspec-parse-spec))))
+    (it "treats every level-one headline as a requirement"
+      (check (length reqs) 2))
+    (it "leaves the operation unset, since a spec records no delta"
+      (check (orgspec-requirement-op (car reqs)) nil))
+    (it "takes the requirement name from the headline text"
+      (check (orgspec-requirement-name (car reqs)) "Req one"))))
+
+(test-helper-summary)
+
+;;; orgspec-parse-test.el ends here

--- a/test/orgspec-review-test.el
+++ b/test/orgspec-review-test.el
@@ -1,9 +1,11 @@
+;;; orgspec-review-test.el --- Tests for the orgspec fold/review/archive commands -*- lexical-binding: t; -*-
+
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'cl-lib)
 (require 'orgspec-commands)
 (require 'orgspec-review)
-
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
 
 (defun review-test--project ()
   "Create a temp project with one change touching two areas; return its root."
@@ -20,49 +22,57 @@
 
 (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
 
-  ;; fold-build: two areas, each with the folded (file . text), nothing written.
-  (let* ((root (review-test--project))
-         (default-directory (file-name-as-directory root))
-         (orgspec-root "orgspec")
-         (built (orgspec-commands-fold-build "add-two")))
-    (check "build-count" (length built) 2)
-    (check "build-areas"
-           (sort (mapcar (lambda (c) (file-name-base (car c))) built) #'string<)
-           '("auth" "billing"))
-    (check "build-folded-has-req"
-           (and (seq-some (lambda (c) (string-match-p "Auth requirement" (cdr c))) built) t) t)
-    (check "build-folded-plain-headline"
-           ;; re-leveled to L1, op tag stripped
-           (and (seq-some (lambda (c)
-                            (string-match-p "^\\* Auth requirement$" (cdr c))) built) t) t)
-    (check "build-writes-nothing"
-           (file-exists-p (expand-file-name "orgspec/specs/auth.org" root)) nil))
+  (describe "orgspec-commands-fold-build"
+    (let* ((root (review-test--project))
+           (default-directory (file-name-as-directory root))
+           (orgspec-root "orgspec")
+           (built (orgspec-commands-fold-build "add-two")))
+      (it "returns one fold per area touched by the change"
+        (check (length built) 2))
+      (it "names each fold after the area it belongs to"
+        (check (sort (mapcar (lambda (c) (file-name-base (car c))) built) #'string<)
+               '("auth" "billing")))
+      (it "carries the requirement text in the folded content"
+        (check-that (seq-some (lambda (c) (string-match-p "Auth requirement" (cdr c))) built)))
+      (it "re-levels requirements to level 1 and strips the operation tag"
+        (check-that (seq-some (lambda (c)
+                                (string-match-p "^\\* Auth requirement$" (cdr c))) built)))
+      (it "writes no spec file, only returning the fold"
+        (check (file-exists-p (expand-file-name "orgspec/specs/auth.org" root)) nil))))
 
-  ;; archive: writes both specs and returns their files; change moves to archive.
-  (let* ((root (review-test--project))
-         (default-directory (file-name-as-directory root))
-         (orgspec-root "orgspec"))
-    (cl-letf (((symbol-function 'orgspec-commands--archive-move) (lambda (_id) nil)))
-      (let ((written (orgspec-archive "add-two")))
-        (check "archive-returns-two" (length written) 2)
-        (check "archive-wrote-auth"
-               (file-exists-p (expand-file-name "orgspec/specs/auth.org" root)) t)
-        (check "archive-wrote-billing"
-               (file-exists-p (expand-file-name "orgspec/specs/billing.org" root)) t)
-        (check "archive-auth-content"
-               (with-temp-buffer
-                 (insert-file-contents (expand-file-name "orgspec/specs/auth.org" root))
-                 (and (string-match-p "Auth requirement" (buffer-string)) t)) t))))
+  (describe "orgspec-archive"
+    (let* ((root (review-test--project))
+           (default-directory (file-name-as-directory root))
+           (orgspec-root "orgspec"))
+      (cl-letf (((symbol-function 'orgspec-commands--archive-move) (lambda (_id) nil)))
+        (let ((written (orgspec-archive "add-two")))
+          (it "returns one written file per area"
+            (check (length written) 2))
+          (it "writes the auth spec"
+            (check (file-exists-p (expand-file-name "orgspec/specs/auth.org" root)) t))
+          (it "writes the billing spec"
+            (check (file-exists-p (expand-file-name "orgspec/specs/billing.org" root)) t))
+          (it "puts the folded requirement into the spec it wrote"
+            (check-that (with-temp-buffer
+                          (insert-file-contents
+                           (expand-file-name "orgspec/specs/auth.org" root))
+                          (string-match-p "Auth requirement" (buffer-string)))))))))
 
-  ;; review-fold: builds and diffs each area, writing nothing; ediff stubbed.
-  (let* ((root (review-test--project))
-         (default-directory (file-name-as-directory root))
-         (orgspec-root "orgspec")
-         (ediff-calls 0))
-    (cl-letf (((symbol-function 'orgspec-review--ediff)
-               (lambda (&rest _) (setq ediff-calls (1+ ediff-calls)))))
-      (let ((reviewed (orgspec-review-fold "add-two")))
-        (check "review-count" (length reviewed) 2)
-        (check "review-ediff-per-area" ediff-calls 2)
-        (check "review-writes-nothing"
-               (file-exists-p (expand-file-name "orgspec/specs/auth.org" root)) nil)))))
+  (describe "orgspec-review-fold"
+    (let* ((root (review-test--project))
+           (default-directory (file-name-as-directory root))
+           (orgspec-root "orgspec")
+           (ediff-calls 0))
+      (cl-letf (((symbol-function 'orgspec-review--ediff)
+                 (lambda (&rest _) (setq ediff-calls (1+ ediff-calls)))))
+        (let ((reviewed (orgspec-review-fold "add-two")))
+          (it "reviews one fold per area"
+            (check (length reviewed) 2))
+          (it "starts an ediff for each area"
+            (check ediff-calls 2))
+          (it "writes no spec file, leaving the specs untouched"
+            (check (file-exists-p (expand-file-name "orgspec/specs/auth.org" root)) nil)))))))
+
+(test-helper-summary)
+
+;;; orgspec-review-test.el ends here

--- a/test/orgspec-validate-test.el
+++ b/test/orgspec-validate-test.el
@@ -1,8 +1,10 @@
+;;; orgspec-validate-test.el --- Tests for the orgspec delta validator -*- lexical-binding: t; -*-
+
 (add-to-list 'load-path (expand-file-name "elisp"))
+(add-to-list 'load-path (expand-file-name "test"))
+(require 'test-helper)
 (require 'orgspec-parse)
 (require 'orgspec-validate)
-
-(defun check (l g w) (princ (format "%s %s\n" (if (equal g w) "PASS" "FAIL") l)))
 
 (defun val-test--change (s)
   (with-temp-buffer
@@ -16,9 +18,9 @@
                  (val-test--errors s))
        t))
 
-;; A canonical valid change: ADDED with SHALL + a scenario.
-(check "valid-clean"
-       (val-test--errors "* Delta
+(describe "orgspec-validate-change"
+  (it "reports no problems for an ADDED requirement with SHALL and a scenario"
+    (check (val-test--errors "* Delta
 ** Notify on lockout :ADDED:
 :PROPERTIES:
 :AREA: auth
@@ -27,15 +29,13 @@ The system SHALL notify.
 *** ok
 - GIVEN a
 ")
-       nil)
+           nil))
 
-;; No delta requirements at all.
-(check "no-delta"
-       (val-test--has "* Delta\n" "at least one delta") t)
+  (it "rejects a delta with no requirements at all"
+    (check (val-test--has "* Delta\n" "at least one delta") t))
 
-;; ADDED without SHALL/MUST.
-(check "added-no-shall"
-       (val-test--has "* Delta
+  (it "rejects an ADDED requirement whose text lacks SHALL or MUST"
+    (check (val-test--has "* Delta
 ** Weak req :ADDED:
 :PROPERTIES:
 :AREA: a
@@ -43,21 +43,19 @@ The system SHALL notify.
 This just describes something.
 *** ok
 - GIVEN a
-" "must contain SHALL or MUST") t)
+" "must contain SHALL or MUST") t))
 
-;; MODIFIED without a scenario.
-(check "modified-no-scenario"
-       (val-test--has "* Delta
+  (it "rejects a MODIFIED requirement with no scenario"
+    (check (val-test--has "* Delta
 ** Change it :MODIFIED:
 :PROPERTIES:
 :AREA: a
 :END:
 The system SHALL change.
-" "must include at least one scenario") t)
+" "must include at least one scenario") t))
 
-;; Duplicate name within ADDED.
-(check "dup-added"
-       (val-test--has "* Delta
+  (it "rejects the same requirement name twice within ADDED"
+    (check (val-test--has "* Delta
 ** Dup :ADDED:
 :PROPERTIES:
 :AREA: a
@@ -72,11 +70,10 @@ SHALL a.
 SHALL b.
 *** s
 - GIVEN b
-" "Duplicate requirement in ADDED: \"Dup\"") t)
+" "Duplicate requirement in ADDED: \"Dup\"") t))
 
-;; Cross-op: same name in MODIFIED and REMOVED.
-(check "modified-and-removed"
-       (val-test--has "* Delta
+  (it "rejects a name that is both MODIFIED and REMOVED"
+    (check (val-test--has "* Delta
 ** X :MODIFIED:
 :PROPERTIES:
 :AREA: a
@@ -89,11 +86,10 @@ SHALL x.
 :AREA: a
 :END:
 gone.
-" "both MODIFIED and REMOVED: \"X\"") t)
+" "both MODIFIED and REMOVED: \"X\"") t))
 
-;; Cross-op: ADDED and REMOVED.
-(check "added-and-removed"
-       (val-test--has "* Delta
+  (it "rejects a name that is both ADDED and REMOVED"
+    (check (val-test--has "* Delta
 ** Y :ADDED:
 :PROPERTIES:
 :AREA: a
@@ -106,11 +102,10 @@ SHALL y.
 :AREA: a
 :END:
 gone.
-" "both ADDED and REMOVED: \"Y\"") t)
+" "both ADDED and REMOVED: \"Y\"") t))
 
-;; RENAMED TO collides with ADDED.
-(check "renamed-collides-added"
-       (val-test--has "* Delta
+  (it "rejects a RENAMED target name that collides with an ADDED one"
+    (check (val-test--has "* Delta
 ** NewName :ADDED:
 :PROPERTIES:
 :AREA: a
@@ -126,17 +121,18 @@ SHALL n.
 SHALL n.
 *** s
 - GIVEN a
-" "RENAMED TO collides with ADDED for \"NewName\"") t)
+" "RENAMED TO collides with ADDED for \"NewName\"") t)))
 
-;; or-signal raises on invalid, returns t on valid.
-(check "signal-raises"
-       (condition-case _ (progn (orgspec-validate-change-or-signal
-                                 (val-test--change "* Delta\n")) 'no-error)
-         (user-error 'raised))
-       'raised)
-(check "signal-ok"
-       (orgspec-validate-change-or-signal
-        (val-test--change "* Delta
+(describe "orgspec-validate-change-or-signal"
+  (it "raises a user-error on an invalid change"
+    (check (condition-case _ (progn (orgspec-validate-change-or-signal
+                                     (val-test--change "* Delta\n")) 'no-error)
+             (user-error 'raised))
+           'raised))
+
+  (it "returns t on a valid change"
+    (check (orgspec-validate-change-or-signal
+            (val-test--change "* Delta
 ** Good :ADDED:
 :PROPERTIES:
 :AREA: a
@@ -145,4 +141,8 @@ The system SHALL work.
 *** s
 - GIVEN a
 "))
-       t)
+           t)))
+
+(test-helper-summary)
+
+;;; orgspec-validate-test.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,0 +1,107 @@
+;;; test-helper.el --- Shared assertion vocabulary for the suites -*- lexical-binding: t; -*-
+
+;; These suites are batch scripts, not `ert' suites: loading a file runs it,
+;; and an assertion is a `check' call that princ's one line.  That stays --
+;; it keeps a suite debuggable with `emacs --batch -l', and bin/test-emacs.sh
+;; builds its report from those lines.
+;;
+;; What changes here is that the line says what was being tested rather than
+;; naming a symbol.  `install-idempotent' tells you which call failed; "keeps
+;; a single entry when installed twice" tells you what the code was supposed
+;; to do, which is the part you need when the failure is a surprise.  So:
+;;
+;;   (describe "orgspec-agenda-install"
+;;     (it "keeps a single entry when installed twice"
+;;       (check (length org-agenda-custom-commands) 1)))
+;;
+;; prints
+;;
+;;   DESCRIBE orgspec-agenda-install
+;;   PASS keeps a single entry when installed twice
+;;
+;; Three drifted copies of `check' existed before this file (one per naming
+;; scheme, one of which also printed got/want); they are now one.
+
+;;; Code:
+
+(require 'cl-lib)
+
+(defvar test-helper-failures 0
+  "Count of failed assertions in this suite run.")
+
+(defvar test-helper--context nil
+  "Description of the `describe' block currently being run, if any.")
+
+(defvar test-helper--current nil
+  "Description of the `it' block currently being run, if any.")
+
+(defun test-helper-report (ok label &optional got want show-values)
+  "Print one PASS/FAIL line for LABEL and count a failure unless OK.
+GOT and WANT are included when SHOW-VALUES is non-nil, or whenever the
+assertion failed -- on failure the values are the whole point, but on a
+green run they are noise that buries the description."
+  (unless ok (setq test-helper-failures (1+ test-helper-failures)))
+  (princ (format "%s %s%s\n"
+                 (if ok "PASS" "FAIL")
+                 label
+                 (if (or show-values (not ok))
+                     (format ": got=%S want=%S" got want)
+                   ""))))
+
+(defmacro describe (description &rest body)
+  "Group the assertions in BODY under DESCRIPTION.
+Prints a DESCRIBE line so the report can indent what follows under it.
+This is a grouping form only: BODY is spliced in place, so fixtures bound
+outside are still visible inside and `let' bindings inside still work the
+way they read."
+  (declare (indent 1))
+  `(progn
+     (princ (format "DESCRIBE %s\n" ,description))
+     (let ((test-helper--context ,description))
+       ,@body)))
+
+(defmacro it (description &rest body)
+  "Run BODY as the expectation DESCRIPTION.
+Any bare `check' inside reports against DESCRIPTION, so the common case
+is one `check' per `it' and no repeated label.  An error escaping BODY is
+reported as a failure of this expectation rather than killing the suite,
+so one broken fixture does not hide every later result."
+  (declare (indent 1))
+  `(let ((test-helper--current ,description))
+     (condition-case err
+         (progn ,@body)
+       (error
+        (test-helper-report nil ,description
+                            (error-message-string err) 'no-error t)))))
+
+(defun check (got want &optional label)
+  "Assert GOT equals WANT, reporting under the enclosing `it'.
+LABEL overrides that description, which is what a loop generating several
+assertions needs; outside any `it' it is required, since a report line
+with nothing to identify it is useless.
+
+Beware when converting a suite: the old per-suite `check' took
+\(LABEL GOT WANT), so the argument order here is deliberately different
+and a call left unconverted compares a label against a value.  The guard
+against that is the assertion count -- a converted suite must report the
+same number of passes as before."
+  (let ((description (or label test-helper--current
+                         (error "check outside `it' needs a label"))))
+    (test-helper-report (equal got want) description got want)))
+
+(defun check-that (got &optional label)
+  "Assert GOT is non-nil.  LABEL behaves as in `check'.
+Saves writing `(check (and ... t) t)', which was the common shape when
+the predicate under test returns a truthy value rather than exactly t."
+  (check (and got t) t label))
+
+(defun test-helper-summary ()
+  "Print the suite's own tally.  Call at the end of a suite."
+  (princ (format "\n%s\n"
+                 (if (zerop test-helper-failures)
+                     "ALL PASS"
+                   (format "%d FAILURE(S)" test-helper-failures)))))
+
+(provide 'test-helper)
+
+;;; test-helper.el ends here


### PR DESCRIPTION
Tests ran in the working Emacs, where fixtures pop windows, ediffs and `*claude-client*` buffers into the middle of whatever is being edited — and a suite that wedges the instance costs the session. `bin/test-emacs.sh` gives them their own instance instead: own init directory (`test/init/`, no Doom or personal config), own emacsclient socket, MCP server on 8775 rather than 8765, packages and runtime state under an ignored `.test-emacs/`. `mcp-emacs-ide` already randomizes its WebSocket port, so that one needed no offset. Every run now ends with a report listing each suite and every test in it, plus JUnit XML at `.test-emacs/report.xml` that CI uploads as an artifact; a suite passes only if it exits clean *and* prints at least one `PASS`, so one that dies before asserting anything reads as `ERRORED`/`NO ASSERTIONS` instead of passing quietly. CI calls the same script, so two copies of the dependency list, the suite glob and the pass/fail contract cannot drift apart.

Verified locally: 19 suites, 700 assertions, exit 0; all four verdicts exercised against injected fixtures; JUnit XML validated well-formed with counts matching. CI itself is unverified — this PR is the first run, and it is on Emacs 29.4 vs 31.1 locally.